### PR TITLE
Improve chat HTTP fallback and voice startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ workspace.
 - Record newly discovered gotchas or workflow aids here using concise bullet
   points.
 - Keep the guide succinct and focused on actionable advice.
+- `pytest` is configured to ignore the `src/` symlink; place new tests under
+  `packages/<pkg>/tests` and stub ROS interfaces when running in environments
+  without ROS installed.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/packages/chat/tests/test_first_sentence.py
+++ b/packages/chat/tests/test_first_sentence.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(name="chat_module")
+def _chat_module():
+    package_root = Path(__file__).resolve().parents[1]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    # Provide lightweight stubs for ROS interfaces so the module can import.
+    if "rclpy" not in sys.modules:
+        fake_rclpy = types.ModuleType("rclpy")
+        fake_node_mod = types.ModuleType("rclpy.node")
+        fake_exec_mod = types.ModuleType("rclpy.executors")
+
+        class _Node:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        class _Executor:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def add_node(self, _node):
+                pass
+
+            def spin(self):
+                pass
+
+        fake_node_mod.Node = _Node
+        fake_exec_mod.MultiThreadedExecutor = _Executor
+        fake_rclpy.node = fake_node_mod
+        fake_rclpy.executors = fake_exec_mod
+        fake_rclpy.init = lambda *args, **kwargs: None
+        fake_rclpy.shutdown = lambda *args, **kwargs: None
+        sys.modules["rclpy"] = fake_rclpy
+        sys.modules["rclpy.node"] = fake_node_mod
+        sys.modules["rclpy.executors"] = fake_exec_mod
+
+    if "std_msgs" not in sys.modules:
+        fake_std_msgs = types.ModuleType("std_msgs")
+        fake_std_msgs_msg = types.ModuleType("std_msgs.msg")
+
+        class _String:
+            def __init__(self, data: str = "") -> None:
+                self.data = data
+
+        fake_std_msgs_msg.String = _String
+        sys.modules["std_msgs"] = fake_std_msgs
+        sys.modules["std_msgs.msg"] = fake_std_msgs_msg
+
+    if "psyched_msgs" not in sys.modules:
+        fake_pkg = types.ModuleType("psyched_msgs")
+        fake_pkg_msg = types.ModuleType("psyched_msgs.msg")
+
+        class _Message:
+            def __init__(self) -> None:
+                self.role = ""
+                self.content = ""
+
+        fake_pkg_msg.Message = _Message
+        sys.modules["psyched_msgs"] = fake_pkg
+        sys.modules["psyched_msgs.msg"] = fake_pkg_msg
+
+    module_name = "chat.node"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    return importlib.import_module(module_name)
+
+
+def test_first_sentence_basic(chat_module):
+    assert chat_module.first_sentence("Hello world. How are you?") == "Hello world."
+
+
+def test_first_sentence_no_terminator(chat_module):
+    text = "This is a long statement without punctuation"
+    result = chat_module.first_sentence(text)
+    assert result.startswith("This is a long statement")
+    assert len(result) <= 201
+
+
+def test_first_sentence_handles_whitespace(chat_module):
+    assert chat_module.first_sentence("   \n   Hello there!  \n") == "Hello there!"
+
+
+def test_first_sentence_empty(chat_module):
+    assert chat_module.first_sentence("   ") == ""

--- a/packages/ear/ear/node.py
+++ b/packages/ear/ear/node.py
@@ -141,7 +141,7 @@ class EarNode(Node):
                 data = self._proc.stdout.read(self.chunk)
                 if not data:
                     # EOF or device issue; restart
-                    self.get_logger().warn('arecord produced no data; restarting...')
+                    self.get_logger().warning('arecord produced no data; restarting...')
                     try:
                         self._proc.terminate()
                     except Exception:

--- a/packages/voice/tests/test_utils.py
+++ b/packages/voice/tests/test_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(name="utils")
+def _utils_module():
+    package_root = Path(__file__).resolve().parents[1]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    module_name = "voice.utils"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    return importlib.import_module(module_name)
+
+
+def test_fetch_fortune_text_success(utils):
+    calls = {}
+
+    def fake_which(cmd):
+        calls.setdefault("which", []).append(cmd)
+        return "/usr/bin/fortune"
+
+    class FakeCompletedProcess:
+        def __init__(self):
+            self.stdout = "Be excellent to each other.\n"
+
+    def fake_run(args, capture_output, text, timeout):
+        calls.setdefault("run", []).append(tuple(args))
+        return FakeCompletedProcess()
+
+    text = utils.fetch_fortune_text(which=fake_which, run=fake_run)
+
+    assert text == "Be excellent to each other."
+    assert calls["which"] == ["fortune"]
+    assert calls["run"] == [("/usr/bin/fortune", "-s")]
+
+
+def test_fetch_fortune_text_failure(utils):
+    def fake_which(_cmd):
+        return None
+
+    assert utils.fetch_fortune_text(which=fake_which) is None
+
+    def fake_which_path(_cmd):
+        return "/usr/bin/fortune"
+
+    def fake_run(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    assert utils.fetch_fortune_text(which=fake_which_path, run=fake_run) is None

--- a/packages/voice/voice/utils.py
+++ b/packages/voice/voice/utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Callable, Optional
+
+
+def fetch_fortune_text(
+    *,
+    which: Callable[[str], Optional[str]] = shutil.which,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str | None:
+    """Return a short fortune string if the ``fortune`` binary is available.
+
+    Args:
+        which: Callable used to locate the ``fortune`` binary. Defaults to
+            :func:`shutil.which`.
+        run: Callable used to execute the command. Defaults to
+            :func:`subprocess.run`.
+
+    Returns:
+        A trimmed fortune string when available, otherwise ``None``.
+
+    Examples:
+        >>> class DummyCompleted:
+        ...     def __init__(self, stdout: str) -> None:
+        ...         self.stdout = stdout
+        >>> fetch_fortune_text(
+        ...     which=lambda _: "/usr/bin/fortune",
+        ...     run=lambda *args, **kwargs: DummyCompleted("Hello\n"),
+        ... )
+        'Hello'
+    """
+    try:
+        fortune_path = which("fortune")
+    except Exception:
+        return None
+    if not fortune_path:
+        return None
+    try:
+        result = run([fortune_path, "-s"], capture_output=True, text=True, timeout=3)
+    except Exception:
+        return None
+    output = getattr(result, "stdout", "") or ""
+    text = output.strip()
+    return text or None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=src


### PR DESCRIPTION
## Summary
- document the pytest collection gotcha and ignore the src symlink during local runs
- make the chat node lazily import requests so it logs and degrades gracefully when the client is absent
- eagerly start the voice worker, share the fortune helper, cover the behaviour with tests, and update the ear node warning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d001754e748320a3dcbb1f7c87db80