### PR TITLE
Fix pilot systemd UI fallback when pills are absent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ or conflicting package sources.
 - `pytest` is configured to ignore the `src/` symlink; place new tests under
   `packages/<pkg>/tests` and stub ROS interfaces when running in environments
   without ROS installed.
+- Pilot UI systemd layout no longer renders a `#servicesPills` element; ensure
+  frontend updates don't depend on it before processing service data.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/modules/pilot/packages/pilot/tests/test_frontend_systemd.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_systemd.py
@@ -1,0 +1,85 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_update_services_list_without_pills():
+    """Pilot UI should still render systemd controls when pill container is absent."""
+    js_path = Path(__file__).resolve().parents[1] / 'pilot' / 'static' / 'joystick.js'
+    script = f"""
+const path = require('path');
+const joystickPath = {json.dumps(str(js_path))};
+
+global.window = {{
+    location: {{ protocol: 'http:', hostname: 'localhost', port: '8080' }},
+    addEventListener: () => {{}},
+    matchMedia: () => ({{ matches: false, addEventListener: () => {{}}, addListener: () => {{}} }}),
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    __PILOT_SKIP_AUTO_INIT__: true,
+}};
+
+global.document = {{
+    addEventListener: (event, cb) => {{ if (typeof cb === 'function') cb(); }},
+    getElementById: () => null,
+    createElement: () => ({{}}),
+}};
+
+global.WebSocket = class {{
+    constructor() {{ this.readyState = 1; }}
+    send() {{}}
+    close() {{}}
+}};
+
+const {{ PilotController }} = require(joystickPath);
+
+const controller = new PilotController({{ deferInit: true }});
+controller.services = controller.services || {{}};
+controller.modules = {{}};
+controller.servicesContainer = null;
+controller.servicesLogs = {{
+    appended: [],
+    appendChild(node) {{ this.appended.push(node); return node; }}
+}};
+controller.serviceDetails = {{}};
+
+const detailCalls = [];
+controller.requestSystemdDetail = (unit, lines) => {{ detailCalls.push([unit, lines]); }};
+const watchCalls = [];
+controller.watchSystemdUnit = (unit, lines) => {{ watchCalls.push([unit, lines]); }};
+const controlUpdates = [];
+controller.updateServiceLogControls = (svc) => {{ controlUpdates.push(svc); }};
+controller.renderServiceLogBlock = (unit) => ({{ unit }});
+
+controller.updateServicesList([{{
+    name: 'psyched-nav.service',
+    active: 'active',
+    enabled: 'enabled',
+    status: 'Active: active (running)',
+    journal: 'log line',
+}}]);
+
+if (!controller.services['psyched-nav.service']) {{
+    throw new Error('service not stored');
+}}
+if (controller.servicesLogs.appended.length !== 1) {{
+    throw new Error('service log block not appended');
+}}
+if (detailCalls.length !== 1 || detailCalls[0][0] !== 'psyched-nav.service') {{
+    throw new Error('detail not requested');
+}}
+if (watchCalls.length !== 1 || watchCalls[0][0] !== 'psyched-nav.service') {{
+    throw new Error('watch not requested');
+}}
+if (controlUpdates.length !== 1 || controlUpdates[0].name !== 'psyched-nav.service') {{
+    throw new Error('controls not updated');
+}}
+if (!controller.serviceDetails['psyched-nav.service']) {{
+    throw new Error('service detail cache missing');
+}}
+"""
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
## Summary
- allow the pilot UI controller to be instantiated without DOM wiring so we can exercise it in isolation
- ensure systemd service rendering works without the legacy `#servicesPills` container and immediately primes status detail/watchers
- add a regression test that drives `updateServicesList` through Node to prevent the fallback path from regressing again
- document the missing `#servicesPills` container in `AGENTS.md` so future edits do not reintroduce the guard

## Testing
- pytest modules/pilot/packages/pilot/tests/test_frontend_systemd.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b21e802c8320abb5452e010e3cb7