### PR TITLE
Refresh pilot LCARS controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ or conflicting package sources.
   without ROS installed.
 - Pilot UI systemd layout no longer renders a `#servicesPills` element; ensure
   frontend updates don't depend on it before processing service data.
+- Pilot control cascade reads from DOM elements flagged with `data-source`
+  attributes; update `modules/pilot/packages/pilot/tests/test_frontend_layout.py`
+  if you adjust that markup.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/modules/pilot/packages/pilot/pilot/static/index.html
+++ b/modules/pilot/packages/pilot/pilot/static/index.html
@@ -9,7 +9,6 @@
     <meta name="format-detection" content="date=no">
     <link rel="stylesheet" type="text/css" href="assets/lower-decks-padd.css">
     <link rel="stylesheet" type="text/css" href="style.css">
-    <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 
 <body>
@@ -26,24 +25,140 @@
             <div class="right-frame-top">
                 <div class="banner">Pilot Interface</div>
                 <div class="data-cascade-button-group">
-                    <div class="data-wrapper" x-data="dataCascade()" x-init="init()">
-                        <!-- Labels row (uses same columns array) -->
-                        <div class="data-labels">
-                            <template x-for="(col, idx) in columns" :key="'label-'+idx">
-                                <div class="data-column">
-                                    <div class="dc-row-1 dc-label" x-text="col.label || ''"></div>
-                                </div>
-                            </template>
-                        </div>
-                        <!-- Numeric data rows -->
-                        <template x-for="(col, idx) in columns" :key="idx">
-                            <div class="data-column">
-                                <div class="dc-row-1" :class="col.r1Class" x-text="valueFor(col.r1)"></div>
-                                <div class="dc-row-2" :class="col.r2Class" x-text="valueFor(col.r2)"></div>
-                                <div class="dc-row-3" :class="col.r3Class" x-text="valueFor(col.r3)"></div>
-                                <div class="dc-row-4" :class="col.r4Class" x-text="valueFor(col.r4)"></div>
+                    <div class="data-wrapper" id="controlCascade" role="group" aria-label="Control status cascade">
+                        <div class="data-column" data-column="drive">
+                            <div class="dc-header font-arctic-ice">DRIVE</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">LIN X</span>
+                                <span class="dc-value font-arctic-ice blink" data-source="linearX">0.00</span>
                             </div>
-                        </template>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">LIN Y</span>
+                                <span class="dc-value font-night-rain" data-source="linearY">0.00</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">ANG Z</span>
+                                <span class="dc-value font-alpha-blue" data-source="angularZ">0.00</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">MODE</span>
+                                <span class="dc-value font-arctic-ice" data-source="robotMode">--</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="safety">
+                            <div class="dc-header">SAFETY</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">SPEED</span>
+                                <span class="dc-value font-arctic-ice" data-source="robotSpeed">--</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">BUMPR</span>
+                                <span class="dc-value font-night-rain blink" data-source="robotBumper">--</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">CLIFF</span>
+                                <span class="dc-value font-night-rain" data-source="robotCliff">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">IR</span>
+                                <span class="dc-value font-alpha-blue" data-source="robotIrOmni">--</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="energy">
+                            <div class="dc-header">ENERGY</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">BAT %</span>
+                                <span class="dc-value font-arctic-ice blink" data-source="batteryPercentInfo">--</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">VOLT</span>
+                                <span class="dc-value" data-source="batteryVoltage">--</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">CURR</span>
+                                <span class="dc-value" data-source="batteryCurrent">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">STAT</span>
+                                <span class="dc-value font-night-rain" data-source="batteryStateInfo">--</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="audio">
+                            <div class="dc-header">AUDIO</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">SPEAK</span>
+                                <span class="dc-value font-arctic-ice" data-source="voiceSpeakingMs">0</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">VAD</span>
+                                <span class="dc-value" data-source="vadSpeechMs">0</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">MIC</span>
+                                <span class="dc-value font-night-rain" data-source="micInfo">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">VOICE</span>
+                                <span class="dc-value font-alpha-blue" data-source="voiceTopic">/voice</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="gps">
+                            <div class="dc-header">GPS</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">FIX</span>
+                                <span class="dc-value font-arctic-ice" data-source="gpsFixStatus">--</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">LAT</span>
+                                <span class="dc-value" data-source="gpsLat">--</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">LON</span>
+                                <span class="dc-value" data-source="gpsLon">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">ALT</span>
+                                <span class="dc-value" data-source="gpsAlt">--</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="network">
+                            <div class="dc-header">NETWORK</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">CMD</span>
+                                <span class="dc-value" data-source="cmdVelTopic">/cmd_vel</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">VOICE</span>
+                                <span class="dc-value" data-source="voiceTopic">/voice</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">WEB</span>
+                                <span class="dc-value" data-source="webAddress">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">WS</span>
+                                <span class="dc-value" data-source="wsAddress">--</span>
+                            </div>
+                        </div>
+                        <div class="data-column" data-column="host">
+                            <div class="dc-header">HOST</div>
+                            <div class="dc-row dc-row-1">
+                                <span class="dc-key">CPU</span>
+                                <span class="dc-value darkfont" data-source="cpuChip">--</span>
+                            </div>
+                            <div class="dc-row dc-row-2">
+                                <span class="dc-key">TEMP</span>
+                                <span class="dc-value font-alpha-blue" data-source="tempChip">--</span>
+                            </div>
+                            <div class="dc-row dc-row-3">
+                                <span class="dc-key">MEM</span>
+                                <span class="dc-value font-arctic-ice" data-source="memChip">--</span>
+                            </div>
+                            <div class="dc-row dc-row-4">
+                                <span class="dc-key">DIAG</span>
+                                <span class="dc-value font-night-rain" data-source="robotDiag">--</span>
+                            </div>
+                        </div>
                     </div>
                     <nav role="navigation" aria-label="pilot main navigation">
                         <div class="buttons justify-space-between">
@@ -110,13 +225,13 @@
                                 <div class="slider-title">D-Pad</div>
                                 <div id="dpad" class="dpad-grid" aria-label="Directional pad controls">
                                     <div></div>
-                                    <button id="dpadUp" class="dpad-btn up" aria-label="Forward">▲</button>
+                                    <button id="dpadUp" class="dpad-btn up" data-direction="up" aria-label="Forward">▲</button>
                                     <div></div>
-                                    <button id="dpadLeft" class="dpad-btn left" aria-label="Left">◀</button>
+                                    <button id="dpadLeft" class="dpad-btn left" data-direction="left" aria-label="Left">◀</button>
                                     <div class="dpad-center" aria-hidden="true"></div>
-                                    <button id="dpadRight" class="dpad-btn right" aria-label="Right">▶</button>
+                                    <button id="dpadRight" class="dpad-btn right" data-direction="right" aria-label="Right">▶</button>
                                     <div></div>
-                                    <button id="dpadDown" class="dpad-btn down" aria-label="Backward">▼</button>
+                                    <button id="dpadDown" class="dpad-btn down" data-direction="down" aria-label="Backward">▼</button>
                                     <div></div>
                                 </div>
                             </div>
@@ -196,6 +311,9 @@
                             <div class="info-item"><label>Current (A)</label><span id="batteryCurrent">--</span></div>
                             <div class="info-item"><label>Temperature</label><span id="batteryTemp">--</span></div>
                             <div class="info-item"><label>State</label><span id="batteryStateInfo">--</span></div>
+                            <div class="info-item"><label>CPU Load</label><span id="cpuChip">--</span></div>
+                            <div class="info-item"><label>Main Temp</label><span id="tempChip">--</span></div>
+                            <div class="info-item"><label>Memory</label><span id="memChip">--</span></div>
                             <div class="info-item"><label>Speaking (ms)</label><span id="voiceSpeakingMs">0</span></div>
                             <div class="info-item"><label>VAD Speech (ms)</label><span id="vadSpeechMs">0</span></div>
                             <div class="info-item"><label>Mic</label><span id="micInfo">--</span></div>
@@ -229,43 +347,112 @@
     <script type="text/javascript" src="assets/lcars.js"></script>
     <script src="joystick.js"></script>
     <script>
-        function dataCascade() {
-            return {
-                // Define columns as mappings to info-grid element IDs or static keys
-                columns: [
-                    { label: 'BAT %', r1: 'batteryPercentInfo', r2: 'robotSpeed', r3: 'robotMode', r4: 'robotBumper', r1Class: 'font-arctic-ice blink' },
-                    { label: 'VEL', r1: 'linearX', r2: 'linearY', r3: 'angularZ', r4: 'gpsFixStatus', r1Class: 'blink' },
-                    { label: 'BATT', r1: 'batteryVoltage', r2: 'batteryCurrent', r3: 'batteryTemp', r4: 'batteryStateInfo', r1Class: 'font-night-rain blink' },
-                    { label: 'AUDIO', r1: 'voiceSpeakingMs', r2: 'vadSpeechMs', r3: 'micInfo', r4: 'voiceTopic', r1Class: 'font-arctic-ice blink' },
-                    { label: 'GPS', r1: 'gpsLat', r2: 'gpsLon', r3: 'gpsAlt', r4: 'robotDiag', r1Class: 'font-arctic-ice blink' },
-                    { label: 'HOST', r1: 'cpuChip', r2: 'tempChip', r3: 'memChip', r4: '', r1Class: 'darkspace darkfont blink' },
-                    { label: 'SENS', r1: 'robotIrOmni', r2: 'robotCliff', r3: 'robotBumper', r4: 'robotMode' },
-                    { label: 'NET', r1: 'cmdVelTopic', r2: 'voiceTopic', r3: 'webAddress', r4: 'wsAddress' },
-                ],
-                init() {
-                    // Observe mutations to the info grid and force Alpine to update by toggling a dummy property
-                    const ids = new Set();
-                    this.columns.forEach(c => { [c.r1, c.r2, c.r3, c.r4].forEach(id => id && ids.add(id)); });
-                    ids.forEach(id => {
-                        const el = document.getElementById(id);
-                        if (el) {
-                            const obs = new MutationObserver(() => this._touch = Date.now());
-                            obs.observe(el, { childList: true, characterData: true, subtree: true });
-                        }
-                    });
-                },
-                valueFor(key) {
-                    if (!key) return '';
-                    const el = document.getElementById(key);
-                    if (!el) return key;
-                    // Read text content; format numbers to shorter form when very large
-                    const v = (el.textContent || '').trim();
-                    if (!v) return '--';
-                    if (/^\d{10,}$/.test(v)) return v.slice(0, 11) + '…';
-                    return v;
+        document.addEventListener('DOMContentLoaded', () => {
+            const cascadeEl = document.getElementById('controlCascade');
+            if (!cascadeEl) {
+                return;
+            }
+
+            const valueEls = Array.from(cascadeEl.querySelectorAll('[data-source]'));
+            if (!valueEls.length) {
+                return;
+            }
+
+            const sourceMap = new Map();
+            valueEls.forEach(el => {
+                const key = el.getAttribute('data-source');
+                if (!key) {
+                    return;
                 }
+                if (!sourceMap.has(key)) {
+                    sourceMap.set(key, []);
+                }
+                sourceMap.get(key).push(el);
+            });
+
+            const readSourceValue = (source) => {
+                if (!source) {
+                    return '';
+                }
+                if (source instanceof HTMLInputElement || source instanceof HTMLSelectElement || source instanceof HTMLTextAreaElement) {
+                    return source.value;
+                }
+                return source.textContent || '';
             };
-        }
+
+            const formatValue = (raw) => {
+                const text = (raw || '').trim();
+                if (!text) {
+                    return '--';
+                }
+                if (/^-?\d+(?:\.\d+)?$/.test(text)) {
+                    const num = parseFloat(text);
+                    const magnitude = Math.abs(num);
+                    if (magnitude >= 1000) {
+                        return num.toFixed(0);
+                    }
+                    if (magnitude >= 100) {
+                        return num.toFixed(1);
+                    }
+                    if (magnitude >= 10) {
+                        return num.toFixed(2);
+                    }
+                    if (magnitude >= 1) {
+                        return num.toFixed(2);
+                    }
+                    if (magnitude === 0) {
+                        return '0';
+                    }
+                    return num.toFixed(3);
+                }
+                return text.length > 14 ? `${text.slice(0, 13)}…` : text;
+            };
+
+            const updateTargets = (id) => {
+                const targets = sourceMap.get(id);
+                if (!targets) {
+                    return;
+                }
+                const source = document.getElementById(id);
+                const formatted = formatValue(readSourceValue(source));
+                targets.forEach(el => {
+                    el.textContent = formatted;
+                    if (source) {
+                        el.classList.remove('dc-value--missing');
+                    } else {
+                        el.classList.add('dc-value--missing');
+                    }
+                });
+            };
+
+            const observerConfig = { childList: true, characterData: true, subtree: true };
+            sourceMap.forEach((_, id) => {
+                const source = document.getElementById(id);
+                if (!source) {
+                    updateTargets(id);
+                    return;
+                }
+
+                const observer = new MutationObserver(() => updateTargets(id));
+                observer.observe(source, observerConfig);
+
+                if (source instanceof HTMLInputElement || source instanceof HTMLSelectElement || source instanceof HTMLTextAreaElement) {
+                    const handler = () => updateTargets(id);
+                    source.addEventListener('input', handler);
+                    source.addEventListener('change', handler);
+                }
+
+                updateTargets(id);
+            });
+
+            document.addEventListener('pilot:cascade:sync', (event) => {
+                const detail = event.detail;
+                if (!detail || !detail.id) {
+                    return;
+                }
+                updateTargets(detail.id);
+            });
+        });
     </script>
     <div class="headtrim"> </div>
     <div class="baseboard"> </div>

--- a/modules/pilot/packages/pilot/pilot/static/style.css
+++ b/modules/pilot/packages/pilot/pilot/static/style.css
@@ -1,0 +1,350 @@
+/* Pilot interface customisations */
+
+/* === Top cascade ======================================================= */
+#controlCascade {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.85rem;
+    padding-block: 0.35rem 0.75rem;
+    align-items: stretch;
+}
+
+#controlCascade .data-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.85rem 1rem 1rem;
+    border-radius: 1.5rem;
+    background: linear-gradient(145deg, rgba(12, 12, 12, 0.72), rgba(0, 0, 0, 0.45));
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 0.6rem 1.3rem rgba(0, 0, 0, 0.45), 0 0.45rem 1.15rem rgba(0, 0, 0, 0.35);
+    min-width: 0;
+}
+
+#controlCascade .dc-header {
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #ffe1a9;
+    margin-bottom: -0.1rem;
+}
+
+#controlCascade .dc-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.65rem;
+    font-variant-numeric: tabular-nums;
+    text-transform: uppercase;
+}
+
+#controlCascade .dc-key {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.58);
+    white-space: nowrap;
+}
+
+#controlCascade .dc-value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fef5dc;
+    min-width: 0;
+    text-align: right;
+}
+
+#controlCascade .dc-value--missing {
+    opacity: 0.45;
+}
+
+/* === D-pad ============================================================= */
+.dpad-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.dpad-grid {
+    position: relative;
+    display: grid;
+    width: clamp(170px, 30vw, 240px);
+    aspect-ratio: 1 / 1;
+    padding: 0.65rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-rows: repeat(3, minmax(0, 1fr));
+    grid-template-areas:
+        ". up ."
+        "left center right"
+        ". down .";
+    gap: 0.5rem;
+    border-radius: 1.6rem;
+    background: linear-gradient(180deg, rgba(255, 240, 200, 0.16), rgba(0, 0, 0, 0.55));
+    box-shadow: inset 0 0.9rem 1.6rem rgba(0, 0, 0, 0.6), 0 0.5rem 1.2rem rgba(0, 0, 0, 0.35);
+}
+
+.dpad-grid::after {
+    content: "";
+    position: absolute;
+    inset: 12%;
+    border-radius: 20px;
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    pointer-events: none;
+}
+
+.dpad-btn {
+    appearance: none;
+    border: 0;
+    border-radius: 1rem;
+    display: grid;
+    place-items: center;
+    font-size: clamp(1.35rem, 5vw, 1.9rem);
+    font-weight: 600;
+    color: #141010;
+    background: linear-gradient(160deg, #fddb97, #e58f2a);
+    box-shadow: 0 0.5rem 0 #a26014, 0 0.55rem 0.75rem rgba(0, 0, 0, 0.45);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.45);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dpad-btn[data-direction="up"] { grid-area: up; border-radius: 1.1rem 1.1rem 0.6rem 0.6rem; }
+.dpad-btn[data-direction="down"] { grid-area: down; border-radius: 0.6rem 0.6rem 1.1rem 1.1rem; }
+.dpad-btn[data-direction="left"] { grid-area: left; border-radius: 1.1rem 0.6rem 0.6rem 1.1rem; }
+.dpad-btn[data-direction="right"] { grid-area: right; border-radius: 0.6rem 1.1rem 1.1rem 0.6rem; }
+
+.dpad-btn:active,
+.dpad-btn[data-pressed="true"] {
+    transform: translateY(0.18rem);
+    box-shadow: 0 0.22rem 0 #a26014, 0 0.25rem 0.6rem rgba(0, 0, 0, 0.35);
+}
+
+.dpad-btn:focus-visible {
+    outline: 3px solid #fef2d2;
+    outline-offset: 2px;
+}
+
+.dpad-center {
+    grid-area: center;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #fdf4d0, #c2771b 75%, #7b4511 100%);
+    border: 4px solid rgba(0, 0, 0, 0.55);
+    box-shadow: inset 0 0.75rem 1.25rem rgba(0, 0, 0, 0.55);
+}
+
+/* === Joystick ========================================================= */
+.drive-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.65rem;
+    align-items: start;
+    margin-top: 1.1rem;
+}
+
+.joystick-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.joystick {
+    position: relative;
+    width: clamp(210px, 34vw, 320px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.22), rgba(15, 15, 15, 0.85));
+    border: 5px solid rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 1.2rem 1.8rem rgba(0, 0, 0, 0.55), 0 0.8rem 1.6rem rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+}
+
+.joystick::after {
+    content: "";
+    position: absolute;
+    inset: 12%;
+    border-radius: 50%;
+    border: 2px dashed rgba(255, 255, 255, 0.12);
+    pointer-events: none;
+}
+
+.joystick-knob {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: clamp(85px, 22vw, 125px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #ffeac0, #e59a3b 65%, #b06411 100%);
+    box-shadow: 0 0.55rem 0.9rem rgba(0, 0, 0, 0.5);
+    transform: translate(-50%, -50%);
+    transition: box-shadow 0.2s ease;
+}
+
+.joystick[data-dragging="true"] .joystick-knob {
+    box-shadow: 0 0.25rem 0.65rem rgba(0, 0, 0, 0.55), inset 0 0.25rem 0.45rem rgba(255, 255, 255, 0.25);
+}
+
+.joystick-labels {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    font-size: 0.75rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.joystick-labels .label-forward {
+    grid-column: 2 / 3;
+    justify-self: center;
+}
+
+.joystick-labels .label-left { justify-self: start; }
+.joystick-labels .label-right { justify-self: end; }
+.joystick-labels .label-backward {
+    grid-column: 2 / 3;
+    justify-self: center;
+}
+
+#imuOverlay {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+#imuOverlay circle,
+#imuOverlay path,
+#imuOverlay line {
+    stroke: rgba(255, 255, 255, 0.4);
+}
+
+#imuOverlay circle { stroke-dasharray: 4 6; }
+#imuOverlay path { stroke: #ffbe57; }
+#imuOverlay line { stroke-width: 4; }
+
+/* === Additional layout helpers ======================================= */
+.aux-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    margin-top: 1.25rem;
+}
+
+.aux-controls .controls,
+.aux-controls .voice-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+}
+
+.aux-controls .controls button {
+    min-width: 150px;
+}
+
+.voice-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.voice-controls input[type="text"] {
+    flex: 1 1 240px;
+}
+
+.voice-controls input[type="range"] {
+    width: min(220px, 100%);
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.75rem 1.4rem;
+    margin-top: 1.1rem;
+}
+
+.info-item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.55rem 0.85rem;
+    border-radius: 1rem;
+    background: rgba(0, 0, 0, 0.35);
+    font-variant-numeric: tabular-nums;
+}
+
+.info-item label {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.62);
+}
+
+.info-item span {
+    font-size: 0.98rem;
+    color: #fef5d6;
+}
+
+/* === Responsive tweaks ================================================ */
+@media (max-width: 1080px) {
+    #controlCascade {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+}
+
+@media (max-width: 860px) {
+    .drive-grid {
+        grid-template-columns: 1fr;
+        justify-items: center;
+    }
+
+    .aux-controls .controls {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 620px) {
+    .dpad-grid {
+        width: min(90vw, 260px);
+        gap: 0.4rem;
+        padding: 0.55rem;
+    }
+
+    .joystick {
+        width: min(88vw, 280px);
+    }
+
+    .joystick-knob {
+        width: clamp(70px, 28vw, 110px);
+    }
+
+    .joystick-labels {
+        font-size: 0.68rem;
+    }
+
+    .info-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+}
+
+@media (max-width: 480px) {
+    #controlCascade {
+        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    }
+
+    .aux-controls .controls,
+    .aux-controls .voice-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .aux-controls .controls button,
+    .voice-controls input[type="text"],
+    .voice-controls button {
+        width: 100%;
+    }
+}

--- a/modules/pilot/packages/pilot/tests/test_frontend_layout.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_layout.py
@@ -1,0 +1,35 @@
+"""BDD-style layout expectations for the pilot frontend."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "pilot" / "static"
+
+
+def read_html() -> str:
+    return (ROOT / "index.html").read_text(encoding="utf-8")
+
+
+def read_css() -> str:
+    return (ROOT / "style.css").read_text(encoding="utf-8")
+
+
+def test_control_cascade_maps_key_metrics():
+    """The top cascade should mirror live control metrics."""
+    html = read_html()
+    assert 'data-source="linearX"' in html
+    assert 'data-source="robotSpeed"' in html
+    assert 'data-source="batteryPercentInfo"' in html
+
+
+def test_dpad_buttons_have_direction_metadata():
+    """D-pad buttons need explicit direction markers for styling and logic."""
+    html = read_html()
+    for direction in ("up", "down", "left", "right"):
+        assert f'data-direction="{direction}"' in html
+
+
+def test_css_defines_dpad_and_joystick_styles():
+    """The custom stylesheet should render the D-pad cross and joystick."""
+    css = read_css()
+    assert ".dpad-grid" in css and "grid-template-areas" in css
+    assert ".joystick" in css and ("aspect-ratio" in css or "padding-top" in css)
+    assert "@media" in css and "max-width" in css

--- a/modules/pilot/packages/pilot/tests/test_frontend_systemd.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_systemd.py
@@ -94,7 +94,7 @@ const joystickPath = {json.dumps(str(js_path))};
 
 const elements = new Map();
 function makeElement(id, classes) {{
-    classes = Array.isArray(classes) ? classes : (classes ? String(classes).split(/\s+/).filter(Boolean) : []);
+    classes = Array.isArray(classes) ? classes : (classes ? String(classes).split(/\\s+/).filter(Boolean) : []);
     const classSet = new Set(classes);
     const el = {{
         id: id || '',


### PR DESCRIPTION
## Summary
- rebuild the top LCARS cascade so it surfaces live drive, safety, energy, audio, GPS, network, and host metrics via data-source bindings
- restyle the D-pad and joystick for better LCARS theming while making the layout responsive on small screens
- add regression tests covering the cascade, D-pad metadata, and CSS expectations, and fix an existing systemd test warning

## Testing
- pytest modules/pilot/packages/pilot/tests

------
https://chatgpt.com/codex/tasks/task_e_68d352f849b08320a10a0f60a56dac52