### PR TITLE
Connect pilot UI to live telemetry via API topics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ or conflicting package sources.
 - Pilot control cascade reads from DOM elements flagged with `data-source`
   attributes; update `modules/pilot/packages/pilot/tests/test_frontend_layout.py`
   if you adjust that markup.
+- Pilot frontend telemetry is bound through an Alpine `$store.pilot` defined in
+  `joystick.js`; keep store fields and the `x-text` bindings in
+  `static/index.html` in sync when adjusting displayed metrics.
+- Topic websocket endpoints are normalised via
+  `buildTopicSubscriptionUrl` in `joystick.js`; keep
+  `modules/pilot/packages/pilot/tests/test_frontend_topics.py` updated when
+  changing host resolution logic.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/modules/pilot/packages/pilot/pilot/static/index.html
+++ b/modules/pilot/packages/pilot/pilot/static/index.html
@@ -9,9 +9,10 @@
     <meta name="format-detection" content="date=no">
     <link rel="stylesheet" type="text/css" href="assets/lower-decks-padd.css">
     <link rel="stylesheet" type="text/css" href="style.css">
+    <script defer src="https://unpkg.com/alpinejs@3.14.4/dist/cdn.min.js"></script>
 </head>
 
-<body>
+<body x-data="pilotApp">
     <audio id="audio1" src="assets/beep1.mp3" preload="auto"></audio>
     <audio id="audio2" src="assets/beep2.mp3" preload="auto"></audio>
     <audio id="audio3" src="assets/beep3.mp3" preload="auto"></audio>
@@ -23,141 +24,170 @@
                 <div class="panel-2">02<span class="hop">-262000</span></div>
             </div>
             <div class="right-frame-top">
-                <div class="banner">Pilot Interface &bull; <span class="font-alpha-blue"
-                        data-source=" connectionStatus">Offline</span></div>
+                <div class="banner">Pilot Interface &bull;
+                    <span id="statusIndicator" class="status-indicator" aria-hidden="true"
+                        x-text="$store.pilot.connection.indicator">🔴</span>
+                    <span class="font-alpha-blue" data-source="connectionStatus"
+                        x-text="$store.pilot.connection.label">Offline</span>
+                </div>
                 <div class="data-cascade-button-group">
                     <div class="data-wrapper" id="controlCascade" role="group" aria-label="Control status cascade">
                         <div class="data-column" data-column="drive">
                             <div class="dc-header font-arctic-ice">DRIVE</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">LIN X</span>
-                                <span class="dc-value font-arctic-ice blink" data-source="linearX">0.00</span>
+                                <span class="dc-value font-arctic-ice blink" data-source="linearX"
+                                    x-text="$store.pilot.twist.linearX">0.00</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">LIN Y</span>
-                                <span class="dc-value font-night-rain" data-source="linearY">0.00</span>
+                                <span class="dc-value font-night-rain" data-source="linearY"
+                                    x-text="$store.pilot.twist.linearY">0.00</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">ANG Z</span>
-                                <span class="dc-value font-alpha-blue" data-source="angularZ">0.00</span>
+                                <span class="dc-value font-alpha-blue" data-source="angularZ"
+                                    x-text="$store.pilot.twist.angularZ">0.00</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">MODE</span>
-                                <span class="dc-value font-arctic-ice" data-source="robotMode">--</span>
+                                <span class="dc-value font-arctic-ice" data-source="robotMode"
+                                    x-text="$store.pilot.robot.mode">--</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="safety">
                             <div class="dc-header">SAFETY</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">SPEED</span>
-                                <span class="dc-value font-arctic-ice" data-source="robotSpeed">--</span>
+                                <span class="dc-value font-arctic-ice" data-source="robotSpeed"
+                                    x-text="$store.pilot.robot.speed">--</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">BUMPR</span>
-                                <span class="dc-value font-night-rain blink" data-source="robotBumper">--</span>
+                                <span class="dc-value font-night-rain blink" data-source="robotBumper"
+                                    x-text="$store.pilot.robot.bumper">--</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">CLIFF</span>
-                                <span class="dc-value font-night-rain" data-source="robotCliff">--</span>
+                                <span class="dc-value font-night-rain" data-source="robotCliff"
+                                    x-text="$store.pilot.robot.cliff">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">IR</span>
-                                <span class="dc-value font-alpha-blue" data-source="robotIrOmni">--</span>
+                                <span class="dc-value font-alpha-blue" data-source="robotIrOmni"
+                                    x-text="$store.pilot.robot.ir">--</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="energy">
                             <div class="dc-header">ENERGY</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">BAT %</span>
-                                <span class="dc-value font-arctic-ice blink" data-source="batteryPercentInfo">--</span>
+                                <span class="dc-value font-arctic-ice blink" data-source="batteryPercentInfo"
+                                    x-text="$store.pilot.battery.percent">--</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">VOLT</span>
-                                <span class="dc-value" data-source="batteryVoltage">--</span>
+                                <span class="dc-value" data-source="batteryVoltage"
+                                    x-text="$store.pilot.battery.voltage">--</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">CURR</span>
-                                <span class="dc-value" data-source="batteryCurrent">--</span>
+                                <span class="dc-value" data-source="batteryCurrent"
+                                    x-text="$store.pilot.battery.current">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">STAT</span>
-                                <span class="dc-value font-night-rain" data-source="batteryStateInfo">--</span>
+                                <span class="dc-value font-night-rain" data-source="batteryStateInfo"
+                                    x-text="$store.pilot.battery.state">--</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="audio">
                             <div class="dc-header">AUDIO</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">SPEAK</span>
-                                <span class="dc-value font-arctic-ice" data-source="voiceSpeakingMs">0</span>
+                                <span class="dc-value font-arctic-ice" data-source="voiceSpeakingMs"
+                                    x-text="$store.pilot.audio.speakingMs">0</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">VAD</span>
-                                <span class="dc-value" data-source="vadSpeechMs">0</span>
+                                <span class="dc-value" data-source="vadSpeechMs"
+                                    x-text="$store.pilot.audio.vadMs">0</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">MIC</span>
-                                <span class="dc-value font-night-rain" data-source="micInfo">--</span>
+                                <span class="dc-value font-night-rain" data-source="micInfo"
+                                    x-text="$store.pilot.audio.mic">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">VOICE</span>
-                                <span class="dc-value font-alpha-blue" data-source="voiceTopic">/voice</span>
+                                <span class="dc-value font-alpha-blue" data-source="voiceTopic"
+                                    x-text="$store.pilot.addresses.voiceSubscribers !== null ? `${$store.pilot.addresses.voice} (${$store.pilot.addresses.voiceSubscribers} subscribers)` : $store.pilot.addresses.voice">/voice</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="gps">
                             <div class="dc-header">GPS</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">FIX</span>
-                                <span class="dc-value font-arctic-ice" data-source="gpsFixStatus">--</span>
+                                <span class="dc-value font-arctic-ice" data-source="gpsFixStatus"
+                                    x-text="$store.pilot.gps.fix">--</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">LAT</span>
-                                <span class="dc-value" data-source="gpsLat">--</span>
+                                <span class="dc-value" data-source="gpsLat" x-text="$store.pilot.gps.lat">--</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">LON</span>
-                                <span class="dc-value" data-source="gpsLon">--</span>
+                                <span class="dc-value" data-source="gpsLon" x-text="$store.pilot.gps.lon">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">ALT</span>
-                                <span class="dc-value" data-source="gpsAlt">--</span>
+                                <span class="dc-value" data-source="gpsAlt" x-text="$store.pilot.gps.alt">--</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="network">
                             <div class="dc-header">NETWORK</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">CMD</span>
-                                <span class="dc-value" data-source="cmdVelTopic">/cmd_vel</span>
+                                <span class="dc-value" data-source="cmdVelTopic"
+                                    x-text="$store.pilot.addresses.cmdVelSubscribers !== null ? `${$store.pilot.addresses.cmdVel} (${$store.pilot.addresses.cmdVelSubscribers} subscribers)` : $store.pilot.addresses.cmdVel">/cmd_vel</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">VOICE</span>
-                                <span class="dc-value" data-source="voiceTopic">/voice</span>
+                                <span class="dc-value" data-source="voiceTopic"
+                                    x-text="$store.pilot.addresses.voiceSubscribers !== null ? `${$store.pilot.addresses.voice} (${$store.pilot.addresses.voiceSubscribers} subscribers)` : $store.pilot.addresses.voice">/voice</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">WEB</span>
-                                <span class="dc-value" data-source="webAddress">--</span>
+                                <span class="dc-value" data-source="webAddress"
+                                    x-text="$store.pilot.addresses.web">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">WS</span>
-                                <span class="dc-value" data-source="wsAddress">--</span>
+                                <span class="dc-value" data-source="wsAddress"
+                                    x-text="$store.pilot.addresses.ws">--</span>
                             </div>
                         </div>
                         <div class="data-column" data-column="host">
                             <div class="dc-header">HOST</div>
                             <div class="dc-row dc-row-1">
                                 <span class="dc-key">CPU</span>
-                                <span class="dc-value darkfont" data-source="cpuChip">--</span>
+                                <span class="dc-value darkfont" data-source="cpuChip"
+                                    x-text="$store.pilot.host.cpu">--</span>
                             </div>
                             <div class="dc-row dc-row-2">
                                 <span class="dc-key">TEMP</span>
-                                <span class="dc-value font-alpha-blue" data-source="tempChip">--</span>
+                                <span class="dc-value font-alpha-blue" data-source="tempChip"
+                                    x-text="$store.pilot.host.temp">--</span>
                             </div>
                             <div class="dc-row dc-row-3">
                                 <span class="dc-key">MEM</span>
-                                <span class="dc-value font-arctic-ice" data-source="memChip">--</span>
+                                <span class="dc-value font-arctic-ice" data-source="memChip"
+                                    x-text="$store.pilot.host.mem">--</span>
                             </div>
                             <div class="dc-row dc-row-4">
                                 <span class="dc-key">DIAG</span>
-                                <span class="dc-value font-night-rain" data-source="robotDiag">--</span>
+                                <span class="dc-value font-night-rain" data-source="robotDiag"
+                                    x-text="$store.pilot.robot.diag">--</span>
                             </div>
                         </div>
                     </div>
@@ -266,7 +296,7 @@
 
                         <div class="aux-controls">
                             <div class="controls buttons justify-space-evenly">
-                                <button id=" resetButton" class="reset-button">Reset</button>
+                                <button id="resetButton" class="reset-button">Reset</button>
                                 <button id="stopButton" class="blink stop-button button-sunset-red"
                                     onclick="playSoundAndRedirect('audio3', '#movement');/* todo: stop the robot!*/">Emergency
                                     Stop</button>
@@ -300,35 +330,59 @@
                             <h2 class="go-center">Control Information</h2>
                         </div>
                         <div class=" info-grid">
-                            <div class="info-item"><label>Linear X</label><span id="linearX">0.00</span></div>
-                            <div class="info-item"><label>Linear Y</label><span id="linearY">0.00</span></div>
-                            <div class="info-item"><label>Angular Z</label><span id="angularZ">0.00</span></div>
-                            <div class="info-item"><label>Mode</label><span id="robotMode">--</span></div>
-                            <div class="info-item"><label>Speed (m/s)</label><span id="robotSpeed">--</span></div>
-                            <div class="info-item"><label>Bumper</label><span id="robotBumper">--</span></div>
-                            <div class="info-item"><label>Cliff</label><span id="robotCliff">--</span></div>
-                            <div class="info-item"><label>IR Omni</label><span id="robotIrOmni">--</span></div>
-                            <div class="info-item"><label>Diagnostics</label><span id="robotDiag">--</span></div>
-                            <div class="info-item"><label>Battery %</label><span id="batteryPercentInfo">--</span>
+                            <div class="info-item"><label>Linear X</label><span id="linearX"
+                                    x-text="$store.pilot.twist.linearX">0.00</span></div>
+                            <div class="info-item"><label>Linear Y</label><span id="linearY"
+                                    x-text="$store.pilot.twist.linearY">0.00</span></div>
+                            <div class="info-item"><label>Angular Z</label><span id="angularZ"
+                                    x-text="$store.pilot.twist.angularZ">0.00</span></div>
+                            <div class="info-item"><label>Mode</label><span id="robotMode"
+                                    x-text="$store.pilot.robot.mode">--</span></div>
+                            <div class="info-item"><label>Speed (m/s)</label><span id="robotSpeed"
+                                    x-text="$store.pilot.robot.speed">--</span></div>
+                            <div class="info-item"><label>Bumper</label><span id="robotBumper"
+                                    x-text="$store.pilot.robot.bumper">--</span></div>
+                            <div class="info-item"><label>Cliff</label><span id="robotCliff"
+                                    x-text="$store.pilot.robot.cliff">--</span></div>
+                            <div class="info-item"><label>IR Omni</label><span id="robotIrOmni"
+                                    x-text="$store.pilot.robot.ir">--</span></div>
+                            <div class="info-item"><label>Diagnostics</label><span id="robotDiag"
+                                    x-text="$store.pilot.robot.diag">--</span></div>
+                            <div class="info-item"><label>Battery %</label><span id="batteryPercentInfo"
+                                    x-text="$store.pilot.battery.percent">--</span>
                             </div>
-                            <div class="info-item"><label>Voltage (V)</label><span id="batteryVoltage">--</span>
+                            <div class="info-item"><label>Voltage (V)</label><span id="batteryVoltage"
+                                    x-text="$store.pilot.battery.voltage">--</span>
                             </div>
-                            <div class="info-item"><label>Current (A)</label><span id="batteryCurrent">--</span>
+                            <div class="info-item"><label>Current (A)</label><span id="batteryCurrent"
+                                    x-text="$store.pilot.battery.current">--</span>
                             </div>
-                            <div class="info-item"><label>Temperature</label><span id="batteryTemp">--</span></div>
-                            <div class="info-item"><label>State</label><span id="batteryStateInfo">--</span></div>
-                            <div class="info-item"><label>CPU Load</label><span id="cpuChip">--</span></div>
-                            <div class="info-item"><label>Main Temp</label><span id="tempChip">--</span></div>
-                            <div class="info-item"><label>Memory</label><span id="memChip">--</span></div>
-                            <div class="info-item"><label>Speaking (ms)</label><span id="voiceSpeakingMs">0</span>
+                            <div class="info-item"><label>Temperature</label><span id="batteryTemp"
+                                    x-text="$store.pilot.battery.temperature">--</span></div>
+                            <div class="info-item"><label>State</label><span id="batteryStateInfo"
+                                    x-text="$store.pilot.battery.state">--</span></div>
+                            <div class="info-item"><label>CPU Load</label><span id="cpuChip"
+                                    x-text="$store.pilot.host.cpu">--</span></div>
+                            <div class="info-item"><label>Main Temp</label><span id="tempChip"
+                                    x-text="$store.pilot.host.temp">--</span></div>
+                            <div class="info-item"><label>Memory</label><span id="memChip"
+                                    x-text="$store.pilot.host.mem">--</span></div>
+                            <div class="info-item"><label>Speaking (ms)</label><span id="voiceSpeakingMs"
+                                    x-text="$store.pilot.audio.speakingMs">0</span>
                             </div>
-                            <div class="info-item"><label>VAD Speech (ms)</label><span id="vadSpeechMs">0</span>
+                            <div class="info-item"><label>VAD Speech (ms)</label><span id="vadSpeechMs"
+                                    x-text="$store.pilot.audio.vadMs">0</span>
                             </div>
-                            <div class="info-item"><label>Mic</label><span id="micInfo">--</span></div>
-                            <div class="info-item"><label>GPS Fix</label><span id="gpsFixStatus">--</span></div>
-                            <div class="info-item"><label>Latitude</label><span id="gpsLat">--</span></div>
-                            <div class="info-item"><label>Longitude</label><span id="gpsLon">--</span></div>
-                            <div class="info-item"><label>Altitude (m)</label><span id="gpsAlt">--</span></div>
+                            <div class="info-item"><label>Mic</label><span id="micInfo"
+                                    x-text="$store.pilot.audio.mic">--</span></div>
+                            <div class="info-item"><label>GPS Fix</label><span id="gpsFixStatus"
+                                    x-text="$store.pilot.gps.fix">--</span></div>
+                            <div class="info-item"><label>Latitude</label><span id="gpsLat"
+                                    x-text="$store.pilot.gps.lat">--</span></div>
+                            <div class="info-item"><label>Longitude</label><span id="gpsLon"
+                                    x-text="$store.pilot.gps.lon">--</span></div>
+                            <div class="info-item"><label>Altitude (m)</label><span id="gpsAlt"
+                                    x-text="$store.pilot.gps.alt">--</span></div>
                         </div>
                     </section>
 
@@ -342,10 +396,12 @@
                 </main>
                 <footer>
                     <div class="connection-info">
-                        <div>Web: <span id="webAddress"></span></div>
-                        <div>WebSocket: <span id="wsAddress"></span></div>
-                        <div>Publishing to: <strong id="cmdVelTopic">/cmd_vel</strong></div>
-                        <div>Voice topic: <strong id="voiceTopic">/voice</strong></div>
+                        <div>Web: <span id="webAddress" x-text="$store.pilot.addresses.web"></span></div>
+                        <div>WebSocket: <span id="wsAddress" x-text="$store.pilot.addresses.ws"></span></div>
+                        <div>Publishing to: <strong id="cmdVelTopic"
+                                x-text="$store.pilot.addresses.cmdVelSubscribers !== null ? `${$store.pilot.addresses.cmdVel} (${$store.pilot.addresses.cmdVelSubscribers} subscribers)` : $store.pilot.addresses.cmdVel">/cmd_vel</strong></div>
+                        <div>Voice topic: <strong id="voiceTopic"
+                                x-text="$store.pilot.addresses.voiceSubscribers !== null ? `${$store.pilot.addresses.voice} (${$store.pilot.addresses.voiceSubscribers} subscribers)` : $store.pilot.addresses.voice">/voice</strong></div>
                     </div>
                 </footer>
             </div>
@@ -354,114 +410,6 @@
 
     <script type="text/javascript" src="assets/lcars.js"></script>
     <script src="joystick.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const cascadeEl = document.getElementById('controlCascade');
-            if (!cascadeEl) {
-                return;
-            }
-
-            const valueEls = Array.from(cascadeEl.querySelectorAll('[data-source]'));
-            if (!valueEls.length) {
-                return;
-            }
-
-            const sourceMap = new Map();
-            valueEls.forEach(el => {
-                const key = el.getAttribute('data-source');
-                if (!key) {
-                    return;
-                }
-                if (!sourceMap.has(key)) {
-                    sourceMap.set(key, []);
-                }
-                sourceMap.get(key).push(el);
-            });
-
-            const readSourceValue = (source) => {
-                if (!source) {
-                    return '';
-                }
-                if (source instanceof HTMLInputElement || source instanceof HTMLSelectElement || source instanceof HTMLTextAreaElement) {
-                    return source.value;
-                }
-                return source.textContent || '';
-            };
-
-            const formatValue = (raw) => {
-                const text = (raw || '').trim();
-                if (!text) {
-                    return '--';
-                }
-                if (/^-?\d+(?:\.\d+)?$/.test(text)) {
-                    const num = parseFloat(text);
-                    const magnitude = Math.abs(num);
-                    if (magnitude >= 1000) {
-                        return num.toFixed(0);
-                    }
-                    if (magnitude >= 100) {
-                        return num.toFixed(1);
-                    }
-                    if (magnitude >= 10) {
-                        return num.toFixed(2);
-                    }
-                    if (magnitude >= 1) {
-                        return num.toFixed(2);
-                    }
-                    if (magnitude === 0) {
-                        return '0';
-                    }
-                    return num.toFixed(3);
-                }
-                return text.length > 14 ? `${text.slice(0, 13)}…` : text;
-            };
-
-            const updateTargets = (id) => {
-                const targets = sourceMap.get(id);
-                if (!targets) {
-                    return;
-                }
-                const source = document.getElementById(id);
-                const formatted = formatValue(readSourceValue(source));
-                targets.forEach(el => {
-                    el.textContent = formatted;
-                    if (source) {
-                        el.classList.remove('dc-value--missing');
-                    } else {
-                        el.classList.add('dc-value--missing');
-                    }
-                });
-            };
-
-            const observerConfig = { childList: true, characterData: true, subtree: true };
-            sourceMap.forEach((_, id) => {
-                const source = document.getElementById(id);
-                if (!source) {
-                    updateTargets(id);
-                    return;
-                }
-
-                const observer = new MutationObserver(() => updateTargets(id));
-                observer.observe(source, observerConfig);
-
-                if (source instanceof HTMLInputElement || source instanceof HTMLSelectElement || source instanceof HTMLTextAreaElement) {
-                    const handler = () => updateTargets(id);
-                    source.addEventListener('input', handler);
-                    source.addEventListener('change', handler);
-                }
-
-                updateTargets(id);
-            });
-
-            document.addEventListener('pilot:cascade:sync', (event) => {
-                const detail = event.detail;
-                if (!detail || !detail.id) {
-                    return;
-                }
-                updateTargets(detail.id);
-            });
-        });
-    </script>
     <div class="headtrim"> </div>
     <div class="baseboard"> </div>
 </body>

--- a/modules/pilot/packages/pilot/pilot/static/style.css
+++ b/modules/pilot/packages/pilot/pilot/static/style.css
@@ -64,6 +64,11 @@
     opacity: 0.45;
 }
 
+.status-indicator {
+    display: inline-block;
+    margin-inline: 0.35rem 0.25rem;
+}
+
 /* === D-pad ============================================================= */
 .dpad-section {
     display: flex;

--- a/modules/pilot/packages/pilot/tests/test_frontend_layout.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_layout.py
@@ -33,3 +33,11 @@ def test_css_defines_dpad_and_joystick_styles():
     assert ".dpad-grid" in css and "grid-template-areas" in css
     assert ".joystick" in css and ("aspect-ratio" in css or "padding-top" in css)
     assert "@media" in css and "max-width" in css
+
+
+def test_index_bootstraps_alpine_store():
+    """The frontend should expose an Alpine data context for live telemetry."""
+    html = read_html()
+    assert 'alpinejs' in html.lower()
+    assert 'x-data="pilotApp"' in html
+    assert '$store.pilot.twist.linearX' in html

--- a/modules/pilot/packages/pilot/tests/test_frontend_topics.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_topics.py
@@ -1,0 +1,204 @@
+"""Topic subscription behaviour for the pilot frontend."""
+
+from pathlib import Path
+import json
+import subprocess
+
+
+JS_PATH = Path(__file__).resolve().parents[1] / 'pilot' / 'static' / 'joystick.js'
+
+
+def run_node(script: str) -> None:
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+NODE_PREAMBLE = f"""
+const joystickPath = {json.dumps(str(JS_PATH))};
+
+function installDom(protocol = 'https:') {{
+    global.window = {{
+        location: {{ protocol, hostname: 'pilot.local', port: protocol === 'https:' ? '8443' : '8080' }},
+        addEventListener: () => {{}},
+        matchMedia: () => ({{ matches: false, addEventListener: () => {{}}, addListener: () => {{}} }}),
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        requestAnimationFrame: (cb) => setTimeout(cb, 16),
+        cancelAnimationFrame: (id) => clearTimeout(id),
+        __PILOT_SKIP_AUTO_INIT__: true,
+    }};
+    const attrStub = {{
+        getAttribute: () => null,
+    }};
+    global.document = {{
+        addEventListener: (event, cb) => {{ if (event === 'DOMContentLoaded' && typeof cb === 'function') cb(); }},
+        getElementById: () => null,
+        createElement: () => ({{ getContext: () => ({{}}) }}),
+        body: attrStub,
+        documentElement: attrStub,
+    }};
+}}
+
+class RecordingSocket {{
+    constructor(url) {{
+        this.url = url;
+        this.readyState = 0;
+        this.listeners = {{}};
+        this.closeCount = 0;
+        RecordingSocket.instances.push(this);
+    }}
+    addEventListener(type, cb) {{
+        if (!this.listeners[type]) this.listeners[type] = [];
+        this.listeners[type].push(cb);
+    }}
+    close() {{
+        this.readyState = 3;
+        this.closeCount += 1;
+    }}
+    send() {{}}
+    static reset() {{ RecordingSocket.instances = []; }}
+}}
+RecordingSocket.instances = [];
+"""
+
+
+def test_subscribe_to_topic_uses_api_host():
+    """subscribeToTopic should open a websocket against the api host."""
+
+    script = NODE_PREAMBLE + """
+installDom();
+global.WebSocket = RecordingSocket;
+RecordingSocket.reset();
+
+const { PilotController } = require(joystickPath);
+const controller = new PilotController({ deferInit: true });
+const handle = controller.subscribeToTopic('/cmd_vel');
+
+if (!handle) {
+    throw new Error('subscribeToTopic should return a handle');
+}
+
+if (RecordingSocket.instances.length !== 1) {
+    throw new Error('subscribeToTopic did not open a WebSocket');
+}
+
+const url = RecordingSocket.instances[0].url;
+const expected = 'wss://api/subscribe?topic=%2Fcmd_vel';
+if (url !== expected) {
+    throw new Error('Unexpected topic websocket url: ' + url);
+}
+
+if (typeof handle.close !== 'function') {
+    throw new Error('subscription handle missing close() method');
+}
+
+handle.close();
+"""
+
+    run_node(script)
+
+
+def test_subscribe_to_topic_normalizes_complex_hosts():
+    """Hosts with protocols, ports, or paths should resolve to ws(s) endpoints."""
+
+    script = NODE_PREAMBLE + """
+installDom('https:');
+global.WebSocket = RecordingSocket;
+RecordingSocket.reset();
+
+const { PilotController } = require(joystickPath);
+
+window.PILOT_API_HOST = 'https://api.example.com/base/';
+const controllerSecure = new PilotController({ deferInit: true });
+const secureHandle = controllerSecure.subscribeToTopic('/cmd_vel');
+if (!secureHandle) {
+    throw new Error('Expected secure handle');
+}
+if (RecordingSocket.instances.length !== 1) {
+    throw new Error('Expected one websocket for secure host');
+}
+const secureUrl = RecordingSocket.instances[0].url;
+const secureExpected = 'wss://api.example.com/base/subscribe?topic=%2Fcmd_vel';
+if (secureUrl !== secureExpected) {
+    throw new Error('Secure host normalization failed: ' + secureUrl);
+}
+secureHandle.close();
+
+// HTTP host should downgrade to ws://
+RecordingSocket.reset();
+window.PILOT_API_HOST = 'http://api.local:8000/ws/';
+window.location.protocol = 'http:';
+const controllerInsecure = new PilotController({ deferInit: true });
+const insecureHandle = controllerInsecure.subscribeToTopic('cmd_vel');
+if (!insecureHandle) {
+    throw new Error('Expected insecure handle');
+}
+if (RecordingSocket.instances.length !== 1) {
+    throw new Error('Expected one websocket for insecure host');
+}
+const insecureUrl = RecordingSocket.instances[0].url;
+const insecureExpected = 'ws://api.local:8000/ws/subscribe?topic=cmd_vel';
+if (insecureUrl !== insecureExpected) {
+    throw new Error('Insecure host normalization failed: ' + insecureUrl);
+}
+insecureHandle.close();
+
+// Trailing slashes should be trimmed cleanly.
+RecordingSocket.reset();
+window.PILOT_API_HOST = 'api/';
+window.location.protocol = 'https:';
+const controllerDefault = new PilotController({ deferInit: true });
+const defaultHandle = controllerDefault.subscribeToTopic('/twist');
+const defaultUrl = RecordingSocket.instances[0].url;
+const defaultExpected = 'wss://api/subscribe?topic=%2Ftwist';
+if (defaultUrl !== defaultExpected) {
+    throw new Error('Default host normalization failed: ' + defaultUrl);
+}
+defaultHandle.close();
+"""
+
+    run_node(script)
+
+
+def test_ensure_cmd_vel_subscription_reuses_existing_socket():
+    """ensureCmdVelSubscription should reuse sockets until the topic changes."""
+
+    script = NODE_PREAMBLE + """
+installDom('https:');
+global.WebSocket = RecordingSocket;
+RecordingSocket.reset();
+
+const { PilotController } = require(joystickPath);
+const controller = new PilotController({ deferInit: true });
+
+controller.ensureCmdVelSubscription('/cmd_vel');
+if (RecordingSocket.instances.length !== 1) {
+    throw new Error('Expected first cmd_vel subscription');
+}
+const firstSocket = RecordingSocket.instances[0];
+if (firstSocket.closeCount !== 0) {
+    throw new Error('Socket should not be closed yet');
+}
+
+// Second call with same topic should be a no-op.
+controller.ensureCmdVelSubscription('/cmd_vel');
+if (RecordingSocket.instances.length !== 1) {
+    throw new Error('Unexpected socket recreation for same topic');
+}
+if (firstSocket.closeCount !== 0) {
+    throw new Error('Existing socket should remain open');
+}
+
+// Changing the topic should close the existing socket and open a new one.
+controller.ensureCmdVelSubscription('/cmd_vel_smoothed');
+if (RecordingSocket.instances.length !== 2) {
+    throw new Error('Expected second socket for new topic');
+}
+if (firstSocket.closeCount !== 1) {
+    throw new Error('Previous socket should be closed when topic changes');
+}
+"""
+
+    run_node(script)


### PR DESCRIPTION
## Summary
- expose a `/subscribe` WebSocket endpoint from the pilot websocket node so the UI can stream ROS topics
- bind the pilot frontend to the Alpine `$store.pilot`, refreshing the cascade, status banner, and LCARS-styled controls with live data
- harden topic subscription URL handling in `joystick.js` and cover it with new Node-based tests

## Testing
- pytest modules/pilot/packages/pilot/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d36354b8b083209074fb12db15eb95