### PR TITLE
Add behavioural regime manager scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@ or conflicting package sources.
 - `pytest` is configured to ignore the `src/` symlink; place new tests under
   `packages/<pkg>/tests` and stub ROS interfaces when running in environments
   without ROS installed.
+- `py_trees_ros` is not published to PyPI; `tools/setup_env.sh` installs it
+  from GitHub. Ensure network access is available the first time you source the
+  environment on a new machine.
 - Pilot UI systemd layout no longer renders a `#servicesPills` element; ensure
   frontend updates don't depend on it before processing service data.
 - Pilot control cascade reads from DOM elements flagged with `data-source`

--- a/hosts/cerebellum/modules/will
+++ b/hosts/cerebellum/modules/will
@@ -1,0 +1,1 @@
+../../../modules/will

--- a/hosts/cerebellum/systemd/psyched-will.service
+++ b/hosts/cerebellum/systemd/psyched-will.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Psyched will Service
+After=network.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pete/psyched
+Environment=HOST=cerebellum
+ExecStart=/home/pete/psyched/tools/systemd_entrypoint.sh /home/pete/psyched/hosts/cerebellum/modules/will/launch.sh
+ExecStop=/home/pete/psyched/tools/systemd_entrypoint.sh bash -c "\"/home/pete/psyched/hosts/cerebellum/modules/will/shutdown.sh\""
+Restart=on-failure
+RestartSec=2
+User=pete
+KillMode=control-group
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/will/launch.sh
+++ b/modules/will/launch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REAL_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$REAL_PATH")"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOST_SHORT="${HOST:-$(hostname -s)}"
+
+CONFIG_FILE=""
+if [ -f "${REPO_DIR}/hosts/${HOST_SHORT}/config/will.env" ]; then
+  CONFIG_FILE="${REPO_DIR}/hosts/${HOST_SHORT}/config/will.env"
+elif [ -f "${REPO_DIR}/config/will.env" ]; then
+  CONFIG_FILE="${REPO_DIR}/config/will.env"
+fi
+
+if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+ros2 launch psyched_bt brain.launch.py "${@:-}"

--- a/modules/will/packages/psyched_bt/launch/brain.launch.py
+++ b/modules/will/packages/psyched_bt/launch/brain.launch.py
@@ -1,0 +1,16 @@
+"""Launch file that starts the Psyched regime manager."""
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    return LaunchDescription(
+        [
+            Node(
+                package='psyched_bt',
+                executable='regime_manager',
+                name='psyched_regime_manager',
+                output='screen',
+            )
+        ]
+    )

--- a/modules/will/packages/psyched_bt/package.xml
+++ b/modules/will/packages/psyched_bt/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>psyched_bt</name>
+  <version>0.1.0</version>
+  <description>Behaviour tree regimes for Pete's cognitive layer.</description>
+  <maintainer email="tdreed@gmail.com">Psyched</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>psyched_msgs</exec_depend>
+  <exec_depend>py_trees</exec_depend>
+  <exec_depend>py_trees_ros</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <test_depend>pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/modules/will/packages/psyched_bt/psyched_bt/__init__.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/__init__.py
@@ -1,0 +1,5 @@
+"""Psyched behaviour tree package."""
+
+from .regime_manager_node import RegimeManagerNode
+
+__all__ = ["RegimeManagerNode"]

--- a/modules/will/packages/psyched_bt/psyched_bt/regime_manager_node.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/regime_manager_node.py
@@ -1,0 +1,146 @@
+"""Regime manager node responsible for orchestrating Psyched behaviour trees."""
+from __future__ import annotations
+
+import json
+from typing import Dict, Optional
+
+import py_trees
+from py_trees.common import Access, Status
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+from .trees import converse_on_face
+from .trees.common_blackboard import PERSON_INFO_KEY
+
+
+def parse_face_payload(raw: str) -> Optional[Dict[str, str]]:
+    """Parse face-detection payloads into a canonical dictionary."""
+
+    data = raw.strip()
+    if not data:
+        return None
+
+    try:
+        decoded = json.loads(data)
+    except json.JSONDecodeError:
+        return {"name": data}
+
+    if isinstance(decoded, dict):
+        name = decoded.get("name")
+        if isinstance(name, str) and name:
+            return {"name": name}
+        return None
+    if isinstance(decoded, str) and decoded:
+        return {"name": decoded}
+    return None
+
+
+class RegimeManagerNode(Node):
+    """ROS node that selects and ticks the active behavioural regime."""
+
+    def __init__(self) -> None:
+        super().__init__("psyched_regime_manager")
+        self.declare_parameter("default_regime", "idle")
+        default_regime = self.get_parameter("default_regime").get_parameter_value().string_value or "idle"
+
+        self._behaviour_tree: Optional[py_trees.trees.BehaviourTree] = None
+        self._current_regime = "idle"
+        self._blackboard = py_trees.blackboard.Client(name="regime_manager")
+        self._blackboard.register_key(key=PERSON_INFO_KEY, access=Access.WRITE)
+
+        self._face_sub = self.create_subscription(String, "/vision/face_detected", self._on_face_detected, 10)
+        self._tick_timer = self.create_timer(0.2, self._tick_current_tree)
+
+        self.get_logger().info(f"Regime manager ready; default regime set to {default_regime}")
+        self._set_regime(default_regime)
+
+    def _on_face_detected(self, msg: String) -> None:
+        payload = parse_face_payload(msg.data)
+        if not payload:
+            self.get_logger().debug("Face detected without a name; ignoring")
+            return
+
+        setattr(self._blackboard, PERSON_INFO_KEY, payload)
+        self.get_logger().info(f"Face detected: {payload['name']}")
+        self._set_regime("converse_on_face")
+
+    def _tick_current_tree(self) -> None:
+        if self._behaviour_tree is None:
+            return
+
+        self._behaviour_tree.tick()
+        status = self._behaviour_tree.root.status
+        if status in (Status.SUCCESS, Status.FAILURE):
+            self.get_logger().info(
+                f"Regime {self._current_regime} completed with status {status.name}"
+            )
+            self._shutdown_tree()
+            self._current_regime = "idle"
+
+    def _set_regime(self, name: str) -> None:
+        if name == "idle":
+            if self._behaviour_tree is not None:
+                self.get_logger().debug("Stopping active regime and returning to idle")
+            self._shutdown_tree()
+            self._current_regime = "idle"
+            return
+
+        if name == "converse_on_face":
+            self._start_converse_on_face()
+            return
+
+        if name == "navigate":
+            self.get_logger().info("Navigate regime not implemented yet; remaining idle")
+            self._shutdown_tree()
+            self._current_regime = "idle"
+            return
+
+        if name == "explore":
+            self.get_logger().info("Explore regime not implemented yet; remaining idle")
+            self._shutdown_tree()
+            self._current_regime = "idle"
+            return
+
+        self.get_logger().warning(f"Unknown regime '{name}'; staying in {self._current_regime}")
+
+    def _start_converse_on_face(self) -> None:
+        self._shutdown_tree()
+        try:
+            root = converse_on_face.create_tree()
+            tree = py_trees.trees.BehaviourTree(root=root)
+            tree.setup(timeout=1.0, node=self)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self.get_logger().error(f"Failed to start converse_on_face regime: {exc}")
+            self._behaviour_tree = None
+            self._current_regime = "idle"
+            return
+
+        self._behaviour_tree = tree
+        self._current_regime = "converse_on_face"
+        self.get_logger().info("Switched to converse_on_face regime")
+
+    def _shutdown_tree(self) -> None:
+        if self._behaviour_tree is None:
+            return
+        try:
+            self._behaviour_tree.shutdown()
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
+        self._behaviour_tree = None
+
+    def destroy_node(self) -> bool:
+        self._shutdown_tree()
+        return super().destroy_node()
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = RegimeManagerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:  # pragma: no cover - manual shutdown path
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/modules/will/packages/psyched_bt/psyched_bt/trees/__init__.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/trees/__init__.py
@@ -1,0 +1,4 @@
+"""Behaviour tree factories for Psyched."""
+from . import converse_on_face
+
+__all__ = ["converse_on_face"]

--- a/modules/will/packages/psyched_bt/psyched_bt/trees/common_actions.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/trees/common_actions.py
@@ -1,0 +1,175 @@
+"""Common ROS actions used by the Psyched behaviour trees."""
+
+from __future__ import annotations
+
+import types
+from typing import Any, Optional
+
+import py_trees
+from py_trees.common import Access, Status
+
+from .common_blackboard import CONVERSATION_SEED_KEY, VOICE_TEXT_KEY
+
+
+class Speak(py_trees.behaviour.Behaviour):
+    """Publish a greeting to ``/voice`` and wait for completion.
+
+    The behaviour reads ``VOICE_TEXT_KEY`` from the blackboard, publishes it to
+    the configured voice topic, and waits for a matching ``voice_done`` message
+    before reporting :class:`~py_trees.common.Status.SUCCESS`.
+
+    Parameters
+    ----------
+    voice_topic:
+        Topic that accepts :class:`std_msgs.msg.String` messages for synthesis.
+    voice_done_topic:
+        Topic used by the voice node to signal completion of playback.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "Speak Greeting",
+        text_key: str = VOICE_TEXT_KEY,
+        voice_topic: str = "/voice",
+        voice_done_topic: str = "voice_done",
+    ) -> None:
+        super().__init__(name=name)
+        self.text_key = text_key
+        self.voice_topic = voice_topic
+        self.voice_done_topic = voice_done_topic
+        self._blackboard = py_trees.blackboard.Client(name=f"{name}_bb")
+        self._blackboard.register_key(key=self.text_key, access=Access.READ)
+        self._publisher: Optional[Any] = None
+        self._subscription: Optional[Any] = None
+        self._voice_done = False
+        self._spoken = False
+        self._last_utterance: Optional[str] = None
+        self._node: Any = None
+        self._string_type: Optional[type] = None
+
+    @property
+    def last_utterance(self) -> Optional[str]:
+        """Expose the last utterance for tests and debugging."""
+
+        return self._last_utterance
+
+    def setup(self, **kwargs: Any) -> None:
+        self._node = kwargs.get("node", None)
+        if self._node is None:
+            raise RuntimeError("Speak requires a ROS node provided via setup(node=...)")
+
+        try:
+            from std_msgs.msg import String  # type: ignore
+        except ImportError:  # pragma: no cover - ROS environment provides the type
+            String = None
+
+        self._string_type = String
+        msg_type = String if String is not None else types.SimpleNamespace
+        self._publisher = self._node.create_publisher(msg_type, self.voice_topic, 10)
+        self._subscription = self._node.create_subscription(msg_type, self.voice_done_topic, self._on_voice_done, 10)
+
+    def initialise(self) -> None:
+        self._voice_done = False
+        self._spoken = False
+        self._last_utterance = None
+
+    def update(self) -> Status:
+        if self._publisher is None:
+            raise RuntimeError("Speak behaviour has not been setup with a ROS node")
+
+        utterance = getattr(self._blackboard, self.text_key, None)
+        if not utterance:
+            self.logger.warning("Voice text missing; failing Speak behaviour")
+            return Status.FAILURE
+
+        if not self._spoken:
+            message = self._build_message(utterance)
+            self._publisher.publish(message)
+            self._last_utterance = utterance
+            self._spoken = True
+            self.logger.info(f"Speaking: {utterance}")
+            return Status.RUNNING
+
+        if self._voice_done:
+            self.logger.debug("voice_done received; Speak succeeded")
+            return Status.SUCCESS
+
+        return Status.RUNNING
+
+    def terminate(self, new_status: Status) -> None:  # pragma: no cover - tear down is trivial
+        if new_status == Status.INVALID:
+            self._spoken = False
+            self._voice_done = False
+
+    def _build_message(self, utterance: str) -> Any:
+        if self._string_type is not None:
+            msg = self._string_type()
+            setattr(msg, "data", utterance)
+            return msg
+        return types.SimpleNamespace(data=utterance)
+
+    def _on_voice_done(self, msg: Any) -> None:
+        completed = getattr(msg, "data", None)
+        if completed == self._last_utterance:
+            self._voice_done = True
+
+
+class SeedConversation(py_trees.behaviour.Behaviour):
+    """Publish a starter :class:`psyched_msgs.msg.Message` to ``/conversation``."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "Seed Conversation",
+        seed_key: str = CONVERSATION_SEED_KEY,
+        topic: str = "/conversation",
+    ) -> None:
+        super().__init__(name=name)
+        self.seed_key = seed_key
+        self.topic = topic
+        self._blackboard = py_trees.blackboard.Client(name=f"{name}_bb")
+        self._blackboard.register_key(key=self.seed_key, access=Access.READ)
+        self._publisher: Optional[Any] = None
+        self._message_type: Optional[type] = None
+        self._node: Any = None
+        self._published = False
+
+    def setup(self, **kwargs: Any) -> None:
+        self._node = kwargs.get("node", None)
+        if self._node is None:
+            raise RuntimeError("SeedConversation requires a ROS node via setup(node=...)")
+
+        try:
+            from psyched_msgs.msg import Message as ConversationMessage  # type: ignore
+        except ImportError:  # pragma: no cover - tests stub this module
+            ConversationMessage = None
+
+        self._message_type = ConversationMessage
+        msg_type = ConversationMessage if ConversationMessage is not None else types.SimpleNamespace
+        self._publisher = self._node.create_publisher(msg_type, self.topic, 10)
+
+    def initialise(self) -> None:
+        self._published = False
+
+    def update(self) -> Status:
+        if self._publisher is None or self._message_type is None:
+            self.logger.warning("Conversation message type unavailable; cannot seed chat yet")
+            return Status.FAILURE
+
+        seed = getattr(self._blackboard, self.seed_key, None)
+        if not isinstance(seed, dict):
+            self.logger.warning("Conversation seed missing; failing behaviour")
+            return Status.FAILURE
+
+        if not self._published:
+            message = self._message_type()
+            message.role = seed.get("role", "user")
+            message.content = seed.get("content", "")
+            self._publisher.publish(message)
+            self._published = True
+            self.logger.info("Seeded conversation with starter message")
+        return Status.SUCCESS
+
+
+# TODO: Add GoToGoal and CommentOnScene behaviours as regimes expand.

--- a/modules/will/packages/psyched_bt/psyched_bt/trees/common_blackboard.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/trees/common_blackboard.py
@@ -1,0 +1,113 @@
+"""Shared blackboard primitives for Psyched behaviour trees."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import py_trees
+from py_trees.common import Access, Status
+
+
+# Blackboard keys used across behaviours. Keep attribute friendly so we can use
+# ``getattr`` / ``setattr`` without additional translation helpers.
+PERSON_INFO_KEY = "psyched_bt_person"
+VOICE_TEXT_KEY = "psyched_bt_voice_text"
+CONVERSATION_SEED_KEY = "psyched_bt_conversation_seed"
+
+
+@dataclass
+class PersonInfo:
+    """Simple container describing a detected person."""
+
+    name: str
+
+
+class SetText(py_trees.behaviour.Behaviour):
+    """Derive utterances and prompts from face-detection data.
+
+    The behaviour reads a :class:`PersonInfo` dictionary from the blackboard and
+    writes two pieces of state:
+
+    ``VOICE_TEXT_KEY``
+        A human-friendly greeting that is sent to :class:`~std_msgs.msg.String`
+        publishers.
+
+    ``CONVERSATION_SEED_KEY``
+        A dictionary compatible with :class:`psyched_msgs.msg.Message`
+        containing the starter prompt for the chat system.
+
+    Examples
+    --------
+    >>> import py_trees
+    >>> writer = py_trees.blackboard.Client(name="writer")
+    >>> writer.register_key(key=PERSON_INFO_KEY, access=Access.WRITE)
+    >>> writer.psyched_bt_person = {"name": "Ada"}
+    >>> behaviour = SetText()
+    >>> tree = py_trees.trees.BehaviourTree(root=behaviour)
+    >>> _ = tree.setup(timeout=1.0)
+    >>> _ = tree.tick()
+    >>> reader = py_trees.blackboard.Client(name="reader")
+    >>> reader.register_key(key=VOICE_TEXT_KEY, access=Access.READ)
+    >>> reader.register_key(key=CONVERSATION_SEED_KEY, access=Access.READ)
+    >>> reader.psyched_bt_voice_text
+    "Hi Ada, I'm Pete. It's great to meet you."
+    >>> reader.psyched_bt_conversation_seed["role"]
+    'user'
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "Prepare Greeting",
+        person_key: str = PERSON_INFO_KEY,
+        voice_key: str = VOICE_TEXT_KEY,
+        conversation_key: str = CONVERSATION_SEED_KEY,
+    ) -> None:
+        super().__init__(name=name)
+        self.person_key = person_key
+        self.voice_key = voice_key
+        self.conversation_key = conversation_key
+        self.blackboard = py_trees.blackboard.Client(name=f"{name}_bb")
+        self.blackboard.register_key(key=self.person_key, access=Access.READ)
+        self.blackboard.register_key(key=self.voice_key, access=Access.WRITE)
+        self.blackboard.register_key(key=self.conversation_key, access=Access.WRITE)
+
+    def update(self) -> Status:
+        person: Optional[Dict[str, str]] = getattr(self.blackboard, self.person_key, None)
+        if not person:
+            self.logger.warning("No person info available; cannot prepare greeting")
+            return Status.FAILURE
+
+        name = person.get("name") if isinstance(person, dict) else None
+        if not name:
+            self.logger.info("Detected person is missing a name; skipping greeting")
+            return Status.FAILURE
+
+        greeting = f"Hi {name}, I'm Pete. It's great to meet you."
+        conversation_seed = {
+            "role": "user",
+            "content": (
+                f"Greet {name} warmly and keep the conversation going. "
+                "Offer a follow-up question after the introduction."
+            ),
+        }
+
+        setattr(self.blackboard, self.voice_key, greeting)
+        setattr(self.blackboard, self.conversation_key, conversation_seed)
+        self.logger.debug(f"Prepared greeting for {name}")
+        return Status.SUCCESS
+
+
+class SetFlag(py_trees.behaviour.Behaviour):
+    """Placeholder for future guard behaviours.
+
+    TODO: implement guard logic when additional regimes are introduced.
+    """
+
+    def __init__(self, name: str = "Set Flag") -> None:
+        super().__init__(name=name)
+
+    def update(self) -> Status:  # pragma: no cover - stub behaviour
+        self.logger.debug("SetFlag is a stub; returning SUCCESS by default")
+        return Status.SUCCESS

--- a/modules/will/packages/psyched_bt/psyched_bt/trees/converse_on_face.py
+++ b/modules/will/packages/psyched_bt/psyched_bt/trees/converse_on_face.py
@@ -1,0 +1,21 @@
+"""Behaviour tree that initiates a conversation when a face is detected."""
+from __future__ import annotations
+
+import py_trees
+
+from .common_actions import SeedConversation, Speak
+from .common_blackboard import SetText
+
+
+def create_tree(name: str = "ConverseOnFace") -> py_trees.behaviour.Behaviour:
+    """Create the behaviour tree for the ``converse_on_face`` regime."""
+
+    root = py_trees.composites.Sequence(name=name, memory=True)
+    root.add_children(
+        [
+            SetText(),
+            Speak(),
+            SeedConversation(),
+        ]
+    )
+    return root

--- a/modules/will/packages/psyched_bt/resource/psyched_bt
+++ b/modules/will/packages/psyched_bt/resource/psyched_bt
@@ -1,0 +1,1 @@
+psyched_bt

--- a/modules/will/packages/psyched_bt/setup.cfg
+++ b/modules/will/packages/psyched_bt/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/psyched_bt
+[install]
+install_scripts=$base/lib/psyched_bt

--- a/modules/will/packages/psyched_bt/setup.py
+++ b/modules/will/packages/psyched_bt/setup.py
@@ -1,0 +1,33 @@
+from setuptools import setup
+
+package_name = 'psyched_bt'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name, f'{package_name}.trees'],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', ['launch/brain.launch.py']),
+    ],
+    install_requires=[
+        'setuptools',
+        'rclpy',
+        'std_msgs',
+        'py_trees',
+        'py_trees_ros',
+        'psyched_msgs',
+    ],
+    zip_safe=True,
+    maintainer='Psyched',
+    maintainer_email='tdreed@gmail.com',
+    description='Behaviour tree regimes for Pete\'s cognitive layer',
+    license='MIT',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'regime_manager = psyched_bt.regime_manager_node:main',
+        ],
+    },
+)

--- a/modules/will/packages/psyched_bt/tests/test_converse_on_face.py
+++ b/modules/will/packages/psyched_bt/tests/test_converse_on_face.py
@@ -1,0 +1,221 @@
+"""Behaviour tree scaffolding tests for the Psyched BT package."""
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, List
+
+def _ensure_psyched_msgs_stub() -> None:
+    if "psyched_msgs.msg" in sys.modules:
+        return
+
+    msg_module = types.SimpleNamespace()
+
+    class Message:  # pylint: disable=too-few-public-methods
+        """Simple stand-in for the ROS message."""
+
+        def __init__(self) -> None:
+            self.role: str = ""
+            self.content: str = ""
+
+    msg_module.Message = Message
+    pkg_module = types.SimpleNamespace(msg=msg_module)
+    sys.modules.setdefault("psyched_msgs", pkg_module)
+    sys.modules.setdefault("psyched_msgs.msg", msg_module)
+
+
+def _ensure_ros_stubs() -> None:
+    if "rclpy" not in sys.modules:
+        class _StubLogger:
+            def debug(self, _msg: str) -> None:  # pragma: no cover - trivial stub
+                pass
+
+            info = debug
+            warning = debug
+            error = debug
+
+        class _StubParamValue:
+            def __init__(self, value: str = "idle") -> None:
+                self.string_value = value
+
+        class _StubParam:
+            def __init__(self, value: str = "idle") -> None:
+                self._value = value
+
+            def get_parameter_value(self) -> _StubParamValue:
+                return _StubParamValue(self._value)
+
+        class _StubNode:
+            def __init__(self, _name: str) -> None:
+                self._logger = _StubLogger()
+
+            def declare_parameter(self, _name: str, _default: Any) -> None:
+                return None
+
+            def get_parameter(self, _name: str) -> _StubParam:
+                return _StubParam()
+
+            def create_subscription(self, *_args: Any, **_kwargs: Any) -> Any:
+                return types.SimpleNamespace()
+
+            def create_timer(self, *_args: Any, **_kwargs: Any) -> Any:
+                return types.SimpleNamespace()
+
+            def get_logger(self) -> _StubLogger:
+                return self._logger
+
+            def destroy_node(self) -> bool:
+                return True
+
+        rclpy_module = types.SimpleNamespace(
+            init=lambda *args, **kwargs: None,
+            shutdown=lambda *args, **kwargs: None,
+            spin=lambda *args, **kwargs: None,
+            node=types.SimpleNamespace(Node=_StubNode),
+        )
+        sys.modules.setdefault("rclpy", rclpy_module)
+        sys.modules.setdefault("rclpy.node", rclpy_module.node)
+
+    if "std_msgs.msg" not in sys.modules:
+        class _SimpleString:  # pylint: disable=too-few-public-methods
+            def __init__(self) -> None:
+                self.data: str = ""
+
+        std_msgs_module = types.SimpleNamespace(msg=types.SimpleNamespace(String=_SimpleString))
+        sys.modules.setdefault("std_msgs", std_msgs_module)
+        sys.modules.setdefault("std_msgs.msg", std_msgs_module.msg)
+
+
+_ensure_ros_stubs()
+_ensure_psyched_msgs_stub()
+
+import pytest
+import py_trees
+
+from py_trees.common import Access, Status
+
+from psyched_bt.trees.common_blackboard import (
+    CONVERSATION_SEED_KEY,
+    PERSON_INFO_KEY,
+    VOICE_TEXT_KEY,
+    SetText,
+)
+from psyched_bt.trees import converse_on_face
+from psyched_bt.regime_manager_node import parse_face_payload
+
+
+class DummyLogger:
+    """Minimal logger used by dummy ROS nodes in tests."""
+
+    def debug(self, msg: str) -> None:  # pragma: no cover - trivial logging helper
+        self._log("DEBUG", msg)
+
+    def info(self, msg: str) -> None:  # pragma: no cover - trivial logging helper
+        self._log("INFO", msg)
+
+    def warning(self, msg: str) -> None:  # pragma: no cover - trivial logging helper
+        self._log("WARNING", msg)
+
+    def error(self, msg: str) -> None:  # pragma: no cover - trivial logging helper
+        self._log("ERROR", msg)
+
+    @staticmethod
+    def _log(level: str, msg: str) -> None:
+        print(f"[{level}] {msg}")
+
+
+class DummyPublisher:
+    """Captures messages published by behaviours during tests."""
+
+    def __init__(self, topic: str) -> None:
+        self.topic = topic
+        self.messages: List[Any] = []
+
+    def publish(self, msg: Any) -> None:
+        self.messages.append(msg)
+
+
+class DummyNode:
+    """Tiny ROS-like node used to exercise behaviours without ROS."""
+
+    def __init__(self) -> None:
+        self.publishers: List[DummyPublisher] = []
+        self.subscriptions: List[Any] = []
+        self._logger = DummyLogger()
+
+    def create_publisher(self, _msg_type: Any, topic: str, _queue_size: int) -> DummyPublisher:
+        publisher = DummyPublisher(topic)
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_subscription(
+        self, _msg_type: Any, topic: str, callback: Any, _queue_size: int
+    ) -> Any:
+        self.subscriptions.append((topic, callback))
+        return callback
+
+    def get_logger(self) -> DummyLogger:
+        return self._logger
+
+
+def test_parse_face_payload_handles_json() -> None:
+    """Faces published as JSON should return a name dictionary."""
+    payload = parse_face_payload('{"name":"Stranger"}')
+    assert payload == {"name": "Stranger"}
+
+
+def test_set_text_populates_blackboard() -> None:
+    """SetText should convert a detection into voice + conversation prompts."""
+    manager_client = py_trees.blackboard.Client(name="manager")
+    manager_client.register_key(key=PERSON_INFO_KEY, access=Access.WRITE)
+    setattr(manager_client, PERSON_INFO_KEY, {"name": "Ada"})
+
+    behaviour = SetText()
+    tree = py_trees.trees.BehaviourTree(root=behaviour)
+    tree.setup(timeout=1.0)
+    tree.tick()
+
+    reader = py_trees.blackboard.Client(name="reader")
+    reader.register_key(key=VOICE_TEXT_KEY, access=Access.READ)
+    reader.register_key(key=CONVERSATION_SEED_KEY, access=Access.READ)
+
+    assert getattr(reader, VOICE_TEXT_KEY).startswith("Hi Ada")
+    assert "Ada" in getattr(reader, CONVERSATION_SEED_KEY)["content"]
+
+
+def test_converse_tree_runs_to_completion() -> None:
+    """The tree should greet, wait for completion, then seed the chat."""
+
+    manager_client = py_trees.blackboard.Client(name="manager")
+    manager_client.register_key(key=PERSON_INFO_KEY, access=Access.WRITE)
+    setattr(manager_client, PERSON_INFO_KEY, {"name": "Grace"})
+
+    node = DummyNode()
+    root = converse_on_face.create_tree()
+    tree = py_trees.trees.BehaviourTree(root=root)
+    tree.setup(timeout=1.0, node=node)
+
+    # First tick should publish speech and wait for completion.
+    tree.tick()
+    speak_behaviour = root.children[1]
+    assert speak_behaviour.status == Status.RUNNING
+    publisher = node.publishers[0]
+    assert publisher.topic == "/voice"
+    assert publisher.messages, "Speak should publish a greeting"
+    utterance = getattr(publisher.messages[-1], "data", None)
+    assert isinstance(utterance, str) and "Grace" in utterance
+
+    # Simulate the voice_done callback and tick again to finish.
+    done_msg = types.SimpleNamespace(data=utterance)
+    node.subscriptions[0][1](done_msg)
+
+    tree.tick()
+    assert speak_behaviour.status == Status.SUCCESS
+    seed_behaviour = root.children[2]
+    assert seed_behaviour.status == Status.SUCCESS
+
+    conversation_pub = node.publishers[1]
+    assert conversation_pub.topic == "/conversation"
+    message = conversation_pub.messages[-1]
+    assert getattr(message, "role", "") == "user"
+    assert "Grace" in getattr(message, "content", "")

--- a/modules/will/setup.sh
+++ b/modules/will/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REAL_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$REAL_PATH")"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC_DIR="${REPO_DIR}/src"
+
+mkdir -p "$SRC_DIR"
+
+echo "Linking will module packages into workspace src"
+for pkg in "$SCRIPT_DIR"/packages/*; do
+  if [ -d "$pkg" ]; then
+    pkg_name="$(basename "$pkg")"
+    target="${SRC_DIR}/${pkg_name}"
+    if [ -e "$target" ]; then
+      echo " - $pkg_name already linked"
+    else
+      ln -s "$pkg" "$target"
+      echo " - linked $pkg_name"
+    fi
+  fi
+done
+
+echo "will module setup complete"

--- a/modules/will/shutdown.sh
+++ b/modules/will/shutdown.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "will module shutdown: no actions required"

--- a/modules/will/teardown.sh
+++ b/modules/will/teardown.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "will module teardown: no persistent state to remove"

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -112,6 +112,39 @@ source_now() {
     done
   fi
   if (( had_u )); then set -u; fi
+
+  ensure_pytrees_dependencies
+}
+
+ensure_pytrees_dependencies() {
+  local python_bin="${PYTHON:-python3}"
+  if ! command -v "$python_bin" >/dev/null 2>&1; then
+    echo "# [setup_env] ${python_bin} not found; skipping py_trees dependency check" >&2
+    return
+  fi
+
+  "$python_bin" - <<'PY'
+import importlib
+import subprocess
+import sys
+
+
+def ensure(package: str, install_spec: str) -> None:
+    try:
+        importlib.import_module(package)
+    except ModuleNotFoundError:
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", install_spec])
+        except Exception as exc:  # pragma: no cover - environment-dependent path
+            print(f"# [setup_env] Failed to install {install_spec}: {exc}", file=sys.stderr)
+
+
+ensure("py_trees", "py_trees")
+try:
+    importlib.import_module("py_trees_ros")
+except ModuleNotFoundError:
+    ensure("py_trees_ros", "git+https://github.com/splintered-reality/py_trees_ros.git")
+PY
 }
 
 case "$MODE" in


### PR DESCRIPTION
## Summary
- add the new `psyched_bt` ROS 2 package with a regime manager node and the initial `converse_on_face` behaviour tree
- provide common speech and conversation actions plus tests that exercise the tree with ROS stubs
- scaffold the `will` module launch/setup scripts, ensure py_trees dependencies install during environment setup, and add the matching systemd service

## Testing
- PYTHONPATH=modules/will/packages/psyched_bt pytest modules/will/packages/psyched_bt/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d3700bb1c88320977d557ac87fb336