### PR TITLE
Use Dax for shell invocations across psh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ workspace.
   summary. If you must skip a check, state why.
 - Smoke-test module commands when you modify them (e.g.
   `deno run -A psh/main.ts mod <module> launch`).
+- Deno-based tests require local CA trust; run them with
+  `DENO_TLS_CA_STORE=system` and grant the needed permissions (e.g.
+  `--allow-read --allow-write --allow-env`).
 
 Important workflow note:
 

--- a/psh/cli_test.ts
+++ b/psh/cli_test.ts
@@ -44,6 +44,12 @@ function createStubDeps() {
     async cleanWorkspace() {
       record("cleanWorkspace");
     },
+    async colconBuild() {
+      record("colconBuild");
+    },
+    async colconInstall() {
+      record("colconInstall");
+    },
   };
 
   return { calls, deps };

--- a/psh/colcon.ts
+++ b/psh/colcon.ts
@@ -1,33 +1,45 @@
-import { repoPath } from "./util.ts";
+import { $, type DaxTemplateTag, repoPath } from "./util.ts";
 
-export async function colconBuild(): Promise<void> {
-    const absSrc = repoPath("../src");
-    const cmd = new Deno.Command("colcon", {
-        args: ["build", "--symlink-install", "--base-paths", absSrc],
-        stdout: "inherit",
-        stderr: "inherit",
-    });
-    const child = cmd.spawn();
-    const status = await child.status;
-    if (!status.success) {
-        console.error(`[psh] colcon build failed with code ${status.code ?? 1}`);
-        Deno.exit(status.code ?? 1);
-    }
-    console.log("Colcon build complete.");
+async function runColcon(
+  runner: DaxTemplateTag,
+  subcommand: string,
+  args: string[],
+  successMessage: string,
+  errorLabel: string,
+): Promise<void> {
+  const absSrc = repoPath("../src");
+  const builder = runner`colcon ${[
+    subcommand,
+    ...args,
+    "--base-paths",
+    absSrc,
+  ]}`
+    .stdout("inherit")
+    .stderr("inherit");
+  const result = await builder.noThrow();
+  if (result.code !== 0) {
+    console.error(`[psh] ${errorLabel} failed with code ${result.code ?? 1}`);
+    Deno.exit(result.code ?? 1);
+  }
+  console.log(successMessage);
 }
 
-export async function colconInstall(): Promise<void> {
-    const absSrc = repoPath("../src");
-    const cmd = new Deno.Command("colcon", {
-        args: ["install", "--base-paths", absSrc],
-        stdout: "inherit",
-        stderr: "inherit",
-    });
-    const child = cmd.spawn();
-    const status = await child.status;
-    if (!status.success) {
-        console.error(`[psh] colcon install failed with code ${status.code ?? 1}`);
-        Deno.exit(status.code ?? 1);
-    }
-    console.log("Colcon install complete.");
+export async function colconBuild(runner: DaxTemplateTag = $): Promise<void> {
+  await runColcon(
+    runner,
+    "build",
+    ["--symlink-install"],
+    "Colcon build complete.",
+    "colcon build",
+  );
+}
+
+export async function colconInstall(runner: DaxTemplateTag = $): Promise<void> {
+  await runColcon(
+    runner,
+    "install",
+    [],
+    "Colcon install complete.",
+    "colcon install",
+  );
 }

--- a/psh/colcon_test.ts
+++ b/psh/colcon_test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "@std/assert";
+import { colconBuild, colconInstall } from "./colcon.ts";
+import { createDaxStub, type StubInvocation } from "./test_utils.ts";
+
+function assertColconInvocation(invocation: StubInvocation) {
+  assertEquals(invocation.parts[0], "colcon ");
+  assertEquals(invocation.parts[1], "");
+  assertEquals(invocation.values.length, 1);
+  assertEquals(invocation.options.stdout, "inherit");
+  assertEquals(invocation.options.stderr, "inherit");
+}
+
+function expectInvocation(
+  invocation: StubInvocation | null,
+  message: string,
+): StubInvocation {
+  if (!invocation) {
+    throw new Error(message);
+  }
+  return invocation;
+}
+
+Deno.test("colcon build shells out via dax", async () => {
+  let captured: StubInvocation | null = null;
+  const stub = createDaxStub((invocation) => {
+    captured = invocation;
+    return { code: 0 };
+  });
+  await colconBuild(stub);
+  const invocation = expectInvocation(
+    captured,
+    "Expected colcon build to invoke dax",
+  );
+  const args = invocation.values[0] as string[];
+  assertEquals(Array.isArray(args), true);
+  assertEquals(args.slice(0, 2), ["build", "--symlink-install"]);
+  assertEquals(args[2], "--base-paths");
+  assertEquals(typeof args[3], "string");
+  assertColconInvocation(invocation);
+});
+
+Deno.test("colcon install shells out via dax", async () => {
+  let captured: StubInvocation | null = null;
+  const stub = createDaxStub((invocation) => {
+    captured = invocation;
+    return { code: 0 };
+  });
+  await colconInstall(stub);
+  const invocation = expectInvocation(
+    captured,
+    "Expected colcon install to invoke dax",
+  );
+  const args = invocation.values[0] as string[];
+  assertEquals(Array.isArray(args), true);
+  assertEquals(args.slice(0, 1), ["install"]);
+  assertEquals(args[1], "--base-paths");
+  assertEquals(typeof args[2], "string");
+  assertColconInvocation(invocation);
+});

--- a/psh/deno.lock
+++ b/psh/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@david/dax@~0.43.2": "0.43.2",
     "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/which@~0.4.1": "0.4.1",
+    "jsr:@std/assert@1": "1.0.14",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/collections@^1.1.3": "1.1.3",
     "jsr:@std/encoding@~1.0.5": "1.0.10",
@@ -84,6 +85,12 @@
     },
     "@david/which@0.4.1": {
       "integrity": "896a682b111f92ab866cc70c5b4afab2f5899d2f9bde31ed00203b9c250f225e"
+    },
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"

--- a/psh/mod_test.ts
+++ b/psh/mod_test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  resetModCommandRunner,
+  runModuleScript,
+  setModCommandRunner,
+} from "./mod.ts";
+import { repoDirFromModules } from "./modules.ts";
+import { createDaxStub, type StubInvocation } from "./test_utils.ts";
+
+async function withTempModule(
+  name: string,
+  setup: (moduleDir: string) => Promise<void>,
+  testFn: (moduleDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = repoDirFromModules();
+  const moduleDir = join(repoDir, "modules", name);
+  await Deno.mkdir(moduleDir, { recursive: true });
+  try {
+    await setup(moduleDir);
+    await testFn(moduleDir);
+  } finally {
+    await Deno.remove(moduleDir, { recursive: true }).catch(() => undefined);
+  }
+}
+
+Deno.test("runModuleScript executes launch script via dax", async () => {
+  let captured: StubInvocation | null = null;
+  const stub = createDaxStub((invocation) => {
+    captured = invocation;
+    return { code: 0 };
+  });
+  setModCommandRunner(stub);
+  try {
+    await withTempModule(
+      "dax_launch_script",
+      async (moduleDir) => {
+        const scriptPath = join(moduleDir, "launch.sh");
+        await Deno.writeTextFile(scriptPath, "#!/usr/bin/env bash\nexit 0\n");
+        await Deno.chmod(scriptPath, 0o755);
+      },
+      async (moduleDir) => {
+        await runModuleScript("dax_launch_script", "launch");
+        if (!captured) {
+          throw new Error("Expected launch.sh to be invoked");
+        }
+        assertEquals(captured.parts[0], "bash ");
+        assertEquals(captured.values[0], [join(moduleDir, "launch.sh")]);
+      },
+    );
+  } finally {
+    resetModCommandRunner();
+  }
+});
+
+Deno.test("runModuleScript falls back to systemd launch command", async () => {
+  let captured: StubInvocation | null = null;
+  const stub = createDaxStub((invocation) => {
+    captured = invocation;
+    return { code: 0 };
+  });
+  setModCommandRunner(stub);
+  try {
+    await withTempModule(
+      "dax_systemd_launch",
+      async (moduleDir) => {
+        await Deno.writeTextFile(
+          join(moduleDir, "module.toml"),
+          `name = "dax_systemd_launch"\n[systemd]\nlaunch_command = "echo hi"\n`,
+        );
+      },
+      async () => {
+        await runModuleScript("dax_systemd_launch", "launch");
+        if (!captured) {
+          throw new Error("Expected launch_command to be invoked");
+        }
+        const repoDir = repoDirFromModules();
+        assertEquals(
+          captured.values[0],
+          join(repoDir, "tools", "systemd_entrypoint.sh"),
+        );
+        assertEquals(captured.values[1], ["bash", "-lc", "echo hi"]);
+      },
+    );
+  } finally {
+    resetModCommandRunner();
+  }
+});

--- a/psh/test_utils.ts
+++ b/psh/test_utils.ts
@@ -1,0 +1,57 @@
+import type { DaxTemplateTag } from "./util.ts";
+
+export interface StubInvocation {
+  parts: TemplateStringsArray;
+  values: unknown[];
+  options: {
+    stdout?: string;
+    stderr?: string;
+    cwd?: string;
+    env?: Record<string, string>;
+  };
+}
+
+export interface StubResult {
+  code: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export type InvocationHandler = (
+  invocation: StubInvocation,
+) => StubResult | Promise<StubResult>;
+
+export function createDaxStub(
+  handler: InvocationHandler,
+): DaxTemplateTag {
+  return ((parts: TemplateStringsArray, ...values: unknown[]) => {
+    const options: StubInvocation["options"] = {};
+    const builder = {
+      stdout(mode: string) {
+        options.stdout = mode;
+        return builder;
+      },
+      stderr(mode: string) {
+        options.stderr = mode;
+        return builder;
+      },
+      cwd(dir: string) {
+        options.cwd = dir;
+        return builder;
+      },
+      env(envVars: Record<string, string>) {
+        options.env = envVars;
+        return builder;
+      },
+      async noThrow() {
+        const result = await handler({ parts, values, options });
+        return {
+          code: result.code,
+          stdout: result.stdout ?? "",
+          stderr: result.stderr ?? "",
+        };
+      },
+    };
+    return builder as unknown as ReturnType<DaxTemplateTag>;
+  }) as DaxTemplateTag;
+}

--- a/psh/util.ts
+++ b/psh/util.ts
@@ -4,9 +4,26 @@
 // @ts-ignore runtime import via jsr
 import $ from "@david/dax";
 
+/**
+ * The Dax template tag type used throughout psh for shell commands.
+ *
+ * @example
+ * ```ts
+ * import { type DaxTemplateTag, $ } from "./util.ts";
+ * const run: DaxTemplateTag = $;
+ * await run`echo hello`;
+ * ```
+ */
+export type DaxTemplateTag = typeof $;
+
+/**
+ * Command builder type returned by the Dax template tag.
+ */
+export type DaxCommandBuilder = ReturnType<typeof $>;
+
 export function repoPath(relative: string): string {
-    // Resolve a path relative to this file (psh/...). Example: '../tools/install_ros2.sh'
-    return decodeURIComponent(new URL(relative, import.meta.url).pathname);
+  // Resolve a path relative to this file (psh/...). Example: '../tools/install_ros2.sh'
+  return decodeURIComponent(new URL(relative, import.meta.url).pathname);
 }
 
 export { $ };


### PR DESCRIPTION
## Summary
- replace direct `Deno.Command` usage in the colcon helpers, module action runner, and module launcher with injectable Dax runners
- add reusable Dax stubs plus unit tests that exercise the colcon helpers and module launcher wiring
- document the environment flags required to execute Deno-based tests locally

## Testing
- DENO_TLS_CA_STORE=system /root/.deno/bin/deno test --config psh/deno.json --allow-read --allow-write --allow-env psh

------
https://chatgpt.com/codex/tasks/task_e_68d55ee551dc8320a1cbc6397c4adba9