### PR TITLE
Fix module action path resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ workspace.
 - Deno-based tests require local CA trust; run them with
   `DENO_TLS_CA_STORE=system` and grant the needed permissions (e.g.
   `--allow-read --allow-write --allow-env`).
+- The container image may not ship with the Deno CLI. Install it locally before
+  running `deno test` or other workspace scripts that depend on it.
 
 Important workflow note:
 

--- a/psh/modules.ts
+++ b/psh/modules.ts
@@ -13,114 +13,113 @@ let commandRunner: DaxTemplateTag = $;
  */
 export function setModuleCommandRunner(runner: DaxTemplateTag): void {
   commandRunner = runner;
+}
 
-  /** Reset the command runner back to the default Dax tag. */
-  function resetModuleCommandRunner(): void {
-    commandRunner = $;
-  }
+/** Reset the command runner back to the default Dax tag. */
+export function resetModuleCommandRunner(): void {
+  commandRunner = $;
+}
 
-  interface ModuleActionBase {
-    type: string;
-    description?: string;
-    cwd?: string;
-    optional?: boolean;
-  }
+interface ModuleActionBase {
+  type: string;
+  description?: string;
+  cwd?: string;
+  optional?: boolean;
+}
 
-  interface LinkPackagesAction extends ModuleActionBase {
-    type: "link_packages";
-    packages: string[];
-    base?: string;
-    destination?: string;
-  }
+interface LinkPackagesAction extends ModuleActionBase {
+  type: "link_packages";
+  packages: string[];
+  base?: string;
+  destination?: string;
+}
 
-  interface GitCloneAction extends ModuleActionBase {
-    type: "git_clone";
-    repo: string;
-    dest: string;
-    branch?: string;
-    tag?: string;
-    depth?: number;
-    base?: string;
-    sparse?: boolean;
-  }
+interface GitCloneAction extends ModuleActionBase {
+  type: "git_clone";
+  repo: string;
+  dest: string;
+  branch?: string;
+  tag?: string;
+  depth?: number;
+  base?: string;
+  sparse?: boolean;
+}
 
-  interface AptInstallAction extends ModuleActionBase {
-    type: "apt_install";
-    packages: string[];
-    update?: boolean;
-  }
+interface AptInstallAction extends ModuleActionBase {
+  type: "apt_install";
+  packages: string[];
+  update?: boolean;
+}
 
-  interface PipInstallAction extends ModuleActionBase {
-    type: "pip_install";
-    packages: string[];
-    import_check?: string[];
-    python?: string;
-    break_system?: boolean;
-    user?: boolean;
-  }
+interface PipInstallAction extends ModuleActionBase {
+  type: "pip_install";
+  packages: string[];
+  import_check?: string[];
+  python?: string;
+  break_system?: boolean;
+  user?: boolean;
+}
 
-  interface RosRunAction extends ModuleActionBase {
-    type: "ros_run";
-    package: string;
-    executable: string;
-    args?: string[];
-  }
+interface RosRunAction extends ModuleActionBase {
+  type: "ros_run";
+  package: string;
+  executable: string;
+  args?: string[];
+}
 
-  interface RunAction extends ModuleActionBase {
-    type: "run";
-    command?: string;
-    script?: string;
-    shell?: string;
-    env?: Record<string, string>;
-  }
+interface RunAction extends ModuleActionBase {
+  type: "run";
+  command?: string;
+  script?: string;
+  shell?: string;
+  env?: Record<string, string>;
+}
 
-  type ModuleAction =
-    | LinkPackagesAction
-    | GitCloneAction
-    | AptInstallAction
-    | PipInstallAction
-    | RosRunAction
-    | RunAction;
+type ModuleAction =
+  | LinkPackagesAction
+  | GitCloneAction
+  | AptInstallAction
+  | PipInstallAction
+  | RosRunAction
+  | RunAction;
 
-  interface ModuleSystemdSpec {
-    description?: string;
-    launch?: string;
-    shutdown?: string;
-    launch_command?: string;
-    shutdown_command?: string;
-    environment?: Record<string, string>;
-    after?: string[];
-    wants?: string[];
-    restart?: string;
-    restart_sec?: number;
-    user?: string;
-    working_directory?: string;
-    kill_mode?: string;
-    timeout_stop_sec?: number;
-  }
+interface ModuleSystemdSpec {
+  description?: string;
+  launch?: string;
+  shutdown?: string;
+  launch_command?: string;
+  shutdown_command?: string;
+  environment?: Record<string, string>;
+  after?: string[];
+  wants?: string[];
+  restart?: string;
+  restart_sec?: number;
+  user?: string;
+  working_directory?: string;
+  kill_mode?: string;
+  timeout_stop_sec?: number;
+}
 
-  interface ModuleSpec {
-    name?: string;
-    description?: string;
-    actions?: ModuleAction[];
-    systemd?: ModuleSystemdSpec;
-  }
+interface ModuleSpec {
+  name?: string;
+  description?: string;
+  actions?: ModuleAction[];
+  systemd?: ModuleSystemdSpec;
+}
 
-  interface ModuleContext {
-    module: string;
-    repoDir: string;
-    moduleDir: string;
-    srcDir: string;
-    moduleConfig: Record<string, unknown> | null;
-    moduleConfigPath: string | null;
-  }
+interface ModuleContext {
+  module: string;
+  repoDir: string;
+  moduleDir: string;
+  srcDir: string;
+  moduleConfig: Record<string, unknown> | null;
+  moduleConfigPath: string | null;
+}
 
-  function resolvePath(base: string, rel?: string | null): string {
-    if (!rel) return base;
-    if (rel.startsWith("/")) return rel;
-    return join(base, rel);
-  }
-
+function resolvePath(base: string, rel?: string | null): string {
+  if (!rel) return base;
+  if (rel.startsWith("/")) return rel;
+  return join(base, rel);
 }
 
 async function runCommand(command: string, options: {

--- a/psh/modules_test.ts
+++ b/psh/modules_test.ts
@@ -1,0 +1,53 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { dirname, join } from "@std/path";
+import {
+  applyModuleActions,
+  resetModuleCommandRunner,
+  setModuleCommandRunner,
+} from "./modules.ts";
+import { createDaxStub } from "./test_utils.ts";
+
+function buildTempContext(moduleName: string) {
+  const repoDir = Deno.makeTempDirSync({ prefix: "psh_modules_test_repo_" });
+  const moduleDir = join(repoDir, "modules", moduleName);
+  const srcDir = join(repoDir, "src");
+  Deno.mkdirSync(moduleDir, { recursive: true });
+  Deno.mkdirSync(srcDir, { recursive: true });
+  return {
+    module: moduleName,
+    repoDir,
+    moduleDir,
+    srcDir,
+    moduleConfig: null,
+    moduleConfigPath: null,
+  };
+}
+
+Deno.test("run action resolves relative script path from module directory", async () => {
+  const ctx = buildTempContext("sample");
+  const scriptPath = join(ctx.moduleDir, "scripts", "demo.sh");
+  Deno.mkdirSync(dirname(scriptPath), { recursive: true });
+  Deno.writeTextFileSync(scriptPath, "#!/bin/bash\necho demo\n");
+  Deno.chmodSync(scriptPath, 0o755);
+
+  const executedCommands: string[] = [];
+  const stub = createDaxStub(({ values }) => {
+    executedCommands.push(String(values[1]));
+    return { code: 0 };
+  });
+  setModuleCommandRunner(stub);
+  try {
+    await applyModuleActions([
+      {
+        type: "run",
+        script: "scripts/demo.sh",
+      },
+    ], ctx);
+  } finally {
+    resetModuleCommandRunner();
+    await Deno.remove(ctx.repoDir, { recursive: true });
+  }
+
+  assertEquals(executedCommands.length, 1);
+  assertStringIncludes(executedCommands[0], scriptPath);
+});


### PR DESCRIPTION
## Summary
- expose the module command runner reset helper and shared path resolver outside of the setter
- ensure module actions can resolve relative paths via a regression test
- note that the container image may not include a Deno CLI in the contributor guide

## Testing
- deno test -A psh/modules_test.ts *(fails: `deno` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e0ef9d448320b04d364a19df19d7