### PR TITLE
Fix psh setup ROS environment and module dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,9 @@ or conflicting package sources.
   cross-check for outdated references between them and fix any inconsistencies.
 - Record newly discovered gotchas or workflow aids here using concise bullet
   points.
+- `tools/with_ros_env.sh` sources the workspace environment before executing a
+  command. Use it (or mirror its behaviour) when scripting `colcon` or `ros2`
+  invocations so ROS 2 dependencies from apt are discoverable.
 - Keep the guide succinct and focused on actionable advice.
 - `pytest` is configured to ignore the `src/` symlink; place new tests under
   `packages/<pkg>/tests` and stub ROS interfaces when running in environments

--- a/modules/chat/module.toml
+++ b/modules/chat/module.toml
@@ -22,7 +22,12 @@ qos = { history = "keep_last", depth = 10, reliability = "reliable", durability 
 
 [[actions]]
 type = "link_packages"
-packages = ["chat", "psyched_msgs", "voice"]
+packages = ["chat", "psyched_msgs"]
+
+[[actions]]
+type = "link_packages"
+base = "../voice/packages"
+packages = ["voice"]
 
 [[actions]]
 type = "pip_install"

--- a/modules/pilot/module.toml
+++ b/modules/pilot/module.toml
@@ -29,15 +29,19 @@ type = "link_packages"
 packages = ["pilot"]
 
 [[actions]]
+type = "run"
+description = "Install ROS Python shims via apt"
+script = "scripts/install_ros_python_deps.sh"
+
+[[actions]]
 type = "pip_install"
 packages = [
     "fastapi",
     "uvicorn[standard]",
     "pydantic",
     "psutil",
-    "rosidl_runtime_py",
 ]
-import_check = ["fastapi", "rosidl_runtime_py"]
+import_check = ["fastapi"]
 break_system = true
 
 [[actions]]

--- a/modules/pilot/scripts/install_ros_python_deps.sh
+++ b/modules/pilot/scripts/install_ros_python_deps.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Ensure ROS Python shims like rosidl_runtime_py are installed via apt so they
+# remain in sync with the system ROS distribution. PIP does not publish these
+# packages which caused previous setup attempts to fail.
+
+set -euo pipefail
+
+detect_ros_distro() {
+  if [[ -n "${ROS_DISTRO:-}" ]]; then
+    echo "${ROS_DISTRO}"
+    return 0
+  fi
+  if [[ -d /opt/ros ]]; then
+    for entry in /opt/ros/*; do
+      [[ -d "${entry}" ]] || continue
+      local setup="${entry}/setup.bash"
+      if [[ -f "${setup}" ]]; then
+        echo "$(basename "${entry}")"
+        return 0
+      fi
+    done
+  fi
+  echo "kilted"
+  return 0
+}
+
+ROS_DISTRO_DETECTED="$(detect_ros_distro)"
+PACKAGE="ros-${ROS_DISTRO_DETECTED}-rosidl-runtime-py"
+
+echo "[pilot] Ensuring ${PACKAGE} is installed via apt"
+
+if dpkg -s "${PACKAGE}" >/dev/null 2>&1; then
+  echo "[pilot] ${PACKAGE} already present"
+  exit 0
+fi
+
+if command -v sudo >/dev/null 2>&1 && [[ $(id -u) -ne 0 ]]; then
+  SUDO=(sudo)
+else
+  SUDO=()
+fi
+
+"${SUDO[@]}" apt-get update
+"${SUDO[@]}" apt-get install -y "${PACKAGE}"

--- a/modules/voice/module.toml
+++ b/modules/voice/module.toml
@@ -22,7 +22,12 @@ qos = { history = "keep_last", depth = 1, reliability = "reliable", durability =
 
 [[actions]]
 type = "link_packages"
-packages = ["voice", "psyched_msgs"]
+packages = ["voice"]
+
+[[actions]]
+type = "link_packages"
+base = "../chat/packages"
+packages = ["psyched_msgs"]
 
 [[actions]]
 type = "apt_install"

--- a/psh/colcon.ts
+++ b/psh/colcon.ts
@@ -1,5 +1,7 @@
 import { $, type DaxTemplateTag, repoPath } from "./util.ts";
 
+const withRosEnv = repoPath("../tools/with_ros_env.sh");
+
 async function runColcon(
   runner: DaxTemplateTag,
   subcommand: string,
@@ -8,7 +10,8 @@ async function runColcon(
   errorLabel: string,
 ): Promise<void> {
   const absSrc = repoPath("../src");
-  const builder = runner`colcon ${[
+  const builder = runner`${withRosEnv} ${[
+    "colcon",
     subcommand,
     ...args,
     "--base-paths",

--- a/psh/colcon_test.ts
+++ b/psh/colcon_test.ts
@@ -1,11 +1,14 @@
 import { assertEquals } from "@std/assert";
 import { colconBuild, colconInstall } from "./colcon.ts";
 import { createDaxStub, type StubInvocation } from "./test_utils.ts";
+import { repoPath } from "./util.ts";
+
+const withRosEnv = repoPath("../tools/with_ros_env.sh");
 
 function assertColconInvocation(invocation: StubInvocation) {
-  assertEquals(invocation.parts[0], "colcon ");
-  assertEquals(invocation.parts[1], "");
-  assertEquals(invocation.values.length, 1);
+  assertEquals(invocation.values[0], withRosEnv);
+  assertEquals(invocation.parts.length, 3);
+  assertEquals(invocation.values.length, 2);
   assertEquals(invocation.options.stdout, "inherit");
   assertEquals(invocation.options.stderr, "inherit");
 }
@@ -31,11 +34,11 @@ Deno.test("colcon build shells out via dax", async () => {
     captured,
     "Expected colcon build to invoke dax",
   );
-  const args = invocation.values[0] as string[];
+  const args = invocation.values[1] as string[];
   assertEquals(Array.isArray(args), true);
-  assertEquals(args.slice(0, 2), ["build", "--symlink-install"]);
-  assertEquals(args[2], "--base-paths");
-  assertEquals(typeof args[3], "string");
+  assertEquals(args.slice(0, 3), ["colcon", "build", "--symlink-install"]);
+  assertEquals(args[3], "--base-paths");
+  assertEquals(typeof args[4], "string");
   assertColconInvocation(invocation);
 });
 
@@ -50,10 +53,10 @@ Deno.test("colcon install shells out via dax", async () => {
     captured,
     "Expected colcon install to invoke dax",
   );
-  const args = invocation.values[0] as string[];
+  const args = invocation.values[1] as string[];
   assertEquals(Array.isArray(args), true);
-  assertEquals(args.slice(0, 1), ["install"]);
-  assertEquals(args[1], "--base-paths");
-  assertEquals(typeof args[2], "string");
+  assertEquals(args.slice(0, 2), ["colcon", "install"]);
+  assertEquals(args[2], "--base-paths");
+  assertEquals(typeof args[3], "string");
   assertColconInvocation(invocation);
 });

--- a/tools/with_ros_env.sh
+++ b/tools/with_ros_env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Shell helper: source the Psyched workspace environment before executing a
+# command. This ensures ROS 2 packages installed via apt are discoverable by
+# downstream build steps (e.g., colcon) without requiring users to manually
+# source setup scripts in every invocation.
+#
+# Usage:
+#   tools/with_ros_env.sh colcon build --symlink-install --base-paths src
+#   tools/with_ros_env.sh ros2 topic list
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the workspace environment so AMENT_PREFIX_PATH, PYTHONPATH, etc. are
+# populated. Default to `source` mode even if the caller overrides
+# SETUP_ENV_MODE.
+SETUP_ENV_MODE=source \
+  # shellcheck disable=SC1090
+  source "${SCRIPT_DIR}/setup_env.sh"
+
+# Hand off to the requested command with the prepared environment. Use exec so
+# signal handling behaves as expected (colcon receives SIGINT, etc.).
+exec "$@"


### PR DESCRIPTION
## Summary
- wrap colcon invocations in a workspace environment helper so ROS 2 packages are discoverable during `psh setup`
- provision `rosidl_runtime_py` via apt for the pilot module and keep chat/voice package links consistent
- document the new helper and add an apt-backed installer script for ROS Python shims

## Testing
- `deno test -A psh/colcon_test.ts` *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f2bd258c8320b7976b25ee010bac