### PR TITLE
Fix pilot command ordering for psh integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ workspace.
   `--allow-read --allow-write --allow-env`).
 - The container image may not ship with the Deno CLI. Install it locally before
   running `deno test` or other workspace scripts that depend on it.
+- Pilot backend tests rely on pip packages (`fastapi`, `httpx`, `uvicorn`).
+  Install them in the environment before running the pilot test suite locally.
 
 Important workflow note:
 

--- a/modules/pilot/packages/pilot/pilot/app.py
+++ b/modules/pilot/packages/pilot/pilot/app.py
@@ -53,7 +53,40 @@ class CommandExecutor:
         if not psh_path.exists():  # pragma: no cover - should exist in deployed repo
             raise RuntimeError("psh toolchain not available")
         deno = "deno"
-        command_args = ["run", "-A", str(psh_path), scope, module, command, *args]
+        scope_normalized = scope.lower()
+        # Align invocation order with the CLI semantics implemented in psh/cli.ts.
+        # - `psh mod` expects `psh mod <action> <modules...>`
+        # - `psh sys` expects `psh sys <action> <units...>`
+        if scope_normalized == "mod":
+            command_args = [
+                "run",
+                "-A",
+                str(psh_path),
+                "mod",
+                command,
+                *( [module] if module else [] ),
+                *args,
+            ]
+        elif scope_normalized == "sys":
+            command_args = [
+                "run",
+                "-A",
+                str(psh_path),
+                "sys",
+                command,
+                *( [module] if module else [] ),
+                *args,
+            ]
+        else:
+            command_args = [
+                "run",
+                "-A",
+                str(psh_path),
+                scope,
+                *( [module] if module else [] ),
+                command,
+                *args,
+            ]
         process = await asyncio.create_subprocess_exec(
             deno,
             *command_args,

--- a/modules/pilot/packages/pilot/tests/test_command_executor.py
+++ b/modules/pilot/packages/pilot/tests/test_command_executor.py
@@ -1,0 +1,93 @@
+"""Tests for the command execution helper used by the pilot service."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+from pilot.app import CommandExecutor
+
+
+class StubProcess:
+    """Asyncio subprocess stub that records invocation details."""
+
+    def __init__(self, argv: Tuple[str, ...]) -> None:
+        self.argv = argv
+        self.kwargs: Dict[str, Any] = {}
+        self.returncode = 0
+
+    async def communicate(self) -> Tuple[bytes, bytes]:
+        return b"", b""
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Create a minimal repository layout for the executor."""
+
+    repo = tmp_path / "repo"
+    psh_dir = repo / "psh"
+    psh_dir.mkdir(parents=True)
+    (psh_dir / "main.ts").write_text("// deno entrypoint")
+    return repo
+
+
+def test_mod_commands_pass_action_before_module(monkeypatch, repo_root: Path) -> None:
+    """`psh mod` expects the action first; ensure we respect that ordering."""
+
+    captured: Dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **kwargs: Any) -> StubProcess:
+        proc = StubProcess(tuple(args))
+        proc.kwargs = kwargs
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    executor = CommandExecutor(repo_root)
+    result = asyncio.run(executor.run("mod", "ear", "setup", ["--flag"]))
+
+    assert result["code"] == 0
+    assert captured["args"] == (
+        "deno",
+        "run",
+        "-A",
+        str(repo_root / "psh" / "main.ts"),
+        "mod",
+        "setup",
+        "ear",
+        "--flag",
+    )
+
+
+def test_system_commands_follow_cli_shape(monkeypatch, repo_root: Path) -> None:
+    """System commands should match `psh sys <action> <unit>` semantics."""
+
+    captured: Dict[str, Any] = {}
+
+    async def fake_exec(*args: str, **kwargs: Any) -> StubProcess:
+        proc = StubProcess(tuple(args))
+        proc.kwargs = kwargs
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    executor = CommandExecutor(repo_root)
+    result = asyncio.run(executor.run("sys", "pilot", "restart", []))
+
+    assert result["code"] == 0
+    assert captured["args"] == (
+        "deno",
+        "run",
+        "-A",
+        str(repo_root / "psh" / "main.ts"),
+        "sys",
+        "restart",
+        "pilot",
+    )


### PR DESCRIPTION
## Summary
- align the pilot CommandExecutor with the psh CLI so mod/sys invocations pass the action before the module
- add regression tests that capture the expected deno argv for module and system commands
- note the FastAPI/httpx/uvicorn requirements in AGENTS.md for running pilot tests

## Testing
- pytest modules/pilot/packages/pilot/tests

------
https://chatgpt.com/codex/tasks/task_e_68d73c145aac83208533bbd1be530afe