### PR TITLE
Ensure setup script enables mDNS support

### DIFF
--- a/setup
+++ b/setup
@@ -5,6 +5,80 @@ sudo apt update && sudo apt upgrade -y
 
 sudo apt install -y curl shellcheck micro mc git build-essential make python3-full python3-pip python3-venv python-is-python3
 
+# Install the packages that provide mDNS (Avahi) discovery support. This ensures
+# avahi-daemon, supporting utilities, and the libc name service switch module
+# for mDNS resolution are present before we manipulate the service state.
+sudo apt install -y avahi-daemon avahi-utils libnss-mdns
+
+# Ensure the libc resolver is configured to consult mDNS. We keep this logic in
+# a helper so the behaviour is idempotent and easy to follow.
+ensure_mdns_hosts_entry() {
+    local NSSWITCH="/etc/nsswitch.conf"
+    if [ ! -f "${NSSWITCH}" ]; then
+        echo "Warning: ${NSSWITCH} not found; skipping mDNS resolver configuration" >&2
+        return 0
+    fi
+    if grep -E '^[[:space:]]*hosts:.*mdns' "${NSSWITCH}" >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "Adding mDNS resolution to ${NSSWITCH}..." >&2
+    sudo python3 - "$NSSWITCH" <<'PY'
+import shutil
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+backup = path.with_name(path.name + ".bak")
+if not backup.exists():
+    shutil.copy2(path, backup)
+
+lines = path.read_text().splitlines()
+preferred = ["files", "mdns4_minimal", "[NOTFOUND=return]", "dns", "mdns"]
+
+for idx, line in enumerate(lines):
+    if not line.startswith("hosts:"):
+        continue
+    prefix, sep, remainder = line.partition(":")
+    tokens = remainder.split()
+    for token in preferred:
+        if token not in tokens:
+            if token == "dns" and "mdns" in tokens:
+                tokens.insert(tokens.index("mdns"), token)
+            else:
+                tokens.append(token)
+    lines[idx] = f"{prefix}{sep}\t{' '.join(tokens)}"
+    break
+else:
+    lines.append("hosts:\t" + " ".join(preferred))
+
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+ensure_mdns_service() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        echo "systemctl not available; skipping Avahi enablement." >&2
+        return 0
+    fi
+    if ! systemctl list-unit-files | grep -q '^avahi-daemon\.service'; then
+        echo "avahi-daemon.service not present; skipping enablement." >&2
+        return 0
+    fi
+    echo "Ensuring avahi-daemon.service is enabled and running..." >&2
+    sudo systemctl unmask avahi-daemon.service >/dev/null 2>&1 || true
+    if ! sudo systemctl enable avahi-daemon.service >/dev/null 2>&1; then
+        echo "Warning: Failed to enable avahi-daemon.service; continuing" >&2
+    fi
+    if ! sudo systemctl restart avahi-daemon.service >/dev/null 2>&1; then
+        if ! sudo systemctl start avahi-daemon.service >/dev/null 2>&1; then
+            echo "Warning: Failed to start avahi-daemon.service; check logs." >&2
+        fi
+    fi
+}
+
+ensure_mdns_hosts_entry
+ensure_mdns_service
+
 # Try to install unzip; tolerate failure but send stdout to stderr so messages
 # appear on the standard error stream like the original intent. Use an if
 # wrapper so a failure doesn't cause the script to exit under `set -e`.


### PR DESCRIPTION
## Summary
- install the Avahi packages and nsswitch configuration needed for reliable mDNS resolution during setup
- ensure avahi-daemon is unmasked, enabled, and started so mDNS advertising is always available

## Testing
- shellcheck setup

------
https://chatgpt.com/codex/tasks/task_e_68d80be4a2688320ac6b4b30898f2a8e