### PR TITLE
Align pilot control styling and expand joystick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,9 @@ or conflicting package sources.
 - Frontend assets now reside directly under `pilot/static`; update
   `modules/pilot/packages/pilot/tests/test_frontend_static.py` when reorganising
   those files so layout checks stay accurate.
+- Pilot frontend buttons now share the `.control-button` variants; reuse that
+  class when introducing new controls and extend the frontend static test if
+  you add new variants.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/modules/pilot/packages/pilot/pilot/static/assets.css
+++ b/modules/pilot/packages/pilot/pilot/static/assets.css
@@ -160,27 +160,64 @@ body {
   color: var(--lcars-accent-secondary);
 }
 
+.control-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid rgba(88, 178, 220, 0.55);
+  background: linear-gradient(180deg, rgba(88, 178, 220, 0.45), rgba(17, 24, 36, 0.9));
+  color: var(--lcars-text);
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  text-decoration: none;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  transition: background 0.2s ease, transform 0.12s ease, box-shadow 0.2s ease;
+}
+
+.control-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.control-button:focus-visible {
+  outline: 2px solid rgba(248, 128, 60, 0.75);
+  outline-offset: 2px;
+}
+
+.control-button:disabled,
+.control-button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.control-button[data-variant="accent"] {
+  background: linear-gradient(180deg, rgba(88, 178, 220, 0.8), rgba(40, 94, 130, 0.95));
+  border-color: rgba(88, 178, 220, 0.75);
+}
+
+.control-button[data-variant="ghost"] {
+  background: linear-gradient(180deg, rgba(88, 178, 220, 0.18), rgba(17, 24, 36, 0.85));
+  border-color: rgba(88, 178, 220, 0.45);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.control-button[data-variant="critical"] {
+  background: linear-gradient(180deg, rgba(248, 128, 60, 0.75), rgba(140, 54, 20, 0.95));
+  border-color: rgba(248, 128, 60, 0.8);
+}
+
 .button-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.button-row button {
-  background: rgba(88, 178, 220, 0.18);
-  border: 1px solid rgba(88, 178, 220, 0.4);
-  color: var(--lcars-text);
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.05rem;
-  transition: background 0.2s ease, transform 0.1s ease;
-}
-
-.button-row button:hover {
-  background: rgba(88, 178, 220, 0.35);
-  transform: translateY(-1px);
+  gap: 0.75rem;
 }
 
 .topics-grid {
@@ -222,22 +259,8 @@ body {
 
 .topic-actions {
   display: flex;
-  gap: 0.5rem;
-}
-
-.topic-actions button {
-  border: none;
-  background: rgba(248, 128, 60, 0.2);
-  color: var(--lcars-text);
-  padding: 0.4rem 0.75rem;
-  border-radius: 0.75rem;
-  cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.04rem;
-}
-
-.topic-actions button:hover {
-  background: rgba(248, 128, 60, 0.35);
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .topic-widget {
@@ -279,22 +302,6 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
-}
-
-.voice-actions button {
-  background: rgba(248, 128, 60, 0.2);
-  border: 1px solid rgba(248, 128, 60, 0.5);
-  color: var(--lcars-text);
-  padding: 0.45rem 1.25rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.08rem;
-  cursor: pointer;
-}
-
-.voice-actions button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .voice-last,
@@ -448,22 +455,6 @@ body {
   font-size: 0.85rem;
 }
 
-.conversation-controls button {
-  background: rgba(248, 128, 60, 0.2);
-  border: 1px solid rgba(248, 128, 60, 0.5);
-  color: var(--lcars-text);
-  padding: 0.45rem 1.25rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.08rem;
-  cursor: pointer;
-}
-
-.conversation-controls button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .topic-state {
   display: flex;
   align-items: center;
@@ -593,25 +584,28 @@ body {
 .joystick {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
   align-items: center;
+  user-select: none;
 }
 
 .joystick-grid {
   position: relative;
-  width: 160px;
-  height: 160px;
+  width: 200px;
+  height: 200px;
   border-radius: 50%;
   background: radial-gradient(circle at 50% 50%, rgba(88, 178, 220, 0.35), rgba(27, 31, 42, 0.9));
   box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.4);
+  touch-action: none;
+  overscroll-behavior: contain;
 }
 
 .joystick-knob {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 60px;
-  height: 60px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   background: radial-gradient(circle at 30% 30%, rgba(248, 128, 60, 0.8), rgba(248, 128, 60, 0.4));
   transform: translate(-50%, -50%);
@@ -620,8 +614,8 @@ body {
 
 .joystick-readout {
   display: flex;
-  gap: 1rem;
-  font-size: 0.85rem;
+  gap: 1.25rem;
+  font-size: 0.9rem;
   color: var(--lcars-muted);
 }
 
@@ -823,21 +817,6 @@ body {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-}
-
-.voice-transport button {
-  background: rgba(88, 178, 220, 0.2);
-  border: 1px solid rgba(88, 178, 220, 0.35);
-  color: var(--lcars-text);
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.08rem;
-}
-
-.voice-transport button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
 }
 
 .voice-volume-inline,

--- a/modules/pilot/packages/pilot/pilot/static/components/conversation-console.js
+++ b/modules/pilot/packages/pilot/pilot/static/components/conversation-console.js
@@ -136,7 +136,14 @@ class PilotConversationConsole extends LitElement {
               ?disabled=${disabled}
               @input=${(event) => this.handleSpeaker(event)}
             />
-            <button type="submit" ?disabled=${disabled || !this._input.trim()}>Send</button>
+            <button
+              type="submit"
+              class="control-button"
+              data-variant="accent"
+              ?disabled=${disabled || !this._input.trim()}
+            >
+              Send
+            </button>
           </div>
         </form>
       </div>

--- a/modules/pilot/packages/pilot/pilot/static/components/module-section.js
+++ b/modules/pilot/packages/pilot/pilot/static/components/module-section.js
@@ -108,7 +108,14 @@ class PilotModuleSection extends LitElement {
       <div class="button-row">
         ${commands.map(
       (name) => html`
-            <button type="button" @click=${() => this.command(scope, name)}>${name}</button>
+            <button
+              type="button"
+              class="control-button"
+              data-variant="ghost"
+              @click=${() => this.command(scope, name)}
+            >
+              ${name}
+            </button>
           `,
     )}
       </div>
@@ -128,12 +135,31 @@ class PilotModuleSection extends LitElement {
           <div class="topic-actions">
             ${record
         ? html`
-                  <button type="button" @click=${() => this.stopTopic(topic)}>Disconnect</button>
-                  <button type="button" @click=${() => this.togglePause(topic, !record.paused)}>
+                  <button
+                    type="button"
+                    class="control-button"
+                    data-variant="critical"
+                    @click=${() => this.stopTopic(topic)}
+                  >
+                    Disconnect
+                  </button>
+                  <button
+                    type="button"
+                    class="control-button"
+                    data-variant=${record.paused ? 'accent' : 'ghost'}
+                    @click=${() => this.togglePause(topic, !record.paused)}
+                  >
                     ${record.paused ? 'Resume' : 'Pause'}
                   </button>
                 `
-        : html`<button type="button" @click=${() => this.startTopic(topic)}>Connect</button>`}
+        : html`<button
+                type="button"
+                class="control-button"
+                data-variant="accent"
+                @click=${() => this.startTopic(topic)}
+              >
+                Connect
+              </button>`}
           </div>
         </div>
         <pilot-topic-widget .record=${record} .topic=${topic}></pilot-topic-widget>

--- a/modules/pilot/packages/pilot/pilot/static/components/voice-console.js
+++ b/modules/pilot/packages/pilot/pilot/static/components/voice-console.js
@@ -107,15 +107,23 @@ class PilotVoiceConsole extends LitElement {
   renderTransportControls() {
     const actions = this._controls;
     const buttons = [
-      { action: 'interrupt', label: 'Pause' },
-      { action: 'resume', label: 'Resume' },
-      { action: 'clear', label: 'Clear' },
+      { action: 'interrupt', label: 'Pause', variant: 'ghost' },
+      { action: 'resume', label: 'Resume', variant: 'accent' },
+      { action: 'clear', label: 'Clear', variant: 'critical' },
     ];
     return html`
       <div class="voice-transport">
-        ${buttons.map(({ action, label }) => {
+        ${buttons.map(({ action, label, variant }) => {
           const available = actions?.[action]?.available;
-          return html`<button type="button" ?disabled=${!available} @click=${() => this.handleTransport(action)}>${label}</button>`;
+          return html`<button
+            type="button"
+            class="control-button"
+            data-variant=${variant}
+            ?disabled=${!available}
+            @click=${() => this.handleTransport(action)}
+          >
+            ${label}
+          </button>`;
         })}
       </div>
     `;
@@ -154,7 +162,14 @@ class PilotVoiceConsole extends LitElement {
           @keydown=${(event) => this.handleKeyDown(event)}
         ></textarea>
         <div class="voice-actions">
-          <button type="submit" ?disabled=${disabled || !this._input.trim()}>Send</button>
+          <button
+            type="submit"
+            class="control-button"
+            data-variant="accent"
+            ?disabled=${disabled || !this._input.trim()}
+          >
+            Send
+          </button>
           ${this._lastSent
             ? html`<span class="voice-last">Last sent: ${this._lastSent}</span>`
             : html`<span class="voice-hint">Connected clients will synthesize the text.</span>`}

--- a/modules/pilot/packages/pilot/tests/test_frontend_static.py
+++ b/modules/pilot/packages/pilot/tests/test_frontend_static.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 STATIC_ROOT = PACKAGE_ROOT / "pilot" / "static"
+
+
+def _read_assets() -> str:
+    return (STATIC_ROOT / "assets.css").read_text(encoding="utf-8")
+
+
+def _css_block(css: str, selector: str) -> str:
+    pattern = rf"{re.escape(selector)}\s*\{{(.*?)\}}"
+    match = re.search(pattern, css, re.DOTALL)
+    assert match, f"missing CSS rules for {selector}"
+    return match.group(1)
 
 
 def test_frontend_uses_modular_entrypoint() -> None:
@@ -36,3 +48,23 @@ def test_legacy_svelte_sources_are_removed() -> None:
     assert not (
         PACKAGE_ROOT / "frontend"
     ).exists(), "legacy Svelte sources should be removed after migration"
+
+
+def test_control_buttons_share_a_unified_style() -> None:
+    """All pilot controls should draw from the shared control button styling."""
+    css = _read_assets()
+    button_block = _css_block(css, ".control-button")
+    assert "border-radius" in button_block
+    assert "text-transform" in button_block
+    assert "box-shadow" in button_block
+
+    for variant in ["accent", "ghost", "critical"]:
+        variant_selector = f'.control-button[data-variant="{variant}"]'
+        _css_block(css, variant_selector)
+
+
+def test_joystick_grid_prevents_touch_scrolling() -> None:
+    """The joystick grid should opt-out of browser scrolling gestures."""
+    css = _read_assets()
+    grid_block = _css_block(css, ".joystick-grid")
+    assert "touch-action: none" in grid_block


### PR DESCRIPTION
## Summary
- add a shared `.control-button` style with accent/ghost/critical variants and apply it to module, conversation, and voice controls
- enlarge the joystick control surface and block touch scrolling on the grid to reduce accidental page movement
- document the control button convention and extend the frontend static test suite for the new styles

## Testing
- pytest modules/pilot/packages/pilot/tests/test_frontend_static.py


------
https://chatgpt.com/codex/tasks/task_e_68d897cd341c8320a2b68e5ce11ad885