### PR TITLE
Add dockerized speech stack with remote fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,9 @@ or conflicting package sources.
 - Pilot frontend buttons now share the `.control-button` variants; reuse that
   class when introducing new controls and extend the frontend static test if
   you add new variants.
+- The speech stack Docker compose file lives in `compose/speech-stack.compose.yml`;
+  keep service ports and default endpoints in sync with module parameters when
+  adjusting remote ASR/TTS/LLM services.
 
 Thanks for keeping Psyched healthy! Update this guide whenever you learn
 something the next agent should know.

--- a/compose/speech-stack.compose.yml
+++ b/compose/speech-stack.compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  asr:
+    build:
+      context: ..
+      dockerfile: docker/asr-fast.Dockerfile
+    image: psyched-asr-fast:local
+    restart: unless-stopped
+    ports:
+      - "8082:8082"
+
+  tts:
+    build:
+      context: ..
+      dockerfile: docker/tts-websocket.Dockerfile
+    image: psyched-tts-websocket:local
+    restart: unless-stopped
+    environment:
+      TTS_MODEL: "tts_models/en/vctk/vits"
+    ports:
+      - "5002:5002"
+
+  llm:
+    build:
+      context: ..
+      dockerfile: docker/forebrain-llm.Dockerfile
+    image: psyched-forebrain-llm:local
+    restart: unless-stopped
+    environment:
+      FOREBRAIN_LLM__MODEL__PATH: "/data/model.gguf"
+      FOREBRAIN_LLM__WEBSOCKET__BIND_ADDR: "0.0.0.0:8080"
+    volumes:
+      - type: bind
+        source: ../forebrain-llm/models
+        target: /data
+        read_only: false
+    ports:
+      - "8080:8080"

--- a/docker/asr-fast.Dockerfile
+++ b/docker/asr-fast.Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:1.76 AS builder
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY asr-core/Cargo.toml asr-core/Cargo.toml
+COPY asr-fast/Cargo.toml asr-fast/Cargo.toml
+RUN cargo fetch --locked
+
+COPY asr-core asr-core
+COPY asr-fast asr-fast
+RUN cargo build --release -p asr-fast
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/asr-fast /usr/local/bin/asr-fast
+
+EXPOSE 8082
+ENV LISTEN=0.0.0.0:8082
+CMD ["asr-fast"]

--- a/docker/forebrain-llm.Dockerfile
+++ b/docker/forebrain-llm.Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.76 AS builder
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY forebrain-llm/Cargo.toml forebrain-llm/Cargo.toml
+RUN cargo fetch --locked
+
+COPY forebrain-llm forebrain-llm
+RUN cargo build --release -p forebrain-llm
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/forebrain-llm /usr/local/bin/forebrain-llm
+
+EXPOSE 8080
+ENV FOREBRAIN_LLM__WEBSOCKET__BIND_ADDR=0.0.0.0:8080
+CMD ["forebrain-llm"]

--- a/docker/tts-websocket.Dockerfile
+++ b/docker/tts-websocket.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY tools/tts_websocket /app/tools/tts_websocket
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "TTS==0.15.5" "websockets>=11,<12"
+
+EXPOSE 5002
+CMD ["python", "-m", "tools.tts_websocket.websocket_server"]

--- a/modules/chat/module.toml
+++ b/modules/chat/module.toml
@@ -31,8 +31,8 @@ packages = ["voice"]
 
 [[actions]]
 type = "pip_install"
-packages = ["requests"]
-import_check = ["requests"]
+packages = ["requests", "websockets>=11,<12"]
+import_check = ["requests", "websockets"]
 break_system = true
 
 [[actions]]

--- a/modules/chat/packages/chat/chat/llm_client.py
+++ b/modules/chat/packages/chat/chat/llm_client.py
@@ -1,0 +1,147 @@
+"""Client helpers for the Forebrain LLM websocket service."""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any, Callable, List, Mapping, Sequence
+
+try:  # Optional dependency required for websocket communication.
+    from websockets.asyncio.client import connect as websocket_connect
+    from websockets.exceptions import ConnectionClosed
+except ImportError:  # pragma: no cover - optional dependency for tests.
+    websocket_connect = None  # type: ignore
+    ConnectionClosed = RuntimeError  # type: ignore
+
+
+class ForebrainUnavailable(RuntimeError):
+    """Raised when the Forebrain websocket service cannot be reached."""
+
+
+class ForebrainLLMClient:
+    """Thin wrapper for streaming completions from the Forebrain LLM service."""
+
+    def __init__(
+        self,
+        *,
+        uri: str,
+        connect_timeout: float,
+        response_timeout: float,
+        logger=None,
+        connector=None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        if not uri:
+            raise ValueError('Forebrain websocket URI must be provided')
+        if connector is None and websocket_connect is None:
+            raise ForebrainUnavailable('websockets client not available')
+        self._uri = uri
+        self._connect_timeout = max(0.1, float(connect_timeout))
+        self._response_timeout = max(0.1, float(response_timeout))
+        self._logger = logger
+        self._connector = connector or websocket_connect
+        self._monotonic = monotonic or time.monotonic
+
+    def generate(self, history: Sequence[Mapping[str, Any]]) -> str:
+        """Return the assistant response for ``history`` messages."""
+
+        if self._connector is None:
+            raise ForebrainUnavailable('websocket connector unavailable')
+        try:
+            return asyncio.run(self._generate_async(list(history)))
+        except ForebrainUnavailable:
+            raise
+        except Exception as exc:
+            raise ForebrainUnavailable(str(exc)) from exc
+
+    async def _generate_async(self, history: List[Mapping[str, Any]]) -> str:
+        connector = self._connector
+        if connector is None:
+            raise ForebrainUnavailable('websocket connector unavailable')
+
+        try:
+            async with connector(
+                self._uri,
+                open_timeout=self._connect_timeout,
+                close_timeout=self._connect_timeout,
+                ping_interval=None,
+                ping_timeout=self._response_timeout,
+                max_size=None,
+            ) as websocket:
+                await websocket.send(json.dumps({'command': 'reset'}))
+                pending = await self._drain_until_idle(websocket)
+
+                assistant_response: List[str] = []
+                if pending and pending.get('role', '').lower() == 'assistant':
+                    assistant_response.append(str(pending.get('content', '')))
+
+                for message in history:
+                    payload = self._normalise_message(message)
+                    await websocket.send(json.dumps(payload))
+                    if payload['role'].lower() == 'user':
+                        assistant_response.extend(
+                            await self._collect_tokens(websocket)
+                        )
+
+                return ''.join(assistant_response).strip()
+        except ForebrainUnavailable:
+            raise
+        except ConnectionClosed as exc:  # pragma: no cover - runtime dependent.
+            raise ForebrainUnavailable(f'connection closed: {exc}') from exc
+        except Exception as exc:
+            raise ForebrainUnavailable(str(exc)) from exc
+
+    async def _drain_until_idle(self, websocket) -> dict[str, Any] | None:  # noqa: ANN001
+        deadline = self._monotonic() + self._response_timeout
+        while True:
+            remaining = deadline - self._monotonic()
+            if remaining <= 0:
+                break
+            try:
+                message = await asyncio.wait_for(websocket.recv(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            if isinstance(message, (bytes, bytearray)):
+                continue
+            try:
+                payload = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            if str(payload.get('role', '')).lower() == 'system':
+                continue
+            return payload
+        return None
+
+    async def _collect_tokens(self, websocket) -> List[str]:  # noqa: ANN001
+        chunks: List[str] = []
+        while True:
+            try:
+                message = await asyncio.wait_for(websocket.recv(), timeout=self._response_timeout)
+            except asyncio.TimeoutError:
+                break
+            if isinstance(message, (bytes, bytearray)):
+                continue
+            try:
+                payload = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            role = str(payload.get('role', '')).lower()
+            content = str(payload.get('content', ''))
+            if role == 'assistant':
+                chunks.append(content)
+            elif role == 'system':
+                # System messages signal either reset confirmations or errors.
+                if 'error' in content.lower():
+                    raise ForebrainUnavailable(content)
+            else:
+                # Ignore non-assistant roles to keep the stream aligned.
+                continue
+        return chunks
+
+    def _normalise_message(self, message: Mapping[str, Any]) -> dict[str, str]:
+        role = str(message.get('role', 'user')).strip() or 'user'
+        content = str(message.get('content', '')).strip()
+        return {'role': role, 'content': content}
+
+
+__all__ = ['ForebrainLLMClient', 'ForebrainUnavailable']

--- a/modules/chat/packages/chat/setup.py
+++ b/modules/chat/packages/chat/setup.py
@@ -11,7 +11,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/launch', ['launch/chat.launch.py']),
     ],
-    install_requires=['setuptools', 'requests'],
+    install_requires=['setuptools', 'requests', 'websockets>=11,<12'],
     zip_safe=True,
     maintainer='Psyched',
     maintainer_email='tdreed@gmail.com',

--- a/modules/chat/packages/chat/tests/test_llm_client.py
+++ b/modules/chat/packages/chat/tests/test_llm_client.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import sys
+from typing import Any, List
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+from chat.llm_client import ForebrainLLMClient, ForebrainUnavailable
+
+
+class StubConnection:
+    """Async context manager that mimics the websocket protocol."""
+
+    def __init__(self, responses: List[Any]) -> None:
+        self.responses = list(responses)
+        self.sent: List[str] = []
+        self.closed = False
+
+    async def __aenter__(self) -> "StubConnection":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        self.closed = True
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def recv(self) -> Any:
+        if not self.responses:
+            raise asyncio.TimeoutError
+        item = self.responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+async def stub_connector(url: str, **_kwargs: Any) -> StubConnection:  # noqa: ANN001
+    raise AssertionError("stub_connector requires fixture override")
+
+
+class TestForebrainClient:
+    def test_collects_streamed_tokens_and_returns_sentence(self, monkeypatch):
+        messages = [
+            json.dumps({"role": "system", "content": "session reset"}),
+            json.dumps({"role": "assistant", "content": "Hello"}),
+            json.dumps({"role": "assistant", "content": " world"}),
+            asyncio.TimeoutError(),
+        ]
+        connection = StubConnection(messages)
+
+        def connector(_url: str, **_kwargs: Any) -> StubConnection:  # noqa: ANN001
+            return connection
+
+        client = ForebrainLLMClient(
+            uri="ws://example.invalid/chat",
+            connect_timeout=0.1,
+            response_timeout=0.1,
+            logger=None,
+            connector=connector,
+        )
+
+        history = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Say hi"},
+        ]
+        result = client.generate(history)
+
+        assert result == "Hello world"
+        assert connection.closed is True
+        sent_payloads = [json.loads(msg) for msg in connection.sent]
+        assert sent_payloads[0] == {"command": "reset"}
+        assert sent_payloads[1] == history[0]
+        assert sent_payloads[2] == history[1]
+
+    def test_raises_when_connection_fails(self):
+        def connector(_url: str, **_kwargs: Any) -> StubConnection:  # noqa: ANN001
+            raise OSError("connection refused")
+
+        client = ForebrainLLMClient(
+            uri="ws://example.invalid/chat",
+            connect_timeout=0.1,
+            response_timeout=0.1,
+            logger=None,
+            connector=connector,
+        )
+
+        with pytest.raises(ForebrainUnavailable):
+            client.generate([
+                {"role": "system", "content": "test"},
+                {"role": "user", "content": "hello"},
+            ])
+

--- a/modules/ear/module.toml
+++ b/modules/ear/module.toml
@@ -62,8 +62,8 @@ break_system = true
 
 [[actions]]
 type = "pip_install"
-packages = ["numpy", "faster-whisper"]
-import_check = ["numpy", "faster_whisper"]
+packages = ["numpy", "faster-whisper", "websockets>=11,<12"]
+import_check = ["numpy", "faster_whisper", "websockets"]
 break_system = true
 
 [[actions]]

--- a/modules/ear/packages/ear/setup.py
+++ b/modules/ear/packages/ear/setup.py
@@ -11,7 +11,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/launch', ['launch/ear.launch.py']),
     ],
-    install_requires=['setuptools', 'pyaudio', 'webrtcvad', 'numpy', 'faster-whisper>=1.0.0'],
+    install_requires=['setuptools', 'pyaudio', 'webrtcvad', 'numpy', 'faster-whisper>=1.0.0', 'websockets>=11,<12'],
     zip_safe=True,
     maintainer='Psyched',
     maintainer_email='tdreed@gmail.com',

--- a/modules/ear/packages/ear/tests/test_transcriber_node.py
+++ b/modules/ear/packages/ear/tests/test_transcriber_node.py
@@ -6,7 +6,7 @@ package_root = str(Path(__file__).resolve().parents[1])
 if package_root not in sys.path:
     sys.path.insert(0, package_root)
 
-from ear.transcriber_node import TranscriptionWorker
+from ear.transcriber_node import ChainedTranscriptionBackend, TranscriptionWorker
 
 
 class DummyBackend:
@@ -17,6 +17,17 @@ class DummyBackend:
     def transcribe(self, pcm_bytes: bytes, sample_rate: int):
         self.calls.append(pcm_bytes)
         return self.response
+
+
+class DummyFailingBackend(DummyBackend):
+    def __init__(self, response: Tuple[str, float]):
+        super().__init__(response)
+        self.failures = 0
+
+    def transcribe(self, pcm_bytes: bytes, sample_rate: int):
+        self.calls.append(pcm_bytes)
+        self.failures += 1
+        raise RuntimeError("remote backend offline")
 
 
 class DummyBackendNoText(DummyBackend):
@@ -55,3 +66,59 @@ def test_transcriber_worker_skips_blank_transcripts():
     worker.handle_segment(b'\x00\x00')
 
     assert not captured
+
+
+def test_chained_backend_prefers_primary():
+    primary = DummyBackend(("primary", 0.9))
+    fallback = DummyBackend(("fallback", 0.5))
+
+    backend = ChainedTranscriptionBackend(primary=primary, fallback=fallback, cooldown_seconds=1.0, logger=None)
+
+    result = backend.transcribe(b"pcm", 16000)
+
+    assert result == ("primary", 0.9)
+    assert len(primary.calls) == 1
+    assert not fallback.calls
+
+
+def test_chained_backend_falls_back_after_failure():
+    primary = DummyFailingBackend(("primary", 0.9))
+    fallback = DummyBackend(("fallback", 0.5))
+
+    backend = ChainedTranscriptionBackend(primary=primary, fallback=fallback, cooldown_seconds=10.0, logger=None)
+
+    result = backend.transcribe(b"pcm", 16000)
+
+    assert result == ("fallback", 0.5)
+    assert len(fallback.calls) == 1
+    assert primary.failures == 1
+
+
+def test_chained_backend_skips_primary_during_cooldown():
+    primary = DummyFailingBackend(("primary", 0.9))
+    fallback = DummyBackend(("fallback", 0.5))
+
+    fake_now = [100.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    backend = ChainedTranscriptionBackend(
+        primary=primary,
+        fallback=fallback,
+        cooldown_seconds=30.0,
+        logger=None,
+        monotonic=fake_monotonic,
+    )
+
+    first = backend.transcribe(b"pcm", 16000)
+    assert first == ("fallback", 0.5)
+    assert primary.failures == 1
+
+    fake_now[0] += 5.0
+    second = backend.transcribe(b"pcm2", 16000)
+
+    assert second == ("fallback", 0.5)
+    assert primary.failures == 1, "primary should not be retried during cooldown"
+    assert len(fallback.calls) == 2
+

--- a/modules/voice/packages/voice/tests/test_provider_fallback.py
+++ b/modules/voice/packages/voice/tests/test_provider_fallback.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any, Callable
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+from voice.providers import (
+    ProviderUnavailable,
+    build_provider_with_fallback,
+)
+
+
+class DummyProvider:
+    def __init__(self, engine: str) -> None:
+        self.engine = engine
+
+
+def config_getter_factory(engine: str) -> Callable[[], object]:
+    return lambda: {"engine": engine}
+
+
+def builder(engine: str, *, logger: Any, config_getter: Callable[[], object]) -> DummyProvider:  # noqa: ANN001
+    _ = logger, config_getter
+    if engine == "broken":
+        raise ProviderUnavailable("nope")
+    return DummyProvider(engine)
+
+
+def test_returns_primary_engine_when_available():
+    selected_engine, provider = build_provider_with_fallback(
+        preferred="websocket",
+        fallbacks=["espeak"],
+        logger=None,
+        config_getter_factory=config_getter_factory,
+        builder=builder,
+    )
+
+    assert selected_engine == "websocket"
+    assert isinstance(provider, DummyProvider)
+    assert provider.engine == "websocket"
+
+
+def test_uses_fallback_when_primary_unavailable():
+    selected_engine, provider = build_provider_with_fallback(
+        preferred="broken",
+        fallbacks=["espeak"],
+        logger=None,
+        config_getter_factory=config_getter_factory,
+        builder=builder,
+    )
+
+    assert selected_engine == "espeak"
+    assert provider.engine == "espeak"
+
+
+def test_raises_when_all_engines_fail():
+    with pytest.raises(ProviderUnavailable):
+        build_provider_with_fallback(
+            preferred="broken",
+            fallbacks=["broken"],
+            logger=None,
+            config_getter_factory=config_getter_factory,
+            builder=builder,
+        )
+


### PR DESCRIPTION
## Summary
- add Dockerfiles and a compose bundle for running the ASR, TTS, and LLM services without ROS
- teach the ear, voice, and chat nodes to use the websocket services first and fall back to their onboard engines automatically
- document the remote speech stack, new environment overrides, and add regression tests for the new fallback clients

## Testing
- pytest modules/ear/packages/ear/tests/test_transcriber_node.py
- pytest modules/voice/packages/voice/tests/test_provider_fallback.py modules/voice/packages/voice/tests/test_websocket_provider.py
- pytest modules/chat/packages/chat/tests


------
https://chatgpt.com/codex/tasks/task_e_68d9257df8a08320938ad732c32ad606