### PR TITLE
Default speech stack to GPT-OSS 20B

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ ros2 topic list
 
 ### Module-Specific Troubleshooting
 
-- **Chat**: Ensure Ollama is running and model is downloaded (`ollama pull llama3.2`)
+- **Chat**: Ensure Ollama is running and the lightweight fallback model is available (`ollama pull tinyllama`)
 - **Voice**: Check ALSA audio devices (`arecord -l`, `aplay -l`)
 - **Eye**: Verify Kinect USB connection and libfreenect installation
 - **Foot**: Check serial/USB connection to robot base
@@ -324,8 +324,9 @@ their onboard implementations when the websocket is unavailable:
   the local Ollama HTTP API when the websocket raises an error.
 
 Place GGUF models for the LLM under `forebrain-llm/models/` (mounted into the
-container at `/data`) and adjust `FOREBRAIN_LLM__MODEL__PATH` in the compose file
-if you use a different filename.
+container at `/data`). The speech stack defaults to loading `gpt-oss-20b.gguf`;
+adjust `FOREBRAIN_LLM__MODEL__PATH` in the compose file if you use a different
+filename.
 
 ## License
 

--- a/compose/speech-stack.compose.yml
+++ b/compose/speech-stack.compose.yml
@@ -26,7 +26,7 @@ services:
     image: psyched-forebrain-llm:local
     restart: unless-stopped
     environment:
-      FOREBRAIN_LLM__MODEL__PATH: "/data/model.gguf"
+      FOREBRAIN_LLM__MODEL__PATH: "/data/gpt-oss-20b.gguf"
       FOREBRAIN_LLM__WEBSOCKET__BIND_ADDR: "0.0.0.0:8080"
     volumes:
       - type: bind

--- a/modules/chat/packages/chat/chat/node.py
+++ b/modules/chat/packages/chat/chat/node.py
@@ -68,7 +68,9 @@ class ChatNode(Node):
         self.declare_parameter('conversation_topic', '/conversation')
         self.declare_parameter('voice_topic', '/voice')
         self.declare_parameter('transcript_topic', '/audio/transcription')
-        self.declare_parameter('model', 'llama3.2')
+        # Default to a tiny local Ollama model so the fallback stays responsive.
+        # The remote speech stack supplies the heavier GPT-OSS:20B model.
+        self.declare_parameter('model', 'tinyllama')
         self.declare_parameter('ollama_host', 'http://localhost:11434')
         self.declare_parameter('max_history', 20)
         self.declare_parameter('llm_ws_url', default_llm_url)

--- a/modules/chat/packages/chat/tests/test_chat_conversation_flow.py
+++ b/modules/chat/packages/chat/tests/test_chat_conversation_flow.py
@@ -281,3 +281,9 @@ def test_chatnode_falls_back_to_ollama_when_llm_unreachable() -> None:
     assert node.pub_voice.messages[-1].data == "Rescued by Ollama."
     assert stub.calls == 1
 
+
+def test_chatnode_defaults_to_tinyllama_for_ollama_fallback() -> None:
+    node = ChatNode()
+
+    assert node.model == "tinyllama"
+


### PR DESCRIPTION
## Summary
- default the speech stack LLM container to load the gpt-oss-20b model image
- document the new model expectations and adjust the chat module to use tinyllama for local fallback
- add a regression test that locks the chat node’s Ollama model default

## Testing
- pytest modules/chat/packages/chat/tests/test_chat_conversation_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d96804f9608320ab5d1670c48bfbbd