### PR TITLE
Add pilot digest to chat system prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,9 @@ Visit `http://<cerebellum-host>:8080`.
 
 * `ear`: PyAudio microphone capture, VAD, Whisper transcription.
 * `voice`: espeak-ng or Coqui/Piper via WebSocket, with playback.
-* `chat`: connects transcription → Ollama LLM → voice.
+* `chat`: connects transcription → Ollama LLM → voice. Exposes a `pilot_base_url`
+  parameter that should point at the running Pilot backend so the chat system
+  prompt can include the text-only control surface summary.
 * `pilot`: LCARS-style web frontend + health reporter.
 * `nav`: depth-to-scan pipeline + AMCL, vision LLM prompts.
 * Others (`eye`, `foot`, `imu`, `gps`, `wifi`, `will`) follow similar structure.


### PR DESCRIPTION
## Summary
- append the Pilot control surface digest to the chat system prompt so the LLM sees the dashboard context
- fetch and cache the Pilot module listing to render a readable text-only summary
- extend conversation flow tests to cover the new system prompt and note the pilot_base_url parameter in the agent guide

## Testing
- pytest modules/chat/packages/chat/tests/test_chat_conversation_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d9adcb1fc88320af59f5ebb1755ac3