### PR TITLE
Honor OLLAMA_HOST for chat fallback

### DIFF
--- a/modules/chat/packages/chat/README.md
+++ b/modules/chat/packages/chat/README.md
@@ -10,7 +10,7 @@ The node always records the spoken payload, even if the acknowledgement text dif
 - `voice_topic` (default `/voice`)
 - `transcript_topic` (default `/audio/transcription`)
 - `model` (env `CHAT_MODEL`, default `llama3.2`)
-- `ollama_host` (env `OLLAMA_HOST`, default `http://forebrain.local:11434`)
+- `ollama_host` (env `CHAT_OLLAMA_HOST` or `OLLAMA_HOST`, default `http://forebrain.local:11434`)
 - `max_history` (int, default 20)
 
 ## Run


### PR DESCRIPTION
## Summary
- normalise and honour CHAT_OLLAMA_HOST/OLLAMA_HOST when configuring the chat node's Ollama fallback
- guard Ollama fallback helpers when the host is unset and improve developer documentation
- extend chat tests to cover environment overrides and host normalisation

## Testing
- pytest modules/chat/packages/chat/tests


------
https://chatgpt.com/codex/tasks/task_e_68d9ebbf74148320bf58a232edf57888