### PR TITLE
Normalize pilot transcript display

### DIFF
--- a/modules/pilot/packages/pilot/pilot/__init__.py
+++ b/modules/pilot/packages/pilot/pilot/__init__.py
@@ -1,9 +1,15 @@
 """Pilot backend package entrypoint."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .module_catalog import ModuleCatalog, ModuleInfo, ModuleTopic, ModuleCommands
-from .app import create_app, PilotApplication
 from .qos import QosConfig
 from .voice_config import VoiceConfigStore
+
+if TYPE_CHECKING:  # pragma: no cover - used only for static analysis
+    from .app import PilotApplication, create_app
 
 __all__ = [
     "ModuleCatalog",
@@ -15,3 +21,13 @@ __all__ = [
     "create_app",
     "PilotApplication",
 ]
+
+
+def __getattr__(name: str):  # noqa: D401 - module attribute loader
+    """Lazily expose application factories to avoid optional dependency churn."""
+
+    if name in {"create_app", "PilotApplication"}:
+        from .app import PilotApplication as _PilotApplication, create_app as _create_app
+
+        return {"create_app": _create_app, "PilotApplication": _PilotApplication}[name]
+    raise AttributeError(f"module 'pilot' has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- strip timing markers and parse JSON segments when relaying Transcript messages to the pilot UI
- fall back to segment text client-side so the transcription panel renders spoken phrases instead of metadata
- add coverage for the transcript normaliser and lazily expose pilot application factories to avoid optional FastAPI imports during tests

## Testing
- pytest modules/pilot/packages/pilot/tests/test_topic_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d9f47a27f08320ab73277defdc1293