### PR TITLE
Add dedicated silence monitor node for raw audio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,9 @@ current architecture.
 - Additive commits; keep messages concise and meaningful.
 - Keep dependencies cached when possible.
 - Fix warnings as you go.
+- When editing ROS launch files, wrap `LaunchConfiguration` values in
+  `ParameterValue` with the appropriate type so nodes receive correctly-typed
+  parameters instead of strings.
 
 ---
 

--- a/modules/ear/packages/ear/README.md
+++ b/modules/ear/packages/ear/README.md
@@ -2,10 +2,11 @@
 
 PyAudio capture, WebRTC VAD, and streaming transcription for ROS 2.
 
-The ear package exposes three executables that form the audio intake pipeline:
+The ear package exposes four executables that form the audio intake pipeline:
 
-- `ear_node` – streams raw PCM16 audio from a PyAudio device to `/audio/raw` and
-  publishes a silence-duration gauge on `/audio/silence_ms`.
+- `ear_node` – streams raw PCM16 audio from a PyAudio device to `/audio/raw`.
+- `silence_node` – monitors `/audio/raw` and publishes a silence-duration gauge
+  on `/audio/silence_ms`.
 - `vad_node` – resamples `/audio/raw` to 16 kHz, applies WebRTC VAD, and emits
   voiced frames on `/audio/speech_segment` while tracking active speech
   duration on `/audio/speech_duration`.
@@ -20,6 +21,8 @@ The ear package exposes three executables that form the audio intake pipeline:
 - `sample_rate` (int, default `44100`): Capture rate in Hz.
 - `channels` (int, default `1`): Channel count.
 - `chunk_size` (int, default `1024`): Frames per callback.
+
+### `silence_node`
 - `silence_threshold` (float, default `500.0`): RMS threshold used to reset the
   silence gauge.
 
@@ -48,10 +51,10 @@ The ear package exposes three executables that form the audio intake pipeline:
 
 ```bash
 ros2 launch ear ear.launch.py \
-    device_id:=0 \
-    sample_rate:=44100 \
-    channels:=1 \
-    chunk_size:=1024 \
+    ear_device_id:=0 \
+    ear_sample_rate:=44100 \
+    ear_channels:=1 \
+    ear_chunk_size:=1024 \
     silence_threshold:=500.0
 ```
 

--- a/modules/ear/packages/ear/ear/__init__.py
+++ b/modules/ear/packages/ear/ear/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     'audio_utils',
     'pyaudio_ear_node',
+    'silence_node',
     'silence_tracker',
     'transcriber_node',
     'vad_node',

--- a/modules/ear/packages/ear/ear/silence_node.py
+++ b/modules/ear/packages/ear/ear/silence_node.py
@@ -1,0 +1,154 @@
+"""ROS 2 node that derives a silence gauge from raw PCM audio.
+
+The node subscribes to ``/audio/raw`` (``std_msgs/msg/ByteMultiArray``),
+converts each message to PCM16 samples, and feeds their RMS amplitude into a
+:class:`~ear.silence_tracker.SilenceTracker`.  The resulting duration in
+milliseconds is emitted on ``/audio/silence_ms`` using ``std_msgs/msg/UInt32``.
+
+A small set of ROS stubs is bundled for unit tests so the logic can be exercised
+without a full ROS installation.  At runtime the real ``rclpy`` imports are
+used automatically.
+"""
+from __future__ import annotations
+
+import math
+import struct
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+
+from .audio_utils import coerce_pcm_bytes
+from .silence_tracker import SilenceTracker
+
+try:  # pragma: no cover - exercised only in ROS environments
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import ByteMultiArray, UInt32
+except ImportError:  # pragma: no cover - unit tests rely on these lightweight stubs
+    rclpy = None  # type: ignore[assignment]
+
+    class _LoggerStub:
+        def info(self, msg: str) -> None:  # noqa: D401 - parity with rclpy logger
+            """Log informational messages (ignored during tests)."""
+
+        def warning(self, msg: str) -> None:
+            pass
+
+        # ``rclpy`` exposes ``warn``; keep compatibility with existing code.
+        warn = warning
+
+        def error(self, msg: str) -> None:
+            pass
+
+    class _PublisherStub:
+        """Minimal publisher that records outbound messages for assertions."""
+
+        def __init__(self, topic: str) -> None:
+            self.topic = topic
+            self.published: list[Any] = []
+
+        def publish(self, msg: Any) -> None:
+            self.published.append(msg)
+
+    class _SubscriptionStub:
+        def __init__(self, topic: str, callback: Callable[[Any], None]) -> None:
+            self.topic = topic
+            self.callback = callback
+
+    class Node:  # type: ignore[override]
+        """Lightweight stand-in for :class:`rclpy.node.Node` used in tests."""
+
+        def __init__(self, name: str) -> None:
+            self._name = name
+            self._logger = _LoggerStub()
+
+        def declare_parameter(self, name: str, default_value: Any) -> SimpleNamespace:
+            return SimpleNamespace(value=default_value)
+
+        def create_publisher(self, msg_type: Any, topic: str, qos: int) -> _PublisherStub:
+            return _PublisherStub(topic)
+
+        def create_subscription(self, msg_type: Any, topic: str, callback: Callable[[Any], None], qos: int) -> _SubscriptionStub:
+            return _SubscriptionStub(topic, callback)
+
+        def get_logger(self) -> _LoggerStub:
+            return self._logger
+
+    @dataclass
+    class ByteMultiArray:  # type: ignore[override]
+        data: Any = b""
+
+    @dataclass
+    class UInt32:  # type: ignore[override]
+        data: int = 0
+
+
+def _calculate_rms(pcm: bytes) -> float:
+    """Return the RMS amplitude of *pcm* assuming little-endian PCM16 samples."""
+    if not pcm:
+        return 0.0
+
+    sample_count = len(pcm) // 2
+    if sample_count == 0:
+        return 0.0
+
+    # Truncate any dangling byte to preserve struct alignment; PyAudio provides
+    # well-formed buffers but callers may pass trimmed payloads during tests.
+    if len(pcm) % 2:
+        pcm = pcm[:-1]
+        sample_count -= 1
+        if sample_count == 0:
+            return 0.0
+
+    samples = struct.unpack(f"<{sample_count}h", pcm)
+    mean_square = sum(sample * sample for sample in samples) / sample_count
+    return math.sqrt(mean_square)
+
+
+class SilenceNode(Node):  # type: ignore[misc]
+    """ROS-compatible node that publishes the ``/audio/silence_ms`` gauge."""
+
+    def __init__(self, tracker_factory: Optional[Callable[[float], SilenceTracker]] = None) -> None:
+        super().__init__('silence_monitor')
+
+        self._silence_threshold = float(self.declare_parameter('silence_threshold', 500.0).value)
+        factory = tracker_factory or (lambda threshold: SilenceTracker(threshold))
+        self._tracker = factory(self._silence_threshold)
+
+        self._publisher = self.create_publisher(UInt32, '/audio/silence_ms', 10)
+        self._subscription = self.create_subscription(ByteMultiArray, '/audio/raw', self._on_audio, 10)
+
+        self.get_logger().info(f'Silence monitor ready: threshold={self._silence_threshold:.1f}')
+
+    def _on_audio(self, msg: ByteMultiArray) -> None:
+        """Handle inbound raw audio payloads."""
+        try:
+            pcm = coerce_pcm_bytes(getattr(msg, 'data', msg))
+        except TypeError as exc:
+            self.get_logger().warning(f'Failed to decode audio payload: {exc}')
+            return
+
+        rms = _calculate_rms(pcm)
+        silence_ms = self._tracker.update(rms=rms)
+
+        message = UInt32()
+        message.data = silence_ms
+        self._publisher.publish(message)
+
+
+def main(args: Any = None) -> None:  # pragma: no cover - requires ROS
+    if rclpy is None:
+        raise RuntimeError('rclpy is required to run SilenceNode')
+
+    rclpy.init(args=args)
+    node = SilenceNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+__all__ = ['SilenceNode', 'SilenceTracker', 'ByteMultiArray', 'UInt32']

--- a/modules/ear/packages/ear/setup.py
+++ b/modules/ear/packages/ear/setup.py
@@ -22,12 +22,13 @@ setup(
     zip_safe=True,
     maintainer='Psyched',
     maintainer_email='tdreed@gmail.com',
-    description='PyAudio-based microphone capture with silence detection',
+    description='PyAudio-based microphone capture and silence monitoring nodes',
     license='MIT',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'ear_node = ear.pyaudio_ear_node:main',
+            'silence_node = ear.silence_node:main',
             'vad_node = ear.vad_node:main',
             'transcriber_node = ear.transcriber_node:main',
             'speech_accumulator_node = ear.speech_accumulator_node:main',

--- a/modules/ear/packages/ear/tests/test_silence_node.py
+++ b/modules/ear/packages/ear/tests/test_silence_node.py
@@ -1,0 +1,74 @@
+"""Tests for the silence monitoring ROS node.
+
+These cover the behaviour of :class:`ear.silence_node.SilenceNode` using the
+built-in ROS stubs provided when ``rclpy`` is unavailable.  The stubs expose
+publishers and subscriptions so the unit tests can inject audio payloads and
+inspect the resulting gauge updates without spinning a ROS executor.
+"""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+import sys
+from typing import Callable
+
+package_root = str(Path(__file__).resolve().parents[1])
+if package_root not in sys.path:
+    sys.path.insert(0, package_root)
+
+from ear.silence_node import ByteMultiArray, SilenceNode, SilenceTracker, UInt32
+
+
+def _tracker_factory(time_source: Callable[[], float]) -> Callable[[float], SilenceTracker]:
+    """Return a tracker factory bound to *time_source* for deterministic tests."""
+
+    def factory(threshold: float) -> SilenceTracker:
+        return SilenceTracker(silence_threshold=threshold, time_source=time_source)
+
+    return factory
+
+
+def test_silence_node_emits_duration_from_quiet_frames() -> None:
+    """The node should accumulate silence while frames remain under threshold."""
+    fake_now = [0.0]
+
+    node = SilenceNode(tracker_factory=_tracker_factory(lambda: fake_now[0]))
+
+    # The stub publisher keeps every message in a ``published`` list for
+    # inspection during tests.
+    publisher = node._publisher  # type: ignore[attr-defined]
+    assert publisher.topic == '/audio/silence_ms'
+
+    quiet_frame = struct.pack('<4h', 0, 0, 0, 0)
+    node._on_audio(ByteMultiArray(data=quiet_frame))
+    assert isinstance(publisher.published[-1], UInt32)
+    assert publisher.published[-1].data == 0
+
+    fake_now[0] = 0.5
+    node._on_audio(ByteMultiArray(data=quiet_frame))
+    assert publisher.published[-1].data == 500
+
+    fake_now[0] = 1.0
+    node._on_audio(ByteMultiArray(data=quiet_frame))
+    assert publisher.published[-1].data == 1000
+
+
+def test_silence_node_resets_when_audio_exceeds_threshold() -> None:
+    """High-RMS frames should reset the silence gauge to zero."""
+    fake_now = [0.0]
+
+    node = SilenceNode(tracker_factory=_tracker_factory(lambda: fake_now[0]))
+    publisher = node._publisher  # type: ignore[attr-defined]
+
+    quiet_frame = struct.pack('<4h', 0, 0, 0, 0)
+    node._on_audio(ByteMultiArray(data=quiet_frame))
+    fake_now[0] = 0.5
+    node._on_audio(ByteMultiArray(data=quiet_frame))
+    assert publisher.published[-1].data == 500
+
+    loud_frame = struct.pack('<4h', 6000, 6000, 6000, 6000)
+    fake_now[0] = 0.6
+    node._on_audio(ByteMultiArray(data=loud_frame))
+    assert publisher.published[-1].data == 0
+
+


### PR DESCRIPTION
## Summary
- add a standalone silence_node that subscribes to /audio/raw, reuses SilenceTracker, and publishes the /audio/silence_ms gauge
- simplify pyaudio_ear_node to focus on raw PCM capture and update documentation, packaging, and launch wiring to run both nodes
- extend the ear test suite with coverage for the silence node using ROS stubs and note launch typing guidance in AGENTS.md

## Testing
- pytest modules/ear/packages/ear/tests

------
https://chatgpt.com/codex/tasks/task_e_68db0febccfc83208db9b7f54018e70b