### PR TITLE
Add headings to pilot controls and decouple battery metrics

### DIFF
--- a/modules/pilot/packages/pilot/pilot/static/components/battery-feed.js
+++ b/modules/pilot/packages/pilot/pilot/static/components/battery-feed.js
@@ -1,48 +1,49 @@
 import { LitElement, html } from 'https://unpkg.com/lit@3.1.4/index.js?module';
 
-import { updateBatteryMetric, batteryLabel } from '../utils/battery.js';
-import { extractNumeric } from '../utils/metrics.js';
+import { batteryLabel, batteryUnit, formatBatteryValue } from '../utils/battery.js';
 
 /**
- * Lightweight component that forwards a battery metric into the shared store.
+ * Displays an individual battery telemetry feed with contextual units.
  */
 class PilotBatteryFeed extends LitElement {
   static properties = {
     record: { type: Object },
     topic: { type: Object },
-    _value: { state: true },
   };
 
   constructor() {
     super();
     this.record = null;
     this.topic = null;
-    this._value = Number.NaN;
   }
 
   createRenderRoot() {
     return this;
   }
 
-  updated(changed) {
-    if (changed.has('record') && this.record) {
-      const topicName = this.topic?.topic ?? this.topic?.name;
-      if (topicName) {
-        const latest = this.record?.last ?? this.record?.messages?.[0];
-        this._value = extractNumeric(latest, this._value);
-        updateBatteryMetric(topicName, latest);
-      }
-    }
+  get topicName() {
+    return this.topic?.topic ?? this.topic?.name ?? '';
+  }
+
+  get latestPayload() {
+    return this.record?.last ?? this.record?.messages?.[0];
+  }
+
+  get formattedValue() {
+    return formatBatteryValue(this.topicName, this.latestPayload);
   }
 
   render() {
-    const label = batteryLabel(this.topic?.topic ?? this.topic?.name ?? 'Battery metric');
-    const formatted = Number.isFinite(this._value) ? this._value.toFixed(2) : '—';
+    const label = batteryLabel(this.topicName || 'battery_metric');
+    const unit = batteryUnit(this.topicName);
+    const topicPath = this.topicName || '—';
+    const statusParts = [topicPath ? `Topic: ${topicPath}` : null, unit ? `Unit: ${unit}` : null].filter(Boolean);
+    const status = statusParts.length ? statusParts.join(' • ') : 'Awaiting telemetry';
     return html`
       <div class="battery-feed" data-state=${this.record?.state ?? 'idle'}>
         <span class="feed-label">${label}</span>
-        <span class="feed-value">${formatted}</span>
-        <span class="feed-status">Linked to battery panel</span>
+        <span class="feed-value">${this.formattedValue}</span>
+        <span class="feed-status">${status}</span>
       </div>
     `;
   }

--- a/modules/pilot/packages/pilot/pilot/static/components/battery-panel.js
+++ b/modules/pilot/packages/pilot/pilot/static/components/battery-panel.js
@@ -1,101 +1,64 @@
 import { LitElement, html } from 'https://unpkg.com/lit@3.1.4/index.js?module';
 
-import { subscribeBattery, batteryLabel, updateBatteryMetric } from '../utils/battery.js';
+import { batteryLabel, formatBatteryValue, batteryMetadata } from '../utils/battery.js';
 import { extractNumeric } from '../utils/metrics.js';
 
-function formatNumber(value, unit = '') {
-  if (!Number.isFinite(value)) {
-    return '—';
-  }
-  const fixed = Math.abs(value) >= 10 ? value.toFixed(1) : value.toFixed(2);
-  return unit ? `${fixed} ${unit}` : fixed;
-}
-
 /**
- * Aggregated battery dashboard combining multiple telemetry feeds.
+ * Presents the aggregated battery charge level for the active platform.
  */
 class PilotBatteryPanel extends LitElement {
   static properties = {
     record: { type: Object },
     topic: { type: Object },
-    _metrics: { state: true },
   };
 
   constructor() {
     super();
     this.record = null;
     this.topic = null;
-    this._metrics = {};
-    this._unsubscribe = null;
   }
 
   createRenderRoot() {
     return this;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this._unsubscribe = subscribeBattery((metrics) => {
-      this._metrics = metrics;
-      this.requestUpdate();
-    });
+  get topicName() {
+    return this.topic?.topic ?? this.topic?.name ?? '/battery/charge_ratio';
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    if (typeof this._unsubscribe === 'function') {
-      this._unsubscribe();
-    }
-    this._unsubscribe = null;
-  }
-
-  updated(changed) {
-    if (changed.has('record') && this.record) {
-      const topicName = this.topic?.topic ?? this.topic?.name;
-      if (topicName) {
-        const value = this.record?.last ?? this.record?.messages?.[0];
-        updateBatteryMetric(topicName, value);
-      }
-    }
+  get latestPayload() {
+    return this.record?.last ?? this.record?.messages?.[0];
   }
 
   get percent() {
-    const raw = this._metrics['/battery/charge_ratio'];
-    const numeric = extractNumeric(raw, Number.NaN);
+    const metadata = batteryMetadata(this.topicName);
+    const numeric = extractNumeric(this.latestPayload, Number.NaN);
     if (!Number.isFinite(numeric)) {
-      return 0;
+      return Number.NaN;
     }
-    return Math.max(0, Math.min(1, numeric)) * 100;
+    const scale = metadata.scale ?? 1;
+    const scaled = scale === 100 && numeric > 1 ? numeric : numeric * scale;
+    return Math.max(0, Math.min(100, scaled));
   }
 
-  renderMetric(topic, unit = '') {
-    const value = this._metrics[topic];
-    if (topic === '/battery/charging_state') {
-      const label = value?.label ?? 'Unknown';
-      return html`<li><span class="label">${batteryLabel(topic)}</span><span>${label}</span></li>`;
-    }
-    const numeric = extractNumeric(value, Number.NaN);
-    return html`<li>
-      <span class="label">${batteryLabel(topic)}</span>
-      <span>${formatNumber(numeric, unit)}</span>
-    </li>`;
+  get formattedCharge() {
+    return formatBatteryValue(this.topicName, this.latestPayload);
   }
 
   render() {
-    const percent = Math.round(this.percent);
+    const percent = this.percent;
+    const chargeLabel = batteryLabel(this.topicName);
     return html`
       <div class="battery-panel" data-state=${this.record?.state ?? 'idle'}>
         <div class="battery-gauge">
-          <div class="battery-fill" style=${`width: ${percent}%`}></div>
-          <span class="battery-percent">${Number.isFinite(percent) ? `${percent}%` : '—'}</span>
+          <div class="battery-fill" style=${Number.isFinite(percent) ? `width: ${percent}%` : 'width: 0%'}></div>
+          <span class="battery-percent">${Number.isFinite(percent) ? `${Math.round(percent)}%` : '—'}</span>
         </div>
         <ul class="battery-metrics">
-          ${this.renderMetric('/battery/voltage', 'V')}
-          ${this.renderMetric('/battery/current', 'A')}
-          ${this.renderMetric('/battery/charge', 'mAh')}
-          ${this.renderMetric('/battery/capacity', 'mAh')}
-          ${this.renderMetric('/battery/temperature', '°C')}
-          ${this.renderMetric('/battery/charging_state')}
+          <li>
+            <span class="label">${chargeLabel}</span>
+            <span>${this.formattedCharge}</span>
+          </li>
         </ul>
       </div>
     `;


### PR DESCRIPTION
## Summary
- add h5 metric headers within each pilot topic widget for clearer control labels
- refactor the battery utilities to provide metadata-driven formatting instead of a shared store
- update the battery panel and feed components to present their own telemetry values per topic

## Testing
- pytest modules/pilot/packages/pilot -q *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68dc2adda7cc8320801fa9ede8135e4d