### PR TITLE
Switch ear capture to ALSA arecord

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Visit `http://<cerebellum-host>:8080`.
   * Development containers may not include the Deno runtime by default; install Deno locally to run `psh` CLI tests.
 * **Hardware deps**:
 
-  * `alsa-utils`, `pyaudio`, `webrtcvad` for `ear`.
+  * `alsa-utils` (for `arecord`), `webrtcvad`, `faster-whisper` for `ear`.
   * `libusb-1.0-dev` for `eye`.
   * Kinect and Create 1 hardware required for full bring-up.
 * **Workarounds**:

--- a/modules/ear/module.toml
+++ b/modules/ear/module.toml
@@ -99,8 +99,6 @@ type = "apt_install"
 packages = [
     "alsa-utils",
     "libasound2-dev",
-    "portaudio19-dev",
-    "python3-pyaudio",
 ]
 update = false
 

--- a/modules/ear/packages/ear/ear/pyaudio_ear_node.py
+++ b/modules/ear/packages/ear/ear/pyaudio_ear_node.py
@@ -1,282 +1,301 @@
-#!/usr/bin/env python3
-"""PyAudio-based microphone capture node.
+"""Raw audio publisher for ``/audio/raw`` using ``arecord``.
 
-Captures raw PCM audio from the configured device and publishes it verbatim on
-``/audio/raw``.  Silence monitoring now lives in :mod:`ear.silence_node`, keeping
-this node focused solely on the microphone interface.
+Despite the legacy name, this node now captures PCM16 audio via ``arecord``
+from ALSA instead of PyAudio.  The change sidesteps the long-running issues we
+observed with PyAudio streams silently stalling after a few minutes on the
+robot.  The output contract remains the same: ``std_msgs/msg/ByteMultiArray``
+messages on ``/audio/raw`` suitable for the existing silence monitor, VAD, and
+segmenter nodes.
+
+The implementation intentionally keeps the runtime dependencies minimal and the
+control flow straightforward.  We spawn ``arecord`` in a background thread,
+pipe its raw stdout into ROS messages, and restart the process if the stream
+goes quiet or the subprocess exits.  A small shim layer emulates the ROS APIs
+whenever the tests run outside a ROS installation so we can exercise the logic
+with standard unit tests.
 """
-from typing import Optional
+from __future__ import annotations
+
+import subprocess
+import threading
 import time
 from contextlib import suppress
-import traceback
-
-import pyaudio
-import rclpy
-from rclpy.node import Node
-from std_msgs.msg import ByteMultiArray
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence
 
 from .qos import sensor_data_qos
 
+try:  # pragma: no cover - exercised only when ROS 2 is available
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import ByteMultiArray
+except ImportError:  # pragma: no cover - unit tests rely on these lightweight stubs
+    rclpy = None  # type: ignore[assignment]
 
-class PyAudioEarNode(Node):
-    def __init__(self) -> None:
+    class _LoggerStub:
+        def info(self, msg: str) -> None:  # noqa: D401 - parity with rclpy logger
+            """Log informational messages (ignored during tests)."""
+
+        def warning(self, msg: str) -> None:
+            pass
+
+        # rclpy exposes ``warn``; keep compatibility with existing code.
+        warn = warning
+
+        def error(self, msg: str) -> None:
+            pass
+
+    class _PublisherStub:
+        """Minimal publisher that records outbound messages for assertions."""
+
+        def __init__(self, topic: str) -> None:
+            self.topic = topic
+            self.published: list[Any] = []
+
+        def publish(self, msg: Any) -> None:
+            self.published.append(msg)
+
+    class _TimerStub:
+        def __init__(self, callback: Callable[[], None]) -> None:
+            self.callback = callback
+
+    class Node:  # type: ignore[override]
+        """Lightweight stand-in for :class:`rclpy.node.Node` used in tests."""
+
+        def __init__(self, name: str) -> None:
+            self._name = name
+            self._logger = _LoggerStub()
+            self._parameters: Dict[str, Any] = {}
+
+        def declare_parameter(self, name: str, default_value: Any) -> Any:
+            self._parameters[name] = default_value
+            return type("_Param", (), {"value": default_value})()
+
+        def get_parameter(self, name: str) -> Any:
+            value = self._parameters.get(name)
+            return type("_Param", (), {"value": value})()
+
+        def create_publisher(self, msg_type: Any, topic: str, qos: Any) -> _PublisherStub:
+            return _PublisherStub(topic)
+
+        def create_timer(self, interval: float, callback: Callable[[], None]) -> _TimerStub:
+            return _TimerStub(callback)
+
+        def get_logger(self) -> _LoggerStub:
+            return self._logger
+
+        def destroy_node(self) -> None:
+            pass
+
+    class ByteMultiArray:  # type: ignore[override]
+        def __init__(self, data: Iterable[int] | bytes | bytearray | None = None) -> None:
+            self.data = bytes(data or b"")
+
+
+PopenFactory = Callable[..., subprocess.Popen]
+
+
+class PyAudioEarNode(Node):  # type: ignore[misc]
+    """Publish raw PCM16 audio frames on ``/audio/raw`` using ALSA ``arecord``."""
+
+    def __init__(
+        self,
+        *,
+        popen_factory: Optional[PopenFactory] = None,
+        parameter_overrides: Optional[Dict[str, object]] = None,
+    ) -> None:
         super().__init__('ear')
-        
-        # Audio parameters
-        self.device_id = self.declare_parameter('device_id', 0).get_parameter_value().integer_value
-        self.sample_rate = self.declare_parameter('sample_rate', 44100).get_parameter_value().integer_value
-        self.channels = self.declare_parameter('channels', 1).get_parameter_value().integer_value
-        self.chunk_size = self.declare_parameter('chunk_size', 2048).get_parameter_value().integer_value
-        self.format = pyaudio.paInt16  # 16-bit PCM
-        
-        # Publisher for raw PCM payloads
-        self.audio_pub = self.create_publisher(ByteMultiArray, '/audio/raw', sensor_data_qos())
-        
-        # Audio processing
-        self.audio = pyaudio.PyAudio()
-        self.stream: Optional[pyaudio.Stream] = None
-        self.running = False
-        
-        # Start audio capture; if initial startup fails, shut down the node.
-        if not self.start_capture(initial=True):
-            # start_capture already logged the error; ensure node is stopped
-            return
 
-        # Counters / heartbeat for diagnosing stalls
+        overrides = parameter_overrides or {}
+        self._popen_factory: PopenFactory = popen_factory or subprocess.Popen
+
+        self._chunk_size = self._get_int_param('chunk_size', 2048, overrides)
+        self._sample_rate = self._get_int_param('sample_rate', 44100, overrides)
+        self._channels = self._get_int_param('channels', 1, overrides)
+        self._device_id = self._get_int_param('device_id', 0, overrides)
+        self._alsa_device = self._get_str_param('alsa_device', '', overrides)
+        self._topic = self._get_str_param('topic', '/audio/raw', overrides)
+
+        self.audio_pub = self.create_publisher(ByteMultiArray, self._topic, sensor_data_qos())
+
+        self._proc: Optional[subprocess.Popen] = None
+        self._stop_evt = threading.Event()
+        self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader_thread.start()
+
         self._frames_published = 0
         self._last_heartbeat = time.time()
         self._last_frames = 0
-        self._stall_count = 0
-        # Callback timing / buffer diagnostics
-        self._prev_callback_time: float | None = None
-        self._last_callback_time: float | None = None
-        self._last_frames_received: int = 0
-        self._overflow_count: int = 0
-        # Timer runs in the rclpy executor thread so logs are serialized with other node logs
+
         try:
-            # create_timer may fail in non-ROS test environments; guard it
             self.create_timer(5.0, self._heartbeat)
         except Exception:
             pass
 
         self.get_logger().info(
-            f'PyAudio Ear started: device={self.device_id}, rate={self.sample_rate}Hz, '
-            f'channels={self.channels}, chunk={self.chunk_size}'
+            f'Arecord Ear started: device={self._resolve_device()} '
+            f'rate={self._sample_rate}Hz channels={self._channels} '
+            f'chunk={self._chunk_size} -> {self._topic}'
         )
 
-    def start_capture(self, initial: bool = False) -> bool:
-        """Start PyAudio stream.
+    # ------------------------------------------------------------------
+    # Parameter helpers
+    def _get_param(self, name: str, default: Any, overrides: Dict[str, object]) -> Any:
+        param = self.declare_parameter(name, default)
+        value = getattr(param, 'value', default)
+        if name in overrides:
+            value = overrides[name]
+        return value
 
-        Returns True on success, False on failure. If `initial` is True then a
-        failure is considered fatal and the caller may decide to stop the node.
-        When called from the heartbeat restart path we avoid shutting down the
-        whole node to allow repeated restart attempts and better diagnostics.
-        """
+    def _get_int_param(self, name: str, default: int, overrides: Dict[str, object]) -> int:
+        value = self._get_param(name, default, overrides)
         try:
-            device_info = self.audio.get_device_info_by_index(self.device_id)
-            self.get_logger().info(f'Using device: {device_info["name"]}')
+            return int(value)
+        except Exception:
+            return default
 
-            self.stream = self.audio.open(
-                format=self.format,
-                channels=self.channels,
-                rate=self.sample_rate,
-                input=True,
-                input_device_index=self.device_id,
-                frames_per_buffer=self.chunk_size,
-                stream_callback=self.audio_callback,
-            )
-
-            self.running = True
-            self.stream.start_stream()
-            return True
-
-        except Exception as e:
-            # Log full traceback to help diagnose ALSA / PyAudio errors
-            tb = traceback.format_exc()
-            try:
-                self.get_logger().error(f'Failed to start audio stream: {type(e).__name__}: {e}')
-                for line in tb.splitlines():
-                    self.get_logger().error(line)
-            except Exception:
-                # Fallback print if logging fails
-                print(f'Failed to start audio stream: {e}')
-                print(tb)
-
-            # If this is the initial startup failure, propagate by returning False.
-            # Do NOT call shutdown() here when invoked from the heartbeat restart path.
-            return False
-
-    def audio_callback(self, in_data, frame_count, time_info, status):
-        """PyAudio callback for processing audio data."""
-        # paInputOverflow is status 2, which is a non-critical warning.
-        if status:
-            # paInputOverflow is status 2; count overflows separately
-            try:
-                if status == 2:
-                    self._overflow_count += 1
-                else:
-                    self.get_logger().warn(f'Audio callback status: {status}')
-            except Exception:
-                pass
-
-        # Defensive checks and guarded publish to prevent silent failures
-        if not in_data:
-            try:
-                self.get_logger().warning('audio_callback received empty buffer')
-            except Exception:
-                pass
-            return (in_data, pyaudio.paContinue)
-
+    def _get_str_param(self, name: str, default: str, overrides: Dict[str, object]) -> str:
+        value = self._get_param(name, default, overrides)
         try:
-            audio_msg = ByteMultiArray()
-            audio_msg.data = in_data  # in_data is already bytes
-            self.audio_pub.publish(audio_msg)
-            # increment counter (safe from callback thread)
+            return str(value)
+        except Exception:
+            return default
+
+    # ------------------------------------------------------------------
+    # Capture management
+    def _resolve_device(self) -> str:
+        if self._alsa_device:
+            return self._alsa_device
+        return f'hw:{self._device_id},0'
+
+    def _spawn_arecord(self) -> Optional[subprocess.Popen]:
+        cmd = [
+            'arecord',
+            '-q',
+            '-D', self._resolve_device(),
+            '-f', 'S16_LE',
+            '-r', str(self._sample_rate),
+            '-c', str(self._channels),
+            '-t', 'raw',
+        ]
+        try:
+            proc = self._popen_factory(cmd, stdout=subprocess.PIPE)
+            self.get_logger().info('Spawned arecord: %s' % ' '.join(cmd))
+            return proc
+        except FileNotFoundError:
+            self.get_logger().error('arecord not found. Install `alsa-utils`.')
+        except Exception as exc:
+            self.get_logger().error(f'Failed to start arecord: {exc}')
+        return None
+
+    def _reader_loop(self) -> None:
+        backoff = 0.5
+        while not self._stop_evt.is_set():
+            if self._proc is None or self._proc.poll() is not None:
+                self._proc = self._spawn_arecord()
+                if self._proc is None:
+                    time.sleep(min(backoff, 5.0))
+                    backoff = min(backoff * 2, 5.0)
+                    continue
+                backoff = 0.5
+                if self._stop_evt.is_set():
+                    break
+
+            assert self._proc.stdout is not None
             try:
+                data = self._proc.stdout.read(self._chunk_size)
+            except Exception as exc:
+                self.get_logger().error(f'Error reading from arecord: {exc}')
+                self._restart_process()
+                time.sleep(0.5)
+                continue
+
+            if self._stop_evt.is_set():
+                break
+
+            if not data:
+                self.get_logger().warning('arecord produced no data; restarting...')
+                self._restart_process()
+                time.sleep(0.2)
+                continue
+
+            try:
+                msg = ByteMultiArray()
+                msg.data = bytes(data)
+                self.audio_pub.publish(msg)
                 self._frames_published += 1
-            except Exception:
-                # best-effort increment; don't let metric bookkeeping crash the callback
-                pass
-            # Record buffer size and timing diagnostics
-            try:
-                now = time.time()
-                self._prev_callback_time = self._last_callback_time
-                self._last_callback_time = now
-                # compute frames received from bytes (16-bit samples)
-                bytes_per_sample = 2  # paInt16
-                frames_received = 0
-                try:
-                    frames_received = int(len(in_data) // (self.channels * bytes_per_sample))
-                except Exception:
-                    frames_received = 0
-                self._last_frames_received = frames_received
-            except Exception:
-                pass
-        except Exception as e:
-            # Log publish errors but continue the stream
-            try:
-                self.get_logger().error(f'Failed to publish audio frame: {type(e).__name__}: {e}')
-            except Exception:
-                pass
+            except Exception as exc:
+                self.get_logger().error(f'Failed to publish audio frame: {exc}')
 
-        return (in_data, pyaudio.paContinue)
+        self._cleanup_process()
 
+    def _restart_process(self) -> None:
+        if self._proc is None:
+            return
+        with suppress(Exception):
+            if self._proc.poll() is None:
+                self._proc.terminate()
+        with suppress(Exception):
+            if self._proc.stdout:
+                self._proc.stdout.close()
+        self._proc = None
+
+    def _cleanup_process(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        with suppress(Exception):
+            if proc.poll() is None:
+                proc.terminate()
+        with suppress(Exception):
+            if proc.poll() is None:
+                proc.kill()
+        with suppress(Exception):
+            if proc.stdout:
+                proc.stdout.close()
+
+    # ------------------------------------------------------------------
+    # Diagnostics
     def _heartbeat(self) -> None:
-        """Periodic heartbeat to show publishing progress and detect stalls."""
         now = time.time()
-        elapsed = now - self._last_heartbeat if self._last_heartbeat else 0.0
-        frames = getattr(self, '_frames_published', 0)
+        elapsed = now - self._last_heartbeat
+        frames = self._frames_published
         delta = frames - getattr(self, '_last_frames', 0)
         rate = (delta / elapsed) if elapsed > 0 else 0.0
+        self._last_frames = frames
+        self._last_heartbeat = now
         try:
-            # Include callback/frame diagnostics when available
-            frames_received = getattr(self, '_last_frames_received', 0)
-            overflow = getattr(self, '_overflow_count', 0)
-            cb_interval = None
-            try:
-                if self._prev_callback_time and self._last_callback_time:
-                    cb_interval = self._last_callback_time - self._prev_callback_time
-            except Exception:
-                cb_interval = None
-
-            extra = f' frames_received={frames_received} overflows={overflow}'
-            if cb_interval:
-                extra += f' cb_interval={cb_interval:.3f}s'
-
             self.get_logger().info(
-                f'heartbeat: total_frames={frames} frames_in_last={delta} rate={rate:.2f}fps elapsed={elapsed:.1f}s' + extra
+                f'heartbeat: total_frames={frames} frames_in_last={delta} '
+                f'rate={rate:.2f}fps elapsed={elapsed:.1f}s'
             )
         except Exception:
             pass
-        # Debug: log PyAudio stream state to help diagnose callback stoppage
-        try:
-            if getattr(self, 'stream', None) is None:
-                self.get_logger().warning('heartbeat: stream is None')
-            else:
-                try:
-                    active = bool(self.stream.is_active())
-                    stopped = bool(self.stream.is_stopped())
-                    self.get_logger().debug(f'heartbeat: stream active={active} stopped={stopped}')
-                except Exception as e:
-                    self.get_logger().warning(f'heartbeat: failed to query stream state: {e}')
-        except Exception:
-            pass
 
-        # Stall detection and simple auto-restart of stream
-        try:
-            if delta == 0:
-                self._stall_count += 1
-            else:
-                self._stall_count = 0
-
-            # If we've seen two consecutive empty intervals, attempt to restart the stream
-            if self._stall_count >= 2:
-                try:
-                    self.get_logger().warning(
-                        f'No audio frames for {self._stall_count * int(elapsed)}s (delta=0); attempting stream restart'
-                    )
-                except Exception:
-                    pass
-
-                # Attempt a safe restart: stop/close existing stream then reopen
-                try:
-                    if getattr(self, 'stream', None) is not None:
-                        with suppress(Exception):
-                            if self.stream.is_active():
-                                self.stream.stop_stream()
-                        with suppress(Exception):
-                            self.stream.close()
-                        self.stream = None
-                except Exception:
-                    pass
-
-                # Try to (re)open the capture stream
-                try:
-                    # start_capture is safe to call multiple times; it will set stream
-                    self.start_capture()
-                except Exception as e:
-                    try:
-                        self.get_logger().error(f'Stream restart failed: {e}')
-                    except Exception:
-                        pass
-
-                # reset stall counter to avoid aggressive restart loop
-                self._stall_count = 0
-        except Exception:
-            pass
-        self._last_heartbeat = now
-        self._last_frames = frames
-
-    def shutdown(self) -> None:
-        """Clean shutdown of audio stream."""
-        self.running = False
-        if self.stream:
-            self.stream.stop_stream()
-            self.stream.close()
-        self.audio.terminate()
-        self.get_logger().info('Audio stream stopped')
-
+    # ------------------------------------------------------------------
+    # Shutdown
     def destroy_node(self) -> None:
-        """Override to ensure clean shutdown."""
-        self.shutdown()
-        super().destroy_node()
+        self._stop_evt.set()
+        if self._reader_thread.is_alive():
+            with suppress(Exception):
+                self._reader_thread.join(timeout=3)
+        self._cleanup_process()
+        return super().destroy_node()
 
 
-def main(args=None):
+def main(args: Optional[Sequence[str]] = None) -> None:  # pragma: no cover - requires ROS
+    if rclpy is None:
+        raise RuntimeError('rclpy is required to run PyAudioEarNode')
+
     rclpy.init(args=args)
-    
+    node = PyAudioEarNode()
     try:
-        node = PyAudioEarNode()
         rclpy.spin(node)
     except KeyboardInterrupt:
         pass
-    except Exception as e:
-        print(f'Error: {e}')
     finally:
-        if 'node' in locals():
-            node.shutdown()
+        node.destroy_node()
         rclpy.shutdown()
 
 
-if __name__ == '__main__':
-    main()
+__all__ = ['PyAudioEarNode', 'main', 'ByteMultiArray']

--- a/modules/ear/packages/ear/setup.py
+++ b/modules/ear/packages/ear/setup.py
@@ -13,7 +13,6 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'pyaudio',
         'webrtcvad',
         'numpy',
         'faster-whisper>=1.0.0',
@@ -22,7 +21,7 @@ setup(
     zip_safe=True,
     maintainer='Psyched',
     maintainer_email='tdreed@gmail.com',
-    description='PyAudio-based microphone capture and silence monitoring nodes',
+    description='ALSA-based microphone capture and silence monitoring nodes',
     license='MIT',
     tests_require=['pytest'],
     entry_points={

--- a/modules/ear/packages/ear/tests/test_pyaudio_ear_node.py
+++ b/modules/ear/packages/ear/tests/test_pyaudio_ear_node.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from pathlib import Path
+import sys
+from typing import Callable, Deque, Iterable, List, Sequence
+
+package_root = Path(__file__).resolve().parents[1]
+if str(package_root) not in sys.path:
+    sys.path.insert(0, str(package_root))
+
+from ear.pyaudio_ear_node import ByteMultiArray, PyAudioEarNode
+
+
+class _FakeStdout:
+    """Minimal file-like object returning predetermined audio chunks."""
+
+    def __init__(self, stop_ref: List[threading.Event], chunks: Iterable[bytes]) -> None:
+        self._stop_ref = stop_ref
+        self._chunks: Deque[bytes] = deque(chunks)
+
+    def read(self, size: int) -> bytes:
+        if self._chunks:
+            return self._chunks.popleft()
+        if self._stop_ref and self._stop_ref[0].wait(0.05):
+            return b""
+        time.sleep(0.01)
+        return b""
+
+    def close(self) -> None:  # pragma: no cover - compatibility shim
+        pass
+
+
+class _FakeProcess:
+    """Subprocess stand-in exposing the subset used by the node."""
+
+    def __init__(self, stdout: _FakeStdout) -> None:
+        self.stdout = stdout
+        self._terminated = False
+
+    def poll(self) -> int | None:
+        return 0 if self._terminated else None
+
+    def terminate(self) -> None:
+        self._terminated = True
+
+    def kill(self) -> None:
+        self._terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._terminated = True
+        return 0
+
+
+class _RecordingFactory:
+    """Capture the commands issued to ``subprocess.Popen``."""
+
+    def __init__(self, stop_ref: List[threading.Event], chunks: Sequence[bytes]) -> None:
+        self.commands: List[Sequence[str]] = []
+        self._stop_ref = stop_ref
+        self._chunks = chunks
+
+    def __call__(self, cmd: Sequence[str], **_: object) -> _FakeProcess:
+        self.commands.append(tuple(cmd))
+        return _FakeProcess(_FakeStdout(self._stop_ref, self._chunks))
+
+
+def _create_node(
+    *,
+    overrides: dict[str, object] | None = None,
+    factory_builder: Callable[[List[threading.Event]], Callable[..., _FakeProcess]] | None = None,
+) -> PyAudioEarNode:
+    """Helper constructing a node with deterministic subprocess behaviour."""
+
+    stop_ref: List[threading.Event] = []
+
+    if factory_builder is None:
+        chunks = (b"\x01\x02\x03\x04", b"")
+        recording_factory = _RecordingFactory(stop_ref, chunks)
+        factory = recording_factory
+    else:
+        recording_factory = factory_builder(stop_ref)
+        factory = recording_factory
+
+    node = PyAudioEarNode(
+        popen_factory=factory,
+        parameter_overrides=overrides or {},
+    )
+    stop_ref.append(node._stop_evt)  # type: ignore[attr-defined]
+    node._factory = recording_factory  # type: ignore[attr-defined]
+    return node
+
+
+def test_arecord_node_publishes_audio_frames() -> None:
+    """Chunks from arecord should be forwarded to ``/audio/raw``."""
+    node = _create_node()
+    publisher = node.audio_pub  # type: ignore[attr-defined]
+
+    for _ in range(50):
+        if getattr(publisher, "published", []):
+            break
+        time.sleep(0.02)
+
+    assert publisher.published, "expected at least one published frame"
+    first = publisher.published[0]
+    assert isinstance(first, ByteMultiArray)
+    assert first.data == b"\x01\x02\x03\x04"
+
+    node.destroy_node()
+
+
+def test_arecord_node_uses_device_id_for_hw_mapping() -> None:
+    """An integer ``device_id`` should resolve to ``hw:<id>,0`` for ALSA."""
+
+    def build_factory(stop_ref: List[threading.Event]) -> _RecordingFactory:
+        return _RecordingFactory(stop_ref, (b"\x00\x00", b""))
+
+    node = _create_node(overrides={"device_id": 3, "channels": 2}, factory_builder=build_factory)
+    factory = getattr(node, "_factory")
+    assert factory is not None
+
+    for _ in range(50):
+        if factory.commands:
+            break
+        time.sleep(0.02)
+
+    assert factory.commands, "arecord should have been spawned"
+    cmd = factory.commands[0]
+    assert "arecord" in cmd[0]
+    assert "-D" in cmd
+    device_index = cmd.index("-D") + 1
+    assert cmd[device_index] == "hw:3,0"
+    channel_index = cmd.index("-c") + 1
+    assert cmd[channel_index] == "2"
+
+    node.destroy_node()


### PR DESCRIPTION
## Summary
- replace the PyAudio microphone node with an ALSA/arecord-backed publisher that restarts safely when the subprocess stalls
- add unit coverage for the new reader to ensure /audio/raw publishing and device mapping continue to work
- update documentation and dependencies to drop PyAudio and reflect the ALSA capture flow

## Testing
- pytest modules/ear/packages/ear/tests

------
https://chatgpt.com/codex/tasks/task_e_68dc2a07e1dc83209617dbba4430d461