### PR TITLE
Add Docker-based ROS Rust binding generation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,20 +1,23 @@
+[patch.crates-io.std_msgs]
+path = "vendor_msgs/std_msgs"
+
 [patch.crates-io.trajectory_msgs]
-path = "/home/pete/psyched/install/share/trajectory_msgs/rust"
+path = "vendor_msgs/trajectory_msgs"
 
 [patch.crates-io.sensor_msgs]
-path = "/home/pete/psyched/install/share/sensor_msgs/rust"
+path = "vendor_msgs/sensor_msgs"
 
 [patch.crates-io.nav_msgs]
-path = "/home/pete/psyched/install/share/nav_msgs/rust"
+path = "vendor_msgs/nav_msgs"
 
 [patch.crates-io.geometry_msgs]
-path = "/home/pete/psyched/install/share/geometry_msgs/rust"
+path = "vendor_msgs/geometry_msgs"
 
 [patch.crates-io.diagnostic_msgs]
-path = "/home/pete/psyched/install/share/diagnostic_msgs/rust"
+path = "vendor_msgs/diagnostic_msgs"
 
 [patch.crates-io.actionlib_msgs]
-path = "/home/pete/psyched/install/share/actionlib_msgs/rust"
+path = "vendor_msgs/actionlib_msgs"
 
 [patch.crates-io.shape_msgs]
-path = "/home/pete/psyched/install/share/shape_msgs/rust"
+path = "vendor_msgs/shape_msgs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Always prefer running the smallest relevant command set.
 
 - **Lockfile drift:** `deno.lock` enforces lockfile version ≥5. Older Deno releases will fail with “unsupported lockfile version”. Upgrade Deno or regenerate the lock.
 - **ROS distro mismatch:** Scripts default to the custom `kilted` distro name. Override with `ROS_DISTRO=<distro>` before running `psh env` if you target `humble`/`jazzy`.
+- **Vendored ROS bindings:** `tools/bootstrap/generate_ros_rust_bindings.sh` runs after ROS provisioning to populate `vendor_msgs/`. It requires Docker; rerun it manually if provisioning skipped the step.
 - **Symlink overlays:** Deleting `modules/*/pilot` symlinks manually breaks the Fresh app. Always re-run `psh mod setup <module>`.
 - **Background processes:** Launch scripts spawn long-lived processes (`cargo run`, `deno task`). Ensure traps stop them (`modules/pilot/launch_unit.sh` shows the pattern).
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ Before starting the stack, ensure `/usr/share/ollama/.ollama` exists on the host
 
 ## Development workflows
 
+### Vendored ROS Rust bindings
+
+Provisioning invokes `tools/bootstrap/generate_ros_rust_bindings.sh` after the ROS apt packages finish installing. The helper spins up a temporary Docker builder for `ros-${ROS_DISTRO:-kilted}-ros-base`, runs `colcon build` with `rosidl_generator_rs`, and copies the resulting crates into `vendor_msgs/`. Cargo is configured to patch common message crates (e.g. `std_msgs`, `sensor_msgs`) to those vendored copies so Rust builds no longer depend on a local colcon workspace.
+
+If Docker was unavailable during provisioning—or you switch `ROS_DISTRO` later—rerun the script manually:
+
+```bash
+ROS_DISTRO=${ROS_DISTRO:-kilted} tools/bootstrap/generate_ros_rust_bindings.sh
+```
+
+The command refreshes the crates in `vendor_msgs/` and prints warnings for any package that fails to build. Commit the updated directories when upstream interface definitions change.
+
 ### Rust + ROS backend
 
 - Build everything: `cargo build --workspace`

--- a/tools/bootstrap/generate_ros_rust_bindings.sh
+++ b/tools/bootstrap/generate_ros_rust_bindings.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# generate_ros_rust_bindings.sh - Build ROS 2 Rust message crates inside Docker and
+# vendor them into the repository so Cargo patches resolve locally.
+#
+# This script intentionally keeps the host environment lean: we only require Docker
+# and the ROS apt repos installed by install_ros2.sh. The heavy lifting happens in a
+# throwaway container that installs rosidl_generator_rs, builds the desired message
+# packages with colcon, and copies their generated `rust/` crates into vendor_msgs/.
+#
+# Usage:
+#   ./generate_ros_rust_bindings.sh        # uses ROS_DISTRO (defaults to kilted)
+#   ROS_DISTRO=jazzy ./generate_ros_rust_bindings.sh
+#
+# The script is idempotent: it clears any previous vendor_msgs/<pkg> directory before
+# copying in the freshly generated crate. If Docker is unavailable, the script emits
+# a warning and exits successfully so provisioning can continue.
+
+set -euo pipefail
+
+ROS_DISTRO=${ROS_DISTRO:-kilted}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+VENDOR_DIR="${REPO_ROOT}/vendor_msgs"
+PACKAGES=(
+  actionlib_msgs
+  diagnostic_msgs
+  geometry_msgs
+  nav_msgs
+  sensor_msgs
+  shape_msgs
+  std_msgs
+  trajectory_msgs
+)
+
+log() {
+  printf '[ros-rust-bindings] %s\n' "$*"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  log "Docker is not available; skipping ROS Rust binding generation."
+  log "Install Docker and re-run this script to vendor std_msgs and related crates."
+  exit 0
+fi
+
+mkdir -p "${VENDOR_DIR}"
+
+BUILD_CONTEXT=$(mktemp -d)
+OUTPUT_DIR=$(mktemp -d)
+trap 'rm -rf "${BUILD_CONTEXT}" "${OUTPUT_DIR}"' EXIT
+
+cat <<'DOCKERFILE' >"${BUILD_CONTEXT}/Dockerfile"
+ARG ROS_DISTRO=kilted
+FROM ros:${ROS_DISTRO}-ros-base
+ARG ROS_DISTRO
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      git \
+      curl \
+      build-essential \
+      python3-colcon-common-extensions \
+      ros-${ROS_DISTRO}-rosidl-generator-rust \
+      ros-${ROS_DISTRO}-rosidl-typesupport-rust \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain for rosidl_generator_rs (minimal profile).
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH=/root/.cargo/bin:${PATH}
+
+WORKDIR /root/ws/src
+RUN git clone --branch ${ROS_DISTRO} --depth 1 https://github.com/ros2/common_interfaces.git \
+    && git clone --branch ${ROS_DISTRO} --depth 1 https://github.com/ros2/rosidl_rust.git
+
+WORKDIR /root/ws
+RUN bash -lc 'source /opt/ros/${ROS_DISTRO}/setup.bash \
+  && colcon build --symlink-install --merge-install \
+  --packages-up-to actionlib_msgs diagnostic_msgs geometry_msgs nav_msgs sensor_msgs shape_msgs std_msgs trajectory_msgs \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release'
+DOCKERFILE
+
+IMAGE_TAG="psyched/ros-rust-bindings:${ROS_DISTRO}"
+log "Building Docker image ${IMAGE_TAG} with ROS_DISTRO=${ROS_DISTRO}..."
+docker build --build-arg ROS_DISTRO="${ROS_DISTRO}" -t "${IMAGE_TAG}" "${BUILD_CONTEXT}"
+
+log "Extracting generated Rust crates for ${PACKAGES[*]}..."
+docker run --rm \
+  -e ROS_DISTRO="${ROS_DISTRO}" \
+  -v "${OUTPUT_DIR}:/out" \
+  "${IMAGE_TAG}" \
+  bash -lc 'set -euo pipefail; \
+    shopt -s nullglob; \
+    for rust_dir in /root/ws/install/share/*/rust; do \
+      pkg=$(basename "$(dirname "${rust_dir}")"); \
+      mkdir -p "/out/${pkg}"; \
+      cp -R "${rust_dir}/." "/out/${pkg}/"; \
+    done'
+
+log "Copying crates into ${VENDOR_DIR}..."
+for pkg in "${PACKAGES[@]}"; do
+  src_pkg_dir="${OUTPUT_DIR}/${pkg}"
+  if [[ ! -d "${src_pkg_dir}" ]]; then
+    log "Warning: package ${pkg} was not produced by the container build."
+    continue
+  fi
+  rm -rf "${VENDOR_DIR}/${pkg}"
+  mkdir -p "${VENDOR_DIR}/${pkg}"
+  cp -R "${src_pkg_dir}/." "${VENDOR_DIR}/${pkg}/"
+  log "Vendored ${pkg} into vendor_msgs/${pkg}."
+done
+
+log "ROS Rust bindings refreshed successfully."

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -13,6 +13,7 @@
 set -euo pipefail
 
 ROS_DISTRO=${ROS_DISTRO:-kilted}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 SUDO=(sudo)
 if [[ $(id -u) -eq 0 ]]; then
@@ -79,3 +80,8 @@ PROFILE
 
 echo "ROS 2 ${ROS_DISTRO} installation completed with Cyclone DDS as the default RMW."
 echo "Source /opt/ros/${ROS_DISTRO}/setup.bash to begin using ROS 2."
+
+GENERATE_SCRIPT="${SCRIPT_DIR}/generate_ros_rust_bindings.sh"
+if ! "${GENERATE_SCRIPT}"; then
+  echo "Warning: failed to vendor ROS Rust message crates. Re-run ${GENERATE_SCRIPT} once Docker is available." >&2
+fi

--- a/vendor_msgs/README.md
+++ b/vendor_msgs/README.md
@@ -1,0 +1,11 @@
+# Vendored ROS 2 Rust message crates
+
+The provisioning flow generates Rust bindings for ROS 2 message packages (e.g. `std_msgs`, `sensor_msgs`) using `rosidl_generator_rs` inside a Docker builder. The resulting crates are copied into this directory so Cargo patches resolve without depending on system-wide colcon workspaces.
+
+Run `tools/bootstrap/generate_ros_rust_bindings.sh` whenever you update `ROS_DISTRO` or need to refresh the bindings:
+
+```bash
+ROS_DISTRO=${ROS_DISTRO:-kilted} tools/bootstrap/generate_ros_rust_bindings.sh
+```
+
+The script overwrites the package folders below with the freshly generated crates. Commit the updated contents when synchronizing with upstream ROS 2 interface changes.


### PR DESCRIPTION
## Summary
- add a Docker-backed helper that vendors ROS 2 Rust message crates into `vendor_msgs/`
- invoke the helper from the ROS provisioning script and document the requirement
- update Cargo patches and docs so builds resolve the vendored crates

## Testing
- bash -n tools/bootstrap/generate_ros_rust_bindings.sh

------
https://chatgpt.com/codex/tasks/task_e_68dea4ec54c48320baff85af1e5b82d2