### PR TITLE
feat: modernize foot telemetry panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ Always prefer running the smallest relevant command set.
 - **ROS distro mismatch:** Scripts default to the custom `kilted` distro name. Override with `ROS_DISTRO=<distro>` before running `psh env` if you target `humble`/`jazzy`.
 - **Symlink overlays:** Deleting `modules/*/pilot` symlinks manually breaks the Fresh app. Always re-run `psh mod setup <module>`.
 - **Background processes:** Launch scripts spawn long-lived processes (`cargo run`, `deno task`). Ensure traps stop them (`modules/pilot/launch_unit.sh` shows the pattern).
+- **ROS message crates:** Rust binaries expect generated message crates under `install/share/<pkg>/rust`. Run the relevant `colcon build` step (e.g. via `psh mod setup`) before invoking `cargo fmt`/`cargo check` so `create_msgs`, `geometry_msgs`, etc. are discoverable.
 
 ## Useful references
 

--- a/modules/foot/pilot/components/FootControlPanel.tsx
+++ b/modules/foot/pilot/components/FootControlPanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   useCallback,
   useEffect,
@@ -8,13 +7,56 @@ import {
 } from "preact/hooks";
 import { type ConnectionStatus, useCockpitTopic } from "@pilot/lib/cockpit.ts";
 
-type FootStatus = {
-  batteryPct?: number | null;
-  docked?: boolean;
-  mode?: string;
-  lastCommand?: string;
-  lastUpdate?: string;
-  faults?: string[];
+type Vector3 = { x: number; y: number; z: number };
+
+type TwistPayload = {
+  linear: Vector3;
+  angular: Vector3;
+};
+
+type TwistSummary = {
+  linear_x: number;
+  linear_y: number;
+  linear_z: number;
+  angular_x: number;
+  angular_y: number;
+  angular_z: number;
+};
+
+type FootTelemetrySnapshot = {
+  battery?: {
+    percentage?: number;
+    charge_ratio?: number;
+    charge_ah?: number;
+    capacity_ah?: number;
+    current_a?: number;
+    voltage_v?: number;
+    temperature_c?: number;
+    charging_state?: string;
+    is_charging?: boolean;
+  };
+  status?: {
+    mode?: string;
+    mode_code?: number;
+    charging_state?: string;
+    charging_state_code?: number;
+    last_command_ms?: number;
+  };
+  motion?: {
+    command?: TwistSummary;
+    odometry?: TwistSummary;
+  };
+  hazards?: {
+    bumper_left?: boolean;
+    bumper_right?: boolean;
+    bumper_light_front?: boolean;
+    bumper_light_center?: boolean;
+    cliff_left?: boolean;
+    cliff_front_left?: boolean;
+    cliff_right?: boolean;
+    cliff_front_right?: boolean;
+  };
+  last_update_ms?: number;
 };
 
 const STATUS_LABELS: Record<ConnectionStatus, string> = {
@@ -25,98 +67,82 @@ const STATUS_LABELS: Record<ConnectionStatus, string> = {
   error: "Error",
 };
 
-const DEFAULT_STATUS: FootStatus = {
-  batteryPct: null,
-  docked: false,
-  mode: "standby",
-  lastCommand: "—",
-  lastUpdate: undefined,
-  faults: [],
-};
-
-type Vector3 = {
-  x: number;
-  y: number;
-  z: number;
-};
-
-type Twist = {
-  linear: Vector3;
-  angular: Vector3;
-};
-
-const ZERO_TWIST: Twist = {
+const ZERO_TWIST: TwistPayload = {
   linear: { x: 0, y: 0, z: 0 },
   angular: { x: 0, y: 0, z: 0 },
 };
 
-const MAX_LINEAR_X = 0.45; // m/s
-const MAX_ANGULAR_Z = 1.2; // rad/s
+const MAX_LINEAR_X = 0.5; // m/s
+const MAX_ANGULAR_Z = 4.25; // rad/s
 
 const clamp = (value: number, min = -1, max = 1) =>
   Math.min(max, Math.max(min, value));
 
 export default function FootControlPanel() {
   const {
-    status,
-    data: statusPayload = DEFAULT_STATUS,
-    error,
-    publish,
-  } = useCockpitTopic<FootStatus>("/foot/status", {
+    status: telemetryStatus,
+    data: telemetry,
+    error: telemetryError,
+  } = useCockpitTopic<FootTelemetrySnapshot>("/foot/telemetry", {
     replay: true,
-    initialValue: DEFAULT_STATUS,
+    initialValue: {},
   });
 
   const {
     status: cmdVelStatus,
     data: currentTwist = ZERO_TWIST,
     publish: publishCmdVel,
-  } = useCockpitTopic<Twist>("/cmd_vel", {
+  } = useCockpitTopic<TwistPayload>("/cmd_vel", {
     replay: true,
     initialValue: ZERO_TWIST,
   });
 
-  const connectionLabel = STATUS_LABELS[status] ?? "Unknown";
-  const badgeVariant = STATUS_LABELS[status] ? status : "idle";
-  const cmdVelLabel = STATUS_LABELS[cmdVelStatus] ?? "Unknown";
-  const cmdVelBadgeVariant = STATUS_LABELS[cmdVelStatus]
-    ? cmdVelStatus
+  const connectionLabel = STATUS_LABELS[telemetryStatus] ?? "Unknown";
+  const telemetryBadgeVariant = STATUS_LABELS[telemetryStatus]
+    ? telemetryStatus
     : "idle";
+  const cmdVelLabel = STATUS_LABELS[cmdVelStatus] ?? "Unknown";
+  const cmdVelBadgeVariant = STATUS_LABELS[cmdVelStatus] ? cmdVelStatus : "idle";
 
-  const formattedBattery = useMemo(() => {
-    const pct = statusPayload.batteryPct;
-    if (pct === undefined || pct === null) return "—";
-    return `${pct.toFixed(0)}%`;
-  }, [statusPayload.batteryPct]);
+  const batteryPercentage = telemetry?.battery?.percentage ?? null;
+  const batteryRatio = useMemo(() => {
+    const ratio = telemetry?.battery?.charge_ratio;
+    if (typeof ratio === "number" && Number.isFinite(ratio)) {
+      return clamp(ratio, 0, 1);
+    }
+    if (typeof batteryPercentage === "number" && Number.isFinite(batteryPercentage)) {
+      return clamp(batteryPercentage / 100, 0, 1);
+    }
+    return null;
+  }, [telemetry?.battery?.charge_ratio, batteryPercentage]);
 
-  const formattedTimestamp = useMemo(() => {
-    const timestamp = statusPayload.lastUpdate;
-    if (!timestamp) return "Awaiting telemetry";
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) return timestamp;
-    return date.toLocaleTimeString();
-  }, [statusPayload.lastUpdate]);
-
-  const faults = statusPayload.faults ?? [];
-
-  const handleCommand = useCallback(
-    (command: string) => () => {
-      publish({
-        ...statusPayload,
-        lastCommand: command,
-        lastUpdate: new Date().toISOString(),
-      });
-    },
-    [publish, statusPayload],
+  const batteryStats = useMemo(
+    () => [
+      { label: "V", value: formatNumber(telemetry?.battery?.voltage_v, 1) },
+      { label: "A", value: formatNumber(telemetry?.battery?.current_a, 2) },
+      {
+        label: "°C",
+        value: formatNumber(telemetry?.battery?.temperature_c, 0),
+      },
+    ],
+    [telemetry?.battery?.voltage_v, telemetry?.battery?.current_a, telemetry?.battery?.temperature_c],
   );
 
-  type StickPosition = { x: number; y: number };
+  const modeLabel = telemetry?.status?.mode ?? "—";
+  const chargingLabel =
+    telemetry?.status?.charging_state ?? telemetry?.battery?.charging_state ?? "—";
+  const lastCommandLabel = formatRelativeMillis(
+    telemetry?.status?.last_command_ms,
+  );
+  const lastUpdateLabel = formatRelativeMillis(telemetry?.last_update_ms);
 
+  const commanded = telemetry?.motion?.command;
+  const odometry = telemetry?.motion?.odometry;
+  const hazards = telemetry?.hazards ?? {};
+
+  type StickPosition = { x: number; y: number };
   const joystickRef = useRef<HTMLDivElement | null>(null);
-  const [stickPosition, setStickPosition] = useState<StickPosition>({
-    x: 0,
-    y: 0,
-  });
+  const [stickPosition, setStickPosition] = useState<StickPosition>({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const activePointerId = useRef<number | null>(null);
 
@@ -124,12 +150,17 @@ export default function FootControlPanel() {
     (normX: number, normY: number) => {
       const linearX = clamp(-normY, -1, 1) * MAX_LINEAR_X;
       const angularZ = clamp(normX, -1, 1) * MAX_ANGULAR_Z;
-      const roundedLinearX = Number(linearX.toFixed(3));
-      const roundedAngularZ = Number(angularZ.toFixed(3));
-
       publishCmdVel({
-        linear: { x: roundedLinearX, y: 0, z: 0 },
-        angular: { x: 0, y: 0, z: roundedAngularZ },
+        linear: {
+          x: Number(linearX.toFixed(3)),
+          y: 0,
+          z: 0,
+        },
+        angular: {
+          x: 0,
+          y: 0,
+          z: Number(angularZ.toFixed(3)),
+        },
       });
     },
     [publishCmdVel],
@@ -139,14 +170,12 @@ export default function FootControlPanel() {
     (clientX: number, clientY: number) => {
       const pad = joystickRef.current;
       if (!pad) return;
-
       const rect = pad.getBoundingClientRect();
       const rawX = (clientX - rect.left) / rect.width;
       const rawY = (clientY - rect.top) / rect.height;
 
       let normX = rawX * 2 - 1;
       let normY = rawY * 2 - 1;
-
       const magnitude = Math.hypot(normX, normY);
       if (magnitude > 1) {
         normX /= magnitude;
@@ -168,7 +197,6 @@ export default function FootControlPanel() {
     (event: PointerEvent) => {
       const pad = joystickRef.current;
       if (!pad) return;
-
       pad.setPointerCapture(event.pointerId);
       activePointerId.current = event.pointerId;
       setIsDragging(true);
@@ -223,14 +251,13 @@ export default function FootControlPanel() {
 
   useEffect(() => {
     if (isDragging) return;
-
     const { linear, angular } = currentTwist;
     const derivedX = clamp(angular.z / MAX_ANGULAR_Z);
     const derivedY = clamp(-linear.x / MAX_LINEAR_X);
-
     setStickPosition((prev) => {
       if (
-        Math.abs(prev.x - derivedX) < 0.01 && Math.abs(prev.y - derivedY) < 0.01
+        Math.abs(prev.x - derivedX) < 0.01 &&
+        Math.abs(prev.y - derivedY) < 0.01
       ) {
         return prev;
       }
@@ -253,78 +280,178 @@ export default function FootControlPanel() {
   );
 
   return (
-    <article class="foot-panel">
+    <article class="foot-panel foot-panel--lcars">
       <header class="foot-panel__header">
-        <div>
-          <h1 class="foot-panel__title">Drive base</h1>
-          <p class="foot-panel__description">
-            Monitor the Create robot state and dispatch high level commands.
-          </p>
+        <div class="foot-panel__heading">
+          <span class="foot-panel__heading-accent" aria-hidden="true" />
+          <div>
+            <h1 class="foot-panel__title">Create base</h1>
+            <p class="foot-panel__description">
+              Compact drive, power, and hazard console for Pete&apos;s drivetrain.
+            </p>
+          </div>
         </div>
-        <span class={`foot-panel__badge foot-panel__badge--${badgeVariant}`}>
-          {connectionLabel}
-        </span>
+        <div class="foot-panel__status-chips">
+          <span class={`foot-panel__badge foot-panel__badge--${telemetryBadgeVariant}`}>
+            {connectionLabel}
+          </span>
+          <span class={`foot-panel__badge foot-panel__badge--${cmdVelBadgeVariant}`}>
+            {cmdVelLabel}
+          </span>
+        </div>
       </header>
 
-      <section class="foot-panel__metrics">
-        <div>
-          <h2>Status</h2>
-          <dl>
-            <div>
-              <dt>Battery</dt>
-              <dd>{formattedBattery}</dd>
-            </div>
-            <div>
-              <dt>Mode</dt>
-              <dd>{statusPayload.mode ?? "—"}</dd>
-            </div>
-            <div>
-              <dt>Docked</dt>
-              <dd>{statusPayload.docked ? "Yes" : "No"}</dd>
-            </div>
-            <div>
-              <dt>Last update</dt>
-              <dd>{formattedTimestamp}</dd>
-            </div>
-            <div>
-              <dt>Last command</dt>
-              <dd>{statusPayload.lastCommand ?? "—"}</dd>
-            </div>
-          </dl>
+      <section class="foot-panel__grid">
+        <div class="foot-panel__tile foot-panel__tile--battery">
+          <div class="foot-panel__tile-header">
+            <BatteryIcon level={batteryRatio} />
+            <span>Power</span>
+          </div>
+          <div class="foot-panel__tile-body">
+            <strong class="foot-panel__tile-value">
+              {batteryPercentage === null || batteryPercentage === undefined
+                ? "—"
+                : `${batteryPercentage.toFixed(0)}%`}
+            </strong>
+            <ul class="foot-panel__mini-list">
+              {batteryStats.map(({ label, value }) => (
+                <li key={label}>
+                  <span>{label}</span>
+                  <strong>{value}</strong>
+                </li>
+              ))}
+            </ul>
+            <p class="foot-panel__tile-meta">
+              {chargingLabel}
+              {telemetry?.battery?.is_charging ? " • charging" : ""}
+            </p>
+          </div>
         </div>
 
-        <div>
-          <h2>Faults</h2>
-          {faults.length === 0
-            ? (
-              <p class="foot-panel__fault foot-panel__fault--empty">
-                No reported faults
-              </p>
-            )
-            : (
-              <ul class="foot-panel__fault-list">
-                {faults.map((fault) => <li key={fault}>{fault}</li>)}
-              </ul>
+        <div class="foot-panel__tile foot-panel__tile--status">
+          <div class="foot-panel__tile-header">
+            <StatusIcon />
+            <span>Status</span>
+          </div>
+          <div class="foot-panel__tile-body">
+            <div class="foot-panel__chip-row">
+              <span class="foot-panel__chip">Mode</span>
+              <strong>{modeLabel}</strong>
+            </div>
+            <div class="foot-panel__chip-row">
+              <span class="foot-panel__chip">Cmd</span>
+              <strong>{lastCommandLabel}</strong>
+            </div>
+            <div class="foot-panel__chip-row">
+              <span class="foot-panel__chip">Telemetry</span>
+              <strong>{lastUpdateLabel}</strong>
+            </div>
+            {telemetryError && (
+              <p class="foot-panel__status-note">{telemetryError}</p>
             )}
-          {error && <p class="foot-panel__error">{error}</p>}
+          </div>
+        </div>
+
+        <div class="foot-panel__tile foot-panel__tile--motion">
+          <div class="foot-panel__tile-header">
+            <MotionIcon />
+            <span>Motion</span>
+          </div>
+          <div class="foot-panel__tile-body foot-panel__motion">
+            <div class="foot-panel__motion-row">
+              <span class="foot-panel__chip">cmd</span>
+              <span>{formatNumber(commanded?.linear_x, 2)} m/s</span>
+              <span>{formatNumber(commanded?.angular_z, 2)} rad/s</span>
+            </div>
+            <div class="foot-panel__motion-row">
+              <span class="foot-panel__chip">odom</span>
+              <span>{formatNumber(odometry?.linear_x, 2)} m/s</span>
+              <span>{formatNumber(odometry?.angular_z, 2)} rad/s</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="foot-panel__tile foot-panel__tile--hazards">
+          <div class="foot-panel__tile-header">
+            <HazardIcon />
+            <span>Hazards</span>
+          </div>
+          <div class="foot-panel__tile-body foot-panel__hazards">
+            <div class="foot-panel__hazard-group">
+              <h3>Bumpers</h3>
+              <div class="foot-panel__hazard-dots">
+                <span
+                  class={hazardClass(hazards.bumper_left)}
+                  title="Left bumper"
+                >
+                  L
+                </span>
+                <span
+                  class={hazardClass(hazards.bumper_right)}
+                  title="Right bumper"
+                >
+                  R
+                </span>
+                <span
+                  class={hazardClass(hazards.bumper_light_front)}
+                  title="Front IR"
+                >
+                  F
+                </span>
+                <span
+                  class={hazardClass(hazards.bumper_light_center)}
+                  title="Center IR"
+                >
+                  C
+                </span>
+              </div>
+            </div>
+            <div class="foot-panel__hazard-group">
+              <h3>Cliffs</h3>
+              <div class="foot-panel__hazard-dots">
+                <span class={hazardClass(hazards.cliff_left)} title="Left cliff">
+                  L
+                </span>
+                <span
+                  class={hazardClass(hazards.cliff_front_left)}
+                  title="Front-left cliff"
+                >
+                  FL
+                </span>
+                <span
+                  class={hazardClass(hazards.cliff_front_right)}
+                  title="Front-right cliff"
+                >
+                  FR
+                </span>
+                <span class={hazardClass(hazards.cliff_right)} title="Right cliff">
+                  R
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
       <section class="foot-panel__joystick">
         <header class="foot-panel__joystick-header">
-          <h2>Joystick</h2>
-          <span
-            class={`foot-panel__badge foot-panel__badge--${cmdVelBadgeVariant}`}
+          <div class="foot-panel__tile-header">
+            <JoystickIcon />
+            <span>Manual control</span>
+          </div>
+          <button
+            type="button"
+            class="foot-panel__chip foot-panel__chip--action"
+            onClick={resetStick}
+            title="Stop"
           >
-            {cmdVelLabel}
-          </span>
+            <StopIcon />
+            <span class="sr-only">Stop</span>
+          </button>
         </header>
         <p class="foot-panel__joystick-description">
-          Drag inside the pad to send velocity commands on{" "}
-          <code>/cmd_vel</code>. Vertical motion maps to forward speed
-          (±{MAX_LINEAR_X.toFixed(2)}{" "}
-          m/s). Horizontal motion adjusts angular velocity (±
-          {MAX_ANGULAR_Z.toFixed(1)} rad/s). Releasing the stick sends a stop.
+          Drag the pad to command velocities (±{MAX_LINEAR_X.toFixed(2)} m/s,
+          ±{MAX_ANGULAR_Z.toFixed(2)} rad/s). Release to halt.
         </p>
         <div
           ref={joystickRef}
@@ -352,34 +479,147 @@ export default function FootControlPanel() {
         <dl class="foot-panel__joystick-readout">
           <div>
             <dt>linear.x</dt>
-            <dd>
-              {currentTwist.linear.x.toFixed(2)} m/s
-            </dd>
+            <dd>{currentTwist.linear.x.toFixed(2)} m/s</dd>
           </div>
           <div>
             <dt>angular.z</dt>
-            <dd>
-              {currentTwist.angular.z.toFixed(2)} rad/s
-            </dd>
+            <dd>{currentTwist.angular.z.toFixed(2)} rad/s</dd>
           </div>
         </dl>
       </section>
-
-      <section class="foot-panel__actions">
-        <h2>Manual commands</h2>
-        <p>
-          Dispatch simple motion cues while testing drivetrain integration.
-          These commands mirror the `/foot/status` heartbeat so the backend can
-          echo the most recent operator intent.
-        </p>
-        <div class="foot-panel__buttons">
-          <button type="button" onClick={handleCommand("forward")}>
-            Forward
-          </button>
-          <button type="button" onClick={handleCommand("stop")}>Stop</button>
-          <button type="button" onClick={handleCommand("dock")}>Dock</button>
-        </div>
-      </section>
     </article>
   );
+}
+
+function BatteryIcon({ level }: { level: number | null }) {
+  const clamped = level === null ? 0 : Math.min(1, Math.max(0, level));
+  const width = 36 * clamped;
+  return (
+    <svg viewBox="0 0 48 24" class="foot-panel__icon" aria-hidden="true">
+      <rect
+        x="1"
+        y="4"
+        width="40"
+        height="16"
+        rx="3"
+        class="foot-panel__icon-outline"
+      />
+      <rect
+        x="42"
+        y="9"
+        width="5"
+        height="6"
+        rx="1"
+        class="foot-panel__icon-outline"
+      />
+      <rect
+        x="3"
+        y="6"
+        width={width}
+        height="12"
+        rx="2"
+        class="foot-panel__icon-fill"
+      />
+    </svg>
+  );
+}
+
+function StatusIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="foot-panel__icon" aria-hidden="true">
+      <circle cx="12" cy="12" r="8" class="foot-panel__icon-outline" />
+      <path
+        d="M12 6v6l4 2"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}
+
+function MotionIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="foot-panel__icon" aria-hidden="true">
+      <path
+        d="M4 12h16M12 4v16M16 8l4 4-4 4M8 16l-4-4 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}
+
+function HazardIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="foot-panel__icon" aria-hidden="true">
+      <path
+        d="M12 3 2.5 20.5h19L12 3z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <circle cx="12" cy="16" r="1.5" class="foot-panel__icon-fill" />
+      <path
+        d="M12 9v5"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+function JoystickIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="foot-panel__icon" aria-hidden="true">
+      <circle cx="12" cy="12" r="3" class="foot-panel__icon-fill" />
+      <path
+        d="M12 3v6M12 15v6M3 12h6M15 12h6"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+function StopIcon() {
+  return (
+    <svg viewBox="0 0 16 16" class="foot-panel__icon" aria-hidden="true">
+      <rect x="3" y="3" width="10" height="10" rx="2" />
+    </svg>
+  );
+}
+
+function formatNumber(value?: number | null, fractionDigits = 2) {
+  if (value === undefined || value === null || Number.isNaN(value)) {
+    return "—";
+  }
+  return value.toFixed(fractionDigits);
+}
+
+function formatRelativeMillis(value?: number) {
+  if (!value) return "—";
+  const delta = Date.now() - value;
+  if (delta < 0) return "0s";
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 1) return "<1s";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function hazardClass(active?: boolean) {
+  return `foot-panel__hazard-dot${active ? " foot-panel__hazard-dot--active" : ""}`;
 }

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -247,135 +247,296 @@ body {
 }
 
 .foot-panel {
+  position: relative;
   display: grid;
-  gap: 1.5rem;
-  padding: 1.75rem;
-  background: #161d28;
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  gap: 1.75rem;
+  padding: 1.85rem;
+  background: linear-gradient(135deg, #0f1622, #1b283a);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.foot-panel--lcars::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 15% -10%,
+    rgba(255, 145, 87, 0.14),
+    transparent 55%
+  );
+  pointer-events: none;
+}
+
+.foot-panel--lcars > * {
+  position: relative;
+  z-index: 1;
 }
 
 .foot-panel__header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 1.75rem;
+}
+
+.foot-panel__heading {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.foot-panel__heading-accent {
+  width: 18px;
+  height: 100%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ff9966, #f36f9f);
+  box-shadow: 0 0 20px rgba(255, 153, 102, 0.45);
 }
 
 .foot-panel__title {
   margin: 0;
-  font-size: 1.75rem;
+  font-size: 1.85rem;
+  letter-spacing: 0.08em;
 }
 
 .foot-panel__description {
-  margin-top: 0.25rem;
-  max-width: 60ch;
-  opacity: 0.85;
+  margin: 0.35rem 0 0;
+  max-width: 50ch;
+  opacity: 0.82;
 }
 
-.foot-panel__badge {
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.foot-panel__badge--open {
-  background: rgba(64, 201, 174, 0.2);
-  color: #59f3c9;
-}
-
-.foot-panel__badge--connecting,
-.foot-panel__badge--idle {
-  background: rgba(113, 201, 248, 0.15);
-  color: #71c9f8;
-}
-
-.foot-panel__badge--closed {
-  background: rgba(255, 166, 91, 0.15);
-  color: #ffb16b;
-}
-
-.foot-panel__badge--error {
-  background: rgba(255, 94, 109, 0.18);
-  color: #ff9aa7;
-}
-
-.foot-panel__metrics {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.foot-panel__metrics dl {
-  margin: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.foot-panel__metrics dt {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  opacity: 0.7;
-}
-
-.foot-panel__metrics dd {
-  margin: 0;
-  font-family:
-    "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
-}
-
-.foot-panel__fault-list {
-  margin: 0;
-  padding-left: 1rem;
-}
-
-.foot-panel__fault {
-  margin: 0;
-  opacity: 0.8;
-}
-
-.foot-panel__fault--empty {
-  font-style: italic;
-}
-
-.foot-panel__error {
-  margin-top: 0.75rem;
-  color: #ff9aa7;
-  font-size: 0.9rem;
-}
-
-.foot-panel__actions {
-  display: grid;
-  gap: 1rem;
-}
-
-.foot-panel__buttons {
+.foot-panel__status-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-.foot-panel__buttons button {
-  padding: 0.65rem 1.25rem;
-  border-radius: 0.75rem;
-  border: none;
-  background: linear-gradient(135deg, #37b5f9, #8853ff);
-  color: #fff;
+.foot-panel__badge {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 0.72rem;
   font-weight: 600;
+  letter-spacing: 0.09em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.foot-panel__badge--open {
+  background: rgba(88, 226, 179, 0.2);
+  color: #5ef2c1;
+}
+
+.foot-panel__badge--connecting,
+.foot-panel__badge--idle {
+  background: rgba(113, 201, 248, 0.18);
+  color: #84d8ff;
+}
+
+.foot-panel__badge--closed {
+  background: rgba(255, 166, 91, 0.2);
+  color: #ffc48a;
+}
+
+.foot-panel__badge--error {
+  background: rgba(255, 94, 109, 0.24);
+  color: #ff9aa7;
+}
+
+.foot-panel__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.foot-panel__tile {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(12, 20, 32, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.foot-panel__tile--battery {
+  border-left: 6px solid rgba(255, 153, 102, 0.65);
+}
+
+.foot-panel__tile--status {
+  border-left: 6px solid rgba(94, 210, 178, 0.6);
+}
+
+.foot-panel__tile--motion {
+  border-left: 6px solid rgba(123, 185, 255, 0.65);
+}
+
+.foot-panel__tile--hazards {
+  border-left: 6px solid rgba(255, 118, 157, 0.65);
+}
+
+.foot-panel__tile-header {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.82;
+}
+
+.foot-panel__tile-body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.foot-panel__tile-value {
+  font-size: 2.25rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.foot-panel__mini-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.foot-panel__mini-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.foot-panel__mini-list strong {
+  font-family:
+    "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+.foot-panel__tile-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.foot-panel__status-note {
+  margin: 0;
+  color: #ff9aa7;
+  font-size: 0.85rem;
+}
+
+.foot-panel__chip-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.foot-panel__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.foot-panel__chip--action {
+  background: rgba(255, 153, 102, 0.2);
+  border: 1px solid rgba(255, 153, 102, 0.35);
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.foot-panel__buttons button:hover {
+.foot-panel__chip--action:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 20px rgba(78, 143, 255, 0.35);
+  box-shadow: 0 6px 14px rgba(255, 153, 102, 0.35);
+}
+
+.foot-panel__icon {
+  width: 28px;
+  height: 28px;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.foot-panel__icon-outline {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
+.foot-panel__icon-fill {
+  fill: rgba(255, 153, 102, 0.6);
+}
+
+.foot-panel__motion {
+  display: grid;
+  gap: 0.65rem;
+  font-family:
+    "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+.foot-panel__motion-row {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.foot-panel__hazards {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.foot-panel__hazard-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.foot-panel__hazard-group h3 {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.75;
+}
+
+.foot-panel__hazard-dots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 0.45rem;
+}
+
+.foot-panel__hazard-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  opacity: 0.75;
+}
+
+.foot-panel__hazard-dot--active {
+  background: rgba(255, 118, 157, 0.35);
+  border-color: rgba(255, 118, 157, 0.6);
+  color: #ffd2de;
+  opacity: 1;
 }
 
 .foot-panel__joystick {
@@ -392,31 +553,31 @@ body {
 
 .foot-panel__joystick-description {
   margin: 0;
-  opacity: 0.85;
+  opacity: 0.82;
 }
 
 .foot-panel__joystick-pad {
   position: relative;
-  width: min(240px, 100%);
-  padding-top: min(240px, 100%);
-  border-radius: 1rem;
+  width: min(220px, 100%);
+  padding-top: min(220px, 100%);
+  border-radius: 1.1rem;
   background: radial-gradient(
     circle at center,
-    rgba(136, 83, 255, 0.18),
-    rgba(12, 20, 32, 0.85)
+    rgba(120, 179, 255, 0.22),
+    rgba(9, 14, 24, 0.9)
   );
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 12px 24px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(134, 193, 255, 0.25);
+  box-shadow: inset 0 14px 28px rgba(0, 0, 0, 0.5);
   touch-action: none;
   cursor: grab;
 }
 
 .foot-panel__joystick-pad--active {
   cursor: grabbing;
-  border-color: rgba(103, 212, 255, 0.35);
+  border-color: rgba(134, 193, 255, 0.45);
   box-shadow:
-    inset 0 0 0 1px rgba(103, 212, 255, 0.25),
-    inset 0 12px 28px rgba(0, 0, 0, 0.55);
+    inset 0 0 0 1px rgba(134, 193, 255, 0.35),
+    inset 0 16px 32px rgba(0, 0, 0, 0.6);
 }
 
 .foot-panel__joystick-axis {
@@ -425,7 +586,7 @@ body {
   left: 50%;
   width: 100%;
   height: 1px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(134, 193, 255, 0.18);
   transform: translate(-50%, -50%);
   pointer-events: none;
 }
@@ -441,15 +602,11 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 64px;
-  height: 64px;
+  width: 58px;
+  height: 58px;
   border-radius: 50%;
-  background: linear-gradient(
-    135deg,
-    rgba(113, 201, 248, 0.9),
-    rgba(136, 83, 255, 0.9)
-  );
-  box-shadow: 0 12px 18px rgba(56, 120, 255, 0.35);
+  background: linear-gradient(135deg, rgba(134, 193, 255, 0.95), rgba(86, 136, 255, 0.9));
+  box-shadow: 0 14px 20px rgba(52, 116, 255, 0.32);
   transform: translate(
     calc(-50% + var(--stick-x) * 45%),
     calc(-50% + var(--stick-y) * 45%)
@@ -481,4 +638,16 @@ body {
   font-family:
     "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -13,8 +13,10 @@ axum = { version = "0.7", features = ["ws"] }
 futures = "0.3"
 rclrs = "*"
 std_msgs = { version = "*", path = "../install/share/std_msgs/rust" }
-# geometry_msgs = { version = "*", path = "../install/geometry_msgs/share/geometry_msgs/rust" }
+geometry_msgs = { version = "*", path = "../install/share/geometry_msgs/rust" }
+nav_msgs = { version = "*", path = "../install/share/nav_msgs/rust" }
 sensor_msgs = { version = "*", path = "../install/share/sensor_msgs/rust" }
+create_msgs = { version = "*", path = "../install/share/create_msgs/rust" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/psyched/src/bin/cockpit.rs
+++ b/psyched/src/bin/cockpit.rs
@@ -7,10 +7,11 @@ use axum::{
     serve, Router,
 };
 use futures::{stream::SplitSink, SinkExt, StreamExt};
+use geometry_msgs::msg::{Twist as RosTwist, Vector3 as RosVector3};
 use rclrs::IntoPrimitiveOptions as _;
 use rclrs::{
-    vendor::example_interfaces::msg::String as RosString, sensor_msgs::msg::Imu as RosImu,
-    Context, CreateBasicExecutor, RclReturnCode, RclrsError, SpinOptions,
+    sensor_msgs::msg::Imu as RosImu, vendor::example_interfaces::msg::String as RosString, Context,
+    CreateBasicExecutor, RclReturnCode, RclrsError, SpinOptions,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -64,6 +65,8 @@ enum CockpitError {
     UnsupportedTopic(String),
     #[error("expected string field '{0}'")]
     MissingString(&'static str),
+    #[error("expected field '{0}'")]
+    MissingField(&'static str),
     #[error("ROS bridge offline")]
     BridgeOffline,
     #[error("failed to subscribe to topic '{topic}': {source}")]
@@ -77,6 +80,7 @@ enum CockpitError {
 #[derive(Debug)]
 enum RosCommand {
     PublishConversation(String),
+    PublishCmdVel(RosTwist),
     SubscribeTopic {
         topic: String,
         respond_to: oneshot::Sender<Result<(), CockpitError>>,
@@ -369,8 +373,52 @@ fn convert_pub(topic: &str, msg: serde_json::Value) -> Result<RosCommand, Cockpi
                 .ok_or(CockpitError::MissingString("msg.data"))?;
             Ok(RosCommand::PublishConversation(data.to_owned()))
         }
+        "/cmd_vel" => {
+            let twist = parse_twist(&msg)?;
+            Ok(RosCommand::PublishCmdVel(twist))
+        }
         other => Err(CockpitError::UnsupportedTopic(other.to_owned())),
     }
+}
+
+fn parse_twist(value: &serde_json::Value) -> Result<RosTwist, CockpitError> {
+    let linear = value
+        .get("linear")
+        .ok_or(CockpitError::MissingField("msg.linear"))?;
+    let angular = value
+        .get("angular")
+        .ok_or(CockpitError::MissingField("msg.angular"))?;
+
+    let linear_x = extract_number(linear, "x", "msg.linear.x")?;
+    let linear_y = extract_number(linear, "y", "msg.linear.y")?;
+    let linear_z = extract_number(linear, "z", "msg.linear.z")?;
+    let angular_x = extract_number(angular, "x", "msg.angular.x")?;
+    let angular_y = extract_number(angular, "y", "msg.angular.y")?;
+    let angular_z = extract_number(angular, "z", "msg.angular.z")?;
+
+    Ok(RosTwist {
+        linear: RosVector3 {
+            x: linear_x,
+            y: linear_y,
+            z: linear_z,
+        },
+        angular: RosVector3 {
+            x: angular_x,
+            y: angular_y,
+            z: angular_z,
+        },
+    })
+}
+
+fn extract_number(
+    parent: &serde_json::Value,
+    field: &str,
+    label: &'static str,
+) -> Result<f64, CockpitError> {
+    parent
+        .get(field)
+        .and_then(|value| value.as_f64())
+        .ok_or(CockpitError::MissingField(label))
 }
 
 fn ros_spin(
@@ -382,6 +430,8 @@ fn ros_spin(
     let node = executor.create_node("cockpit")?;
 
     let conversation_publisher = node.create_publisher::<RosString>("/conversation")?;
+    let cmd_vel_publisher = node.create_publisher::<RosTwist>("/cmd_vel")?;
+    let foot_bridge = foot::FootTelemetryBridge::new(&node, ws_outbound.clone())?;
     let mut subscriptions: HashMap<String, SubscriptionEntry> = HashMap::new();
 
     loop {
@@ -403,13 +453,28 @@ fn ros_spin(
                             });
                         }
                     }
+                    RosCommand::PublishCmdVel(twist) => {
+                        if let Err(err) = cmd_vel_publisher.publish(twist.clone()) {
+                            error!(?err, "failed to publish /cmd_vel");
+                            let _ = ws_outbound.send(WsOutbound::Err {
+                                reason: format!("failed to publish to /cmd_vel: {err}"),
+                            });
+                        } else {
+                            foot_bridge.record_command(&twist);
+                        }
+                    }
                     RosCommand::SubscribeTopic { topic, respond_to } => {
-                        let result =
-                            subscribe_topic(&node, &ws_outbound, &mut subscriptions, &topic);
+                        let result = subscribe_topic(
+                            &node,
+                            &ws_outbound,
+                            &mut subscriptions,
+                            &topic,
+                            &foot_bridge,
+                        );
                         let _ = respond_to.send(result);
                     }
                     RosCommand::UnsubscribeTopic { topic, respond_to } => {
-                        let result = unsubscribe_topic(&mut subscriptions, &topic);
+                        let result = unsubscribe_topic(&mut subscriptions, &topic, &foot_bridge);
                         let _ = respond_to.send(result);
                     }
                 },
@@ -449,7 +514,13 @@ fn subscribe_topic(
     ws_outbound: &broadcast::Sender<WsOutbound>,
     subscriptions: &mut HashMap<String, SubscriptionEntry>,
     topic: &str,
+    foot_bridge: &foot::FootTelemetryBridge,
 ) -> Result<(), CockpitError> {
+    if foot::FootTelemetryBridge::handles_topic(topic) {
+        foot_bridge.handle_subscribe(topic);
+        return Ok(());
+    }
+
     if let Some(entry) = subscriptions.get_mut(topic) {
         entry.ref_count += 1;
         return Ok(());
@@ -469,9 +540,15 @@ fn subscribe_topic(
 fn unsubscribe_topic(
     subscriptions: &mut HashMap<String, SubscriptionEntry>,
     topic: &str,
+    foot_bridge: &foot::FootTelemetryBridge,
 ) -> Result<(), CockpitError> {
     if !is_supported_topic(topic) {
         return Err(CockpitError::UnsupportedTopic(topic.to_owned()));
+    }
+
+    if foot::FootTelemetryBridge::handles_topic(topic) {
+        foot_bridge.handle_unsubscribe(topic);
+        return Ok(());
     }
 
     if let Some(entry) = subscriptions.get_mut(topic) {
@@ -487,6 +564,7 @@ fn unsubscribe_topic(
 
 fn is_supported_topic(topic: &str) -> bool {
     matches!(topic, "/audio/transcript/final" | "/imu/data")
+        || foot::FootTelemetryBridge::handles_topic(topic)
 }
 
 fn create_topic_subscription(
@@ -574,6 +652,704 @@ fn create_topic_subscription(
             Ok(TopicSubscription::Imu(subscription))
         }
         _ => Err(CockpitError::UnsupportedTopic(topic.to_owned())),
+    }
+}
+
+mod foot {
+    use super::{CockpitError, WsOutbound};
+    use create_msgs::msg::{
+        Bumper as RosBumper, ChargingState as RosChargingState, Cliff as RosCliff, Mode as RosMode,
+    };
+    use geometry_msgs::msg::Twist as RosTwist;
+    use nav_msgs::msg::Odometry as RosOdometry;
+    use rclrs;
+    use serde::Serialize;
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std_msgs::msg::{Float32 as RosFloat32, Int16 as RosInt16};
+    use tokio::sync::broadcast;
+    use tracing::{error, warn};
+
+    const TELEMETRY_TOPIC: &str = "/foot/telemetry";
+    const CMD_VEL_TOPIC: &str = "/cmd_vel";
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct FootTelemetrySnapshot {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub battery: Option<BatterySnapshot>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub status: Option<StatusSnapshot>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub motion: Option<MotionSnapshot>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub hazards: Option<HazardSnapshot>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub last_update_ms: Option<u64>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct BatterySnapshot {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub percentage: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub charge_ratio: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub charge_ah: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub capacity_ah: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub current_a: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub voltage_v: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub temperature_c: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub charging_state: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub is_charging: Option<bool>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct StatusSnapshot {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub mode: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub mode_code: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub charging_state: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub charging_state_code: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub last_command_ms: Option<u64>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct MotionSnapshot {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub command: Option<TwistSummary>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub odometry: Option<TwistSummary>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct HazardSnapshot {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub bumper_left: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub bumper_right: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub bumper_light_front: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub bumper_light_center: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cliff_left: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cliff_front_left: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cliff_right: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub cliff_front_right: Option<bool>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize)]
+    pub struct TwistSummary {
+        pub linear_x: f64,
+        pub linear_y: f64,
+        pub linear_z: f64,
+        pub angular_x: f64,
+        pub angular_y: f64,
+        pub angular_z: f64,
+    }
+
+    pub struct FootTelemetryBridge {
+        state: Arc<Mutex<FootTelemetrySnapshot>>,
+        #[allow(dead_code)]
+        subscriptions: Vec<FootSubscription>,
+        ws_outbound: broadcast::Sender<WsOutbound>,
+    }
+
+    enum FootSubscription {
+        Float32(rclrs::Subscription<RosFloat32>),
+        Int16(rclrs::Subscription<RosInt16>),
+        ChargingState(rclrs::Subscription<RosChargingState>),
+        Mode(rclrs::Subscription<RosMode>),
+        Bumper(rclrs::Subscription<RosBumper>),
+        Cliff(rclrs::Subscription<RosCliff>),
+        CmdVel(rclrs::Subscription<RosTwist>),
+        Odom(rclrs::Subscription<RosOdometry>),
+    }
+
+    impl FootTelemetryBridge {
+        pub fn new(
+            node: &rclrs::Node,
+            ws_outbound: broadcast::Sender<WsOutbound>,
+        ) -> Result<Self, CockpitError> {
+            let state = Arc::new(Mutex::new(FootTelemetrySnapshot::default()));
+            let mut subscriptions = Vec::new();
+
+            subscriptions.push(FootSubscription::Float32(
+                node.create_subscription("/battery/charge_ratio", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosFloat32| handle_charge_ratio(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/charge_ratio".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Float32(
+                node.create_subscription("/battery/capacity", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosFloat32| handle_capacity(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/capacity".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Float32(
+                node.create_subscription("/battery/charge", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosFloat32| handle_charge(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/charge".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Float32(
+                node.create_subscription("/battery/current", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosFloat32| handle_current(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/current".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Float32(
+                node.create_subscription("/battery/voltage", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosFloat32| handle_voltage(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/voltage".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Int16(
+                node.create_subscription("/battery/temperature", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosInt16| handle_temperature(&state, &ws, msg.data)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/temperature".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::ChargingState(
+                node.create_subscription("/battery/charging_state", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosChargingState| handle_charging_state(&state, &ws, msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/battery/charging_state".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Mode(
+                node.create_subscription("/mode", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosMode| handle_mode(&state, &ws, msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/mode".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Bumper(
+                node.create_subscription("/bumper", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosBumper| handle_bumper(&state, &ws, msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/bumper".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Cliff(
+                node.create_subscription("/cliff", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosCliff| handle_cliff(&state, &ws, msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/cliff".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::CmdVel(
+                node.create_subscription("/cmd_vel", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosTwist| handle_cmd_vel(&state, &ws, &msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/cmd_vel".into(),
+                    source,
+                })?,
+            ));
+
+            subscriptions.push(FootSubscription::Odom(
+                node.create_subscription("/odom", {
+                    let state = Arc::clone(&state);
+                    let ws = ws_outbound.clone();
+                    move |msg: RosOdometry| handle_odom(&state, &ws, &msg)
+                })
+                .map_err(|source| CockpitError::SubscribeFailed {
+                    topic: "/odom".into(),
+                    source,
+                })?,
+            ));
+
+            Ok(Self {
+                state,
+                subscriptions,
+                ws_outbound,
+            })
+        }
+
+        pub fn handles_topic(topic: &str) -> bool {
+            matches!(topic, TELEMETRY_TOPIC | CMD_VEL_TOPIC)
+        }
+
+        pub fn handle_subscribe(&self, topic: &str) {
+            match topic {
+                TELEMETRY_TOPIC => {
+                    if let Some(snapshot) = self.snapshot() {
+                        broadcast_snapshot(&self.ws_outbound, snapshot);
+                    }
+                }
+                CMD_VEL_TOPIC => {
+                    if let Some(snapshot) = self.snapshot() {
+                        if let Some(summary) = snapshot.motion.and_then(|motion| motion.command) {
+                            self.send_cmd_vel_summary(&summary);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        pub fn handle_unsubscribe(&self, _topic: &str) {}
+
+        pub fn record_command(&self, twist: &RosTwist) {
+            handle_cmd_vel(&self.state, &self.ws_outbound, twist);
+        }
+
+        fn snapshot(&self) -> Option<FootTelemetrySnapshot> {
+            match self.state.lock() {
+                Ok(guard) => Some(guard.clone()),
+                Err(poisoned) => {
+                    error!("foot telemetry state mutex poisoned");
+                    Some(poisoned.into_inner().clone())
+                }
+            }
+        }
+
+        fn send_cmd_vel_summary(&self, summary: &TwistSummary) {
+            let payload = json!({
+                "linear": {
+                    "x": summary.linear_x,
+                    "y": summary.linear_y,
+                    "z": summary.linear_z,
+                },
+                "angular": {
+                    "x": summary.angular_x,
+                    "y": summary.angular_y,
+                    "z": summary.angular_z,
+                },
+            });
+            if let Err(err) = self.ws_outbound.send(WsOutbound::Msg {
+                topic: CMD_VEL_TOPIC.into(),
+                msg: payload,
+            }) {
+                warn!(?err, "no websocket listeners for /cmd_vel broadcast");
+            }
+        }
+    }
+
+    fn handle_charge_ratio(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        ratio: f32,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let ratio = ratio.clamp(0.0, 1.0);
+            let battery = battery_section(state);
+            battery.charge_ratio = Some(ratio);
+            battery.percentage = Some(ratio * 100.0);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_capacity(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        capacity: f32,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let battery = battery_section(state);
+            battery.capacity_ah = Some(capacity);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_charge(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        charge: f32,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let battery = battery_section(state);
+            battery.charge_ah = Some(charge.max(0.0));
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_current(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        current: f32,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let battery = battery_section(state);
+            battery.current_a = Some(current);
+            battery.is_charging = Some(current > 0.0);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_voltage(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        voltage: f32,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let battery = battery_section(state);
+            battery.voltage_v = Some(voltage);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_temperature(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        temperature: i16,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let battery = battery_section(state);
+            battery.temperature_c = Some(temperature as f32);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_charging_state(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        msg: RosChargingState,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let label = charging_state_label(msg.state).to_owned();
+            let battery = battery_section(state);
+            battery.charging_state = Some(label.clone());
+            battery.is_charging = Some(matches!(
+                msg.state,
+                RosChargingState::CHARGE_RECONDITION
+                    | RosChargingState::CHARGE_FULL
+                    | RosChargingState::CHARGE_TRICKLE
+                    | RosChargingState::CHARGE_WAITING
+            ));
+            let status = status_section(state);
+            status.charging_state = Some(label);
+            status.charging_state_code = Some(msg.state);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_mode(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        msg: RosMode,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let status = status_section(state);
+            status.mode_code = Some(msg.mode);
+            status.mode = Some(mode_label(msg.mode).to_owned());
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_bumper(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        msg: RosBumper,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let hazards = hazard_section(state);
+            hazards.bumper_left = Some(msg.is_left_pressed);
+            hazards.bumper_right = Some(msg.is_right_pressed);
+            hazards.bumper_light_front = Some(msg.is_light_front_left || msg.is_light_front_right);
+            hazards.bumper_light_center =
+                Some(msg.is_light_center_left || msg.is_light_center_right);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_cliff(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        msg: RosCliff,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let hazards = hazard_section(state);
+            hazards.cliff_left = Some(msg.is_cliff_left);
+            hazards.cliff_front_left = Some(msg.is_cliff_front_left);
+            hazards.cliff_right = Some(msg.is_cliff_right);
+            hazards.cliff_front_right = Some(msg.is_cliff_front_right);
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_cmd_vel(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        twist: &RosTwist,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, now| {
+            let motion = motion_section(state);
+            motion.command = Some(summary_from_twist(twist));
+            let status = status_section(state);
+            status.last_command_ms = Some(now);
+        }) {
+            broadcast_cmd_vel_from_twist(ws, twist);
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn handle_odom(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        ws: &broadcast::Sender<WsOutbound>,
+        msg: &RosOdometry,
+    ) {
+        if let Some(snapshot) = update_state(state, |state, _| {
+            let motion = motion_section(state);
+            motion.odometry = Some(summary_from_odometry(msg));
+        }) {
+            broadcast_snapshot(ws, snapshot);
+        }
+    }
+
+    fn update_state<F>(
+        state: &Arc<Mutex<FootTelemetrySnapshot>>,
+        mut update: F,
+    ) -> Option<FootTelemetrySnapshot>
+    where
+        F: FnMut(&mut FootTelemetrySnapshot, u64),
+    {
+        let mut guard = match state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                error!("foot telemetry state mutex poisoned");
+                poisoned.into_inner()
+            }
+        };
+        let timestamp = now_millis();
+        update(&mut guard, timestamp);
+        guard.last_update_ms = Some(timestamp);
+        Some(guard.clone())
+    }
+
+    fn broadcast_snapshot(ws: &broadcast::Sender<WsOutbound>, snapshot: FootTelemetrySnapshot) {
+        match serde_json::to_value(snapshot) {
+            Ok(msg) => {
+                if let Err(err) = ws.send(WsOutbound::Msg {
+                    topic: TELEMETRY_TOPIC.into(),
+                    msg,
+                }) {
+                    warn!(?err, "no websocket listeners for foot telemetry broadcast");
+                }
+            }
+            Err(err) => {
+                error!(?err, "failed to serialize foot telemetry snapshot");
+            }
+        }
+    }
+
+    fn broadcast_cmd_vel_from_twist(ws: &broadcast::Sender<WsOutbound>, twist: &RosTwist) {
+        broadcast_cmd_vel_summary(ws, &summary_from_twist(twist));
+    }
+
+    fn broadcast_cmd_vel_summary(ws: &broadcast::Sender<WsOutbound>, summary: &TwistSummary) {
+        let payload = json!({
+            "linear": {
+                "x": summary.linear_x,
+                "y": summary.linear_y,
+                "z": summary.linear_z,
+            },
+            "angular": {
+                "x": summary.angular_x,
+                "y": summary.angular_y,
+                "z": summary.angular_z,
+            },
+        });
+        if let Err(err) = ws.send(WsOutbound::Msg {
+            topic: CMD_VEL_TOPIC.into(),
+            msg: payload,
+        }) {
+            warn!(?err, "no websocket listeners for /cmd_vel broadcast");
+        }
+    }
+
+    fn battery_section(state: &mut FootTelemetrySnapshot) -> &mut BatterySnapshot {
+        state.battery.get_or_insert_with(BatterySnapshot::default)
+    }
+
+    fn status_section(state: &mut FootTelemetrySnapshot) -> &mut StatusSnapshot {
+        state.status.get_or_insert_with(StatusSnapshot::default)
+    }
+
+    fn motion_section(state: &mut FootTelemetrySnapshot) -> &mut MotionSnapshot {
+        state.motion.get_or_insert_with(MotionSnapshot::default)
+    }
+
+    fn hazard_section(state: &mut FootTelemetrySnapshot) -> &mut HazardSnapshot {
+        state.hazards.get_or_insert_with(HazardSnapshot::default)
+    }
+
+    fn summary_from_twist(twist: &RosTwist) -> TwistSummary {
+        TwistSummary {
+            linear_x: twist.linear.x,
+            linear_y: twist.linear.y,
+            linear_z: twist.linear.z,
+            angular_x: twist.angular.x,
+            angular_y: twist.angular.y,
+            angular_z: twist.angular.z,
+        }
+    }
+
+    fn summary_from_odometry(msg: &RosOdometry) -> TwistSummary {
+        let twist = &msg.twist.twist;
+        TwistSummary {
+            linear_x: twist.linear.x,
+            linear_y: twist.linear.y,
+            linear_z: twist.linear.z,
+            angular_x: twist.angular.x,
+            angular_y: twist.angular.y,
+            angular_z: twist.angular.z,
+        }
+    }
+
+    fn charging_state_label(state: u8) -> &'static str {
+        match state {
+            RosChargingState::CHARGE_NONE => "Idle",
+            RosChargingState::CHARGE_RECONDITION => "Recondition",
+            RosChargingState::CHARGE_FULL => "Full",
+            RosChargingState::CHARGE_TRICKLE => "Trickle",
+            RosChargingState::CHARGE_WAITING => "Waiting",
+            RosChargingState::CHARGE_FAULT => "Fault",
+            _ => "Unknown",
+        }
+    }
+
+    fn mode_label(mode: u8) -> &'static str {
+        match mode {
+            RosMode::MODE_OFF => "Off",
+            RosMode::MODE_PASSIVE => "Passive",
+            RosMode::MODE_SAFE => "Safe",
+            RosMode::MODE_FULL => "Full",
+            _ => "Unknown",
+        }
+    }
+
+    fn now_millis() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use geometry_msgs::msg::{Twist as RosTwist, Vector3 as RosVector3};
+
+        #[test]
+        fn charging_state_labels_cover_known_values() {
+            assert_eq!(charging_state_label(RosChargingState::CHARGE_NONE), "Idle");
+            assert_eq!(
+                charging_state_label(RosChargingState::CHARGE_FAULT),
+                "Fault"
+            );
+            assert_eq!(charging_state_label(99), "Unknown");
+        }
+
+        #[test]
+        fn mode_label_covers_known_values() {
+            assert_eq!(mode_label(RosMode::MODE_SAFE), "Safe");
+            assert_eq!(mode_label(42), "Unknown");
+        }
+
+        #[test]
+        fn summary_from_twist_maps_all_axes() {
+            let twist = RosTwist {
+                linear: RosVector3 {
+                    x: 0.4,
+                    y: -0.1,
+                    z: 0.2,
+                },
+                angular: RosVector3 {
+                    x: 0.5,
+                    y: 0.0,
+                    z: -0.75,
+                },
+            };
+            let summary = summary_from_twist(&twist);
+            assert_eq!(summary.linear_x, 0.4);
+            assert_eq!(summary.linear_y, -0.1);
+            assert_eq!(summary.linear_z, 0.2);
+            assert_eq!(summary.angular_z, -0.75);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- bridge /cmd_vel publishing and aggregated Create telemetry into the cockpit backend
- redesign the foot pilot panel with icon-driven tiles, LCARS-inspired styling, and updated joystick limits
- refresh shared styles and document the need for generated ROS message crates in the agent guide

## Testing
- `rustfmt --edition 2021 psyched/src/bin/cockpit.rs`
- (blocked) `cargo fmt` *(missing generated ROS message crates in install/share)*
- (blocked) `deno fmt modules/foot/pilot/components/FootControlPanel.tsx` *(deno executable unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dea9be1b388320b3faf968910148f5