### PR TITLE
Ensure docker provisioning precedes ROS 2 setup

### DIFF
--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -81,7 +81,7 @@ PROFILE
 echo "ROS 2 ${ROS_DISTRO} installation completed with Cyclone DDS as the default RMW."
 echo "Source /opt/ros/${ROS_DISTRO}/setup.bash to begin using ROS 2."
 
-GENERATE_SCRIPT="${SCRIPT_DIR}/generate_ros_rust_bindings.sh"
-if ! "${GENERATE_SCRIPT}"; then
-  echo "Warning: failed to vendor ROS Rust message crates. Re-run ${GENERATE_SCRIPT} once Docker is available." >&2
-fi
+# Vendored ROS bindings are now generated separately by provisioning orchestrators
+# (for example `psh host setup`) once Docker is available. If you need to refresh
+# them manually, run tools/provision/generate_ros_rust_bindings.sh after Docker
+# installation completes.


### PR DESCRIPTION
## Summary
- derive host provisioning features so docker, ROS 2, and binding generation scripts run in the correct order
- add unit tests that exercise the new provisioning planner logic
- stop install_ros2.sh from invoking binding generation directly so orchestrators can insert it after docker is available

## Testing
- cargo fmt *(fails: missing generated ROS crates such as create_msgs)*
- cargo check --manifest-path psh/Cargo.toml *(fails: missing generated ROS crates such as create_msgs)*
- cargo test --manifest-path psh/Cargo.toml --lib *(fails: missing generated ROS crates such as create_msgs)*

------
https://chatgpt.com/codex/tasks/task_e_68debd684020832096e753a1c4a62f52