### PR TITLE
Add harness and CI workflow for Deno e2e scenarios

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E Scenarios
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run e2e scenarios
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Prime Deno cache
+        run: deno cache psh/e2e/mod.ts
+
+      - name: Prepare report directory
+        run: mkdir -p reports
+
+      - name: Execute scenarios
+        env:
+          DENO_TLS_CA_STORE: system
+        run: deno task e2e
+
+      - name: Upload junit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-junit-report
+          path: reports/e2e.xml
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target/
 
 models/
 .speech_setup_complete
+reports/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,17 @@ Visit `http://<cerebellum-host>:8080`.
 * Deno tests: run with `DENO_TLS_CA_STORE=system` and explicit permissions.
 * Pilot backend tests require `fastapi`, `httpx`, `uvicorn`.
 
+### E2E Scenarios (Deno)
+
+* Put new scenarios under `psh/e2e/` and import helpers from `./mod.ts` so the
+  shared harness stays in sync.
+* Use `defineScenario("behaviour", fn, { knownFailure })` to wrap
+  expectations; only tag failures that are actively triaged and include a short
+  reason string.
+* Keep JUnit output concise: prefer focused assertions, avoid dumping large
+  payloads to stdout, and trim noisy logs so the artifact uploaded by CI stays
+  lightweight.
+
 ---
 
 ## Common Issues

--- a/psh/deno.json
+++ b/psh/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch main.ts",
+    "e2e": "deno test --config deno.json --allow-run --allow-env --reporter=junit --junit-path reports/e2e.xml psh/e2e"
   },
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
@@ -13,6 +14,7 @@
     "@std/fs": "jsr:@std/fs@1",
     "@std/testing/mock": "jsr:@std/testing@1/mock",
     "@std/yaml": "jsr:@std/yaml@1",
-    "@std/encoding/base64": "jsr:@std/encoding@1/base64"
+    "@std/encoding/base64": "jsr:@std/encoding@1/base64",
+    "@std/testing/reporters": "jsr:@std/testing@1/reporters"
   }
 }

--- a/psh/e2e/harness.ts
+++ b/psh/e2e/harness.ts
@@ -1,0 +1,86 @@
+/**
+ * Scenario harness for PSH end-to-end tests.
+ *
+ * ```ts
+ * import { defineScenario } from "./harness.ts";
+ *
+ * defineScenario("speech stack boots", async (t) => {
+ *   // Arrange, act, assert – follow BDD naming conventions.
+ *   await t.step("should expose health endpoint", async () => {
+ *     // ... interact with the system under test ...
+ *   });
+ * });
+ *
+ * defineScenario("legacy oauth callback", async () => {
+ *   throw new Error("still broken in staging");
+ * }, { knownFailure: "tracking INFRA-123" });
+ * ```
+ */
+export interface ScenarioOptions {
+  /**
+   * Annotate a scenario as a known failure so CI remains green while
+   * investigations continue. Provide a short reason or ticket reference when
+   * possible so the junit output stays actionable.
+   */
+  readonly knownFailure?: boolean | string;
+}
+
+/**
+ * Wrap a Deno test with reporter-friendly lifecycle logging and known failure
+ * handling. When `knownFailure` is set, the scenario passes only if the wrapped
+ * function throws, helping us spot unblocked behaviour early.
+ */
+export function defineScenario(
+  name: string,
+  fn: (t: Deno.TestContext) => void | Promise<void>,
+  options: ScenarioOptions = {},
+): void {
+  const { knownFailure } = options;
+
+  Deno.test({
+    name,
+    // Let scenarios manage their own resources; e2e workflows often spin up
+    // subprocesses or network servers intentionally.
+    sanitizeOps: false,
+    sanitizeResources: false,
+    sanitizeExit: false,
+    fn: async (t) => {
+      const start = performance.now();
+      const label = `scenario:${name}`;
+      const duration = () => `${Math.round(performance.now() - start)}ms`;
+      const knownFailureReason =
+        typeof knownFailure === "string" ? knownFailure : undefined;
+
+      console.log(`BEGIN ${label}`);
+      if (knownFailureReason) {
+        console.log(`KNOWN-FAILURE ${label} reason=${knownFailureReason}`);
+      } else if (knownFailure) {
+        console.log(`KNOWN-FAILURE ${label}`);
+      }
+
+      try {
+        await fn(t);
+        console.log(`SUCCESS ${label} duration=${duration()}`);
+
+        if (knownFailure) {
+          const reason = knownFailureReason ?? "marked as known failure";
+          throw new Error(
+            `Scenario \"${name}\" unexpectedly passed (reason: ${reason}). Remove the knownFailure flag to re-enable CI enforcement.`,
+          );
+        }
+      } catch (error) {
+        if (knownFailure) {
+          const reason = knownFailureReason ?? "marked as known failure";
+          console.log(
+            `EXPECTED-FAILURE ${label} duration=${duration()} reason=${reason}`,
+          );
+          console.log(`${label} error=${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+          return;
+        }
+
+        console.log(`FAILURE ${label} duration=${duration()}`);
+        throw error;
+      }
+    },
+  });
+}

--- a/psh/e2e/mod.ts
+++ b/psh/e2e/mod.ts
@@ -1,0 +1,1 @@
+export * from "./harness.ts";


### PR DESCRIPTION
## Summary
- add a reusable Deno harness for PSH end-to-end scenarios and re-export it from the module entry point
- wire up a GitHub Actions workflow and task to exercise the scenarios and publish a junit report
- document the e2e authoring workflow in AGENTS.md and ignore generated reports

## Testing
- ⚠️ `deno task e2e` *(fails locally: Deno is not installed in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68def8ec2e0c8320a7c5447711980c9f