### PR TITLE
Add ROS 2 dockerized service and service shell command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Always prefer running the smallest relevant command set.
 - **Background processes:** Launch scripts spawn long-lived processes (for example `deno task dev`). Ensure traps stop them (`modules/pilot/launch_unit.sh` shows the pattern).
 - **Workspace resets:** `tools/clean_workspace` wipes `work/` and relinks local ROS/Python packages. Run it (or `psh clean`) whenever package paths drift instead of tweaking build directories manually.
 - **Deno TLS certificates:** When fetching dependencies during `deno task test`, set `DENO_TLS_CA_STORE=system` if you encounter TLS certificate errors in restricted environments.
+- **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
 
 ## Useful references
 

--- a/services/ros2/docker-compose.yml
+++ b/services/ros2/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  ros2:
+    image: osrf/ros:humble-desktop
+    container_name: psyched-ros2
+    command: ["bash", "-lc", "trap : TERM INT; sleep infinity & wait"]
+    environment:
+      ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
+      DISPLAY: ${DISPLAY}
+    stdin_open: true
+    tty: true
+    network_mode: host
+    working_dir: /workspace/psyched
+    volumes:
+      - ../..:/workspace/psyched
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/services/ros2/service.toml
+++ b/services/ros2/service.toml
@@ -1,0 +1,5 @@
+[service.ros2]
+compose = "docker-compose.yml"
+description = "ROS 2 workspace container based on osrf/ros:humble-desktop"
+shell_service = "ros2"
+shell_command = ["/ros_entrypoint.sh", "bash"]

--- a/tools/psh/lib/service_test.ts
+++ b/tools/psh/lib/service_test.ts
@@ -1,8 +1,77 @@
-import { assert, assertArrayIncludes } from "$std/testing/asserts.ts";
-import { listServices } from "./service.ts";
+import { assert, assertEquals } from "$std/testing/asserts.ts";
+import { ServiceConfig, ServiceShellOptions, __test__, listServices } from "./service.ts";
 
-Deno.test("listServices finds declared services", () => {
+const { buildShellArgs } = __test__;
+
+type MinimalConfig = ServiceConfig & { compose: string };
+
+Deno.test("buildShellArgs uses defaults from config", () => {
+  const config: MinimalConfig = {
+    compose: "docker-compose.yml",
+    shell_command: ["/ros_entrypoint.sh", "bash"],
+  };
+  const args = buildShellArgs(
+    "ros2",
+    config,
+    "/tmp/docker-compose.yml",
+    "psyched-ros2",
+  );
+  assertEquals(args, [
+    "docker",
+    "compose",
+    "-f",
+    "/tmp/docker-compose.yml",
+    "-p",
+    "psyched-ros2",
+    "exec",
+    "-i",
+    "-t",
+    "ros2",
+    "/ros_entrypoint.sh",
+    "bash",
+  ]);
+});
+
+Deno.test("buildShellArgs honors overrides", () => {
+  const config: MinimalConfig = {
+    compose: "docker-compose.yml",
+    shell_service: "bridge",
+    shell_user: "1000:1000",
+    shell_command: ["bash"],
+  };
+  const options: ServiceShellOptions = {
+    command: ["bash", "-lc", "echo hi"],
+    service: "workspace",
+    user: "2000:2000",
+    interactive: false,
+    tty: false,
+  };
+  const args = buildShellArgs(
+    "ros2",
+    config,
+    "/etc/compose.yml",
+    "ros2-dev",
+    options,
+  );
+  assertEquals(args, [
+    "docker",
+    "compose",
+    "-f",
+    "/etc/compose.yml",
+    "-p",
+    "ros2-dev",
+    "exec",
+    "workspace",
+    "bash",
+    "-lc",
+    "echo hi",
+  ]);
+});
+
+Deno.test("listServices picks up ros2", () => {
   const services = listServices();
-  assert(services.length > 0, "expected at least one service");
-  assertArrayIncludes(services, ["tts"], "tts service should be present");
+  assert(
+    services.includes("ros2"),
+    "ros2 service should be discoverable",
+  );
 });


### PR DESCRIPTION
## Summary
- add a docker-compose backed ros2 service with defaults for interactive shells
- allow host provisioning dependencies to reference module/service aliases and guard against alias conflicts
- extend the psh service tooling with a `shell` command plus helpers for building compose exec invocations

## Testing
- `deno test` *(fails: deno binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e063bcc3a083208e5c3cf5efb487d2