### PR TITLE
Add ear transcription module

### DIFF
--- a/modules/ear/AGENTS.md
+++ b/modules/ear/AGENTS.md
@@ -1,0 +1,6 @@
+# Ear module guidelines
+
+- Provide comprehensive type annotations and doctrings for public APIs.
+- Run `PYTHONPATH=modules/ear/packages/ear:$PYTHONPATH pytest modules/ear/packages/ear/tests` after modifying Python code in this module.
+- Prefer backend-agnostic abstractions so additional transcription backends can plug in easily.
+- Keep shell scripts POSIX-friendly with `#!/usr/bin/env bash` and `set -euo pipefail`.

--- a/modules/ear/launch_unit.sh
+++ b/modules/ear/launch_unit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND=${EAR_BACKEND:-console}
+HOLE_TOPIC=${EAR_HOLE_TOPIC:-/ear/hole}
+AUDIO_TOPIC=${EAR_AUDIO_TOPIC:-/audio/raw}
+TEXT_TOPIC=${EAR_TEXT_TOPIC:-}
+SERVICE_URI=${EAR_SERVICE_URI:-}
+AUDIO_SAMPLE_RATE=${EAR_AUDIO_SAMPLE_RATE:-}
+AUDIO_CHANNELS=${EAR_AUDIO_CHANNELS:-}
+WHISPER_MODEL=${EAR_FASTER_WHISPER_MODEL:-}
+WHISPER_DEVICE=${EAR_FASTER_WHISPER_DEVICE:-}
+WHISPER_COMPUTE=${EAR_FASTER_WHISPER_COMPUTE_TYPE:-}
+WHISPER_LANGUAGE=${EAR_FASTER_WHISPER_LANGUAGE:-}
+WHISPER_BEAM_SIZE=${EAR_FASTER_WHISPER_BEAM_SIZE:-}
+
+ROS_ARGS=(
+  -p backend:="${BACKEND}"
+  -p hole_topic:="${HOLE_TOPIC}"
+)
+
+if [[ -n "${AUDIO_TOPIC}" ]]; then
+  ROS_ARGS+=(-p audio_topic:="${AUDIO_TOPIC}")
+fi
+if [[ -n "${TEXT_TOPIC}" ]]; then
+  ROS_ARGS+=(-p text_input_topic:="${TEXT_TOPIC}")
+fi
+if [[ -n "${SERVICE_URI}" ]]; then
+  ROS_ARGS+=(-p service_uri:="${SERVICE_URI}")
+fi
+if [[ -n "${AUDIO_SAMPLE_RATE}" ]]; then
+  ROS_ARGS+=(-p audio_sample_rate:=${AUDIO_SAMPLE_RATE})
+fi
+if [[ -n "${AUDIO_CHANNELS}" ]]; then
+  ROS_ARGS+=(-p audio_channels:=${AUDIO_CHANNELS})
+fi
+if [[ -n "${WHISPER_MODEL}" ]]; then
+  ROS_ARGS+=(-p faster_whisper_model:="${WHISPER_MODEL}")
+fi
+if [[ -n "${WHISPER_DEVICE}" ]]; then
+  ROS_ARGS+=(-p faster_whisper_device:="${WHISPER_DEVICE}")
+fi
+if [[ -n "${WHISPER_COMPUTE}" ]]; then
+  ROS_ARGS+=(-p faster_whisper_compute_type:="${WHISPER_COMPUTE}")
+fi
+if [[ -n "${WHISPER_LANGUAGE}" ]]; then
+  ROS_ARGS+=(-p faster_whisper_language:="${WHISPER_LANGUAGE}")
+fi
+if [[ -n "${WHISPER_BEAM_SIZE}" ]]; then
+  ROS_ARGS+=(-p faster_whisper_beam_size:=${WHISPER_BEAM_SIZE})
+fi
+
+ros2 run ear ear_service --ros-args "${ROS_ARGS[@]}" &
+
+wait -n

--- a/modules/ear/module.toml
+++ b/modules/ear/module.toml
@@ -1,0 +1,12 @@
+[unit.ear]
+apt = [
+    "python3-websockets",
+    "python3-numpy",
+]
+pip = []
+launch = "modules/ear/launch_unit.sh"
+shutdown = "modules/ear/shutdown_unit.sh"
+
+[unit.ear.ros]
+workspace = "."
+packages = ["ear"]

--- a/modules/ear/packages/ear/ear/__init__.py
+++ b/modules/ear/packages/ear/ear/__init__.py
@@ -1,0 +1,8 @@
+"""Public interface for the ear transcription package."""
+
+from __future__ import annotations
+
+from .backends import ConsoleEarBackend, EarBackend
+from .worker import EarWorker
+
+__all__ = ["ConsoleEarBackend", "EarBackend", "EarWorker"]

--- a/modules/ear/packages/ear/ear/backends.py
+++ b/modules/ear/packages/ear/ear/backends.py
@@ -1,0 +1,249 @@
+"""Transcription backend implementations for the ear module."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import queue
+import sys
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Protocol, TextIO, runtime_checkable
+
+_LOGGER = logging.getLogger(__name__)
+
+PublishCallback = Callable[[str], None]
+
+
+class EarBackend(Protocol):
+    """Protocol implemented by all ear transcription backends."""
+
+    def run(self, publish: PublishCallback, stop_event: threading.Event) -> None:
+        """Start consuming input and invoke ``publish`` for recognised text."""
+
+
+@runtime_checkable
+class AudioAwareBackend(EarBackend, Protocol):
+    """Protocol for backends that accept PCM audio input."""
+
+    def submit_audio(self, pcm: bytes, sample_rate: int, channels: int) -> None:
+        """Supply raw PCM audio data to the backend."""
+
+    def close(self) -> None:  # pragma: no cover - optional shutdown hook
+        """Release backend resources. Implementations may override."""
+
+
+@dataclass(slots=True)
+class ConsoleEarBackend:
+    """Simple backend that reads lines from a text stream.
+
+    Parameters
+    ----------
+    input_stream:
+        Stream from which user input is read. Defaults to :data:`sys.stdin`.
+    output_stream:
+        Optional stream used to render a coloured prompt. Defaults to
+        :data:`sys.stdout`.
+    prompt:
+        Prompt rendered before waiting for user input. Defaults to ``"🦻  "``.
+    colour:
+        ANSI escape sequence applied to the prompt. Defaults to cyan.
+
+    Example
+    -------
+    >>> backend = ConsoleEarBackend()
+    >>> stop_event = threading.Event()
+    >>> backend.run(print, stop_event)  # doctest: +SKIP
+    """
+
+    input_stream: TextIO = sys.stdin
+    output_stream: TextIO | None = sys.stdout
+    prompt: str = "🦻  "
+    colour: str = "\x1b[36m"
+    _reset: str = field(default="\x1b[0m", init=False, repr=False)
+
+    def run(self, publish: PublishCallback, stop_event: threading.Event) -> None:
+        """Continuously read lines and publish non-empty entries."""
+
+        while not stop_event.is_set():
+            if self.output_stream is not None:
+                self.output_stream.write(f"{self.colour}{self.prompt}{self._reset}")
+                self.output_stream.flush()
+            try:
+                line = self.input_stream.readline()
+            except Exception:  # pragma: no cover - defensive logging
+                _LOGGER.exception("Failed to read from console input")
+                break
+            if line == "":
+                break
+            text = line.strip()
+            if not text:
+                continue
+            publish(text)
+
+
+class FasterWhisperEarBackend(AudioAwareBackend):
+    """Backend that performs offline transcription via `faster-whisper`.
+
+    Notes
+    -----
+    The backend lazily instantiates :class:`faster_whisper.WhisperModel` to
+    avoid importing heavy dependencies when unused. Audio chunks must be
+    supplied via :meth:`submit_audio` using 16-bit PCM samples.
+    """
+
+    def __init__(
+        self,
+        model_size: str = "base",
+        *,
+        device: str = "cpu",
+        compute_type: str = "int8",
+        language: str | None = None,
+        beam_size: int | None = None,
+    ) -> None:
+        self._model_size = model_size
+        self._device = device
+        self._compute_type = compute_type
+        self._language = language
+        self._beam_size = beam_size
+        self._queue: "queue.Queue[tuple[bytes, int, int] | None]" = queue.Queue()
+        self._model = None
+
+    def submit_audio(self, pcm: bytes, sample_rate: int, channels: int) -> None:
+        """Queue audio for transcription."""
+
+        self._queue.put((pcm, sample_rate, channels))
+
+    def close(self) -> None:
+        """Wake the worker so it can terminate promptly."""
+
+        self._queue.put(None)
+
+    def run(self, publish: PublishCallback, stop_event: threading.Event) -> None:
+        """Continuously transcribe queued audio segments."""
+
+        try:
+            from faster_whisper import WhisperModel  # type: ignore[import-not-found]
+            import numpy as np  # type: ignore[import-not-found]
+        except ImportError as error:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "faster-whisper backend requested but dependencies are missing"
+            ) from error
+
+        if self._model is None:
+            self._model = WhisperModel(
+                self._model_size,
+                device=self._device,
+                compute_type=self._compute_type,
+            )
+
+        while not stop_event.is_set():
+            try:
+                item = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            pcm, sample_rate, channels = item
+            if channels != 1:
+                _LOGGER.warning(
+                    "faster-whisper backend currently expects mono audio; received %s channels",
+                    channels,
+                )
+            audio = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+            segments, _ = self._model.transcribe(
+                audio,
+                language=self._language,
+                beam_size=self._beam_size,
+                temperature=0.0,
+                vad_filter=True,
+                vad_parameters={"min_speech_duration_ms": 250},
+            )
+            transcript_parts = [segment.text.strip() for segment in segments if segment.text]
+            transcript = " ".join(filter(None, transcript_parts)).strip()
+            if transcript:
+                publish(transcript)
+
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+
+
+class ServiceASREarBackend(AudioAwareBackend):
+    """Backend that streams audio frames to the `/service/asr` websocket."""
+
+    def __init__(
+        self,
+        uri: str = "ws://127.0.0.1:8089/ws",
+        *,
+        loop: asyncio.AbstractEventLoop | None = None,
+        connect_timeout: float = 5.0,
+    ) -> None:
+        self._uri = uri
+        self._loop = loop
+        self._connect_timeout = connect_timeout
+        self._queue: "queue.Queue[tuple[bytes, int, int] | None]" = queue.Queue()
+
+    def submit_audio(self, pcm: bytes, sample_rate: int, channels: int) -> None:
+        """Queue audio to forward to the websocket service."""
+
+        self._queue.put((pcm, sample_rate, channels))
+
+    def close(self) -> None:
+        """Signal the streaming task to finish."""
+
+        self._queue.put(None)
+
+    async def _transcribe(self, publish: PublishCallback, stop_event: threading.Event) -> None:
+        import websockets
+
+        async with websockets.connect(self._uri, open_timeout=self._connect_timeout) as ws:
+            while not stop_event.is_set():
+                try:
+                    item = await asyncio.to_thread(self._queue.get, True, 0.1)
+                except queue.Empty:
+                    continue
+                if item is None:
+                    break
+                pcm, sample_rate, channels = item
+                payload = {
+                    "type": "chunk",
+                    "sample_rate": sample_rate,
+                    "channels": channels,
+                    "pcm": base64.b64encode(pcm).decode("ascii"),
+                }
+                await ws.send(json.dumps(payload))
+                response = await ws.recv()
+                if isinstance(response, bytes):
+                    continue
+                if not response:
+                    continue
+                try:
+                    decoded = json.loads(response)
+                except json.JSONDecodeError:
+                    text = response.strip()
+                else:
+                    text = str(decoded.get("text", "")).strip()
+                if text:
+                    publish(text)
+
+    def run(self, publish: PublishCallback, stop_event: threading.Event) -> None:
+        """Bridge the websocket transcription service to the publish callback."""
+
+        loop = self._loop or asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self._transcribe(publish, stop_event))
+        finally:
+            pending = asyncio.all_tasks(loop=loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.stop()
+            loop.close()

--- a/modules/ear/packages/ear/ear/cli.py
+++ b/modules/ear/packages/ear/ear/cli.py
@@ -1,0 +1,7 @@
+"""Console entry point for the ear transcription service."""
+
+from __future__ import annotations
+
+from .node import main
+
+__all__ = ["main"]

--- a/modules/ear/packages/ear/ear/node.py
+++ b/modules/ear/packages/ear/ear/node.py
@@ -1,0 +1,128 @@
+"""ROS 2 node orchestrating transcription backends for the ear module."""
+
+from __future__ import annotations
+
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from std_msgs.msg import String, UInt8MultiArray
+
+from .backends import (
+    AudioAwareBackend,
+    ConsoleEarBackend,
+    EarBackend,
+    FasterWhisperEarBackend,
+    ServiceASREarBackend,
+)
+from .worker import EarWorker
+
+
+class EarNode(Node):
+    """ROS node that publishes recognised transcripts to a topic."""
+
+    def __init__(self) -> None:
+        super().__init__("ear")
+        self._hole_topic = self._declare_topic("hole_topic", "/ear/hole")
+        self._publisher = self.create_publisher(String, self._hole_topic, 10)
+        backend = self._create_backend()
+        self._worker = EarWorker(backend=backend, publisher=self._publish_text, logger=self.get_logger())
+        self._worker.start()
+
+        self._text_subscription = None
+        text_topic = self._declare_topic("text_input_topic", "")
+        if text_topic and text_topic != self._hole_topic:
+            self._text_subscription = self.create_subscription(String, text_topic, self._handle_text, 10)
+        elif text_topic == self._hole_topic:
+            self.get_logger().warning("text_input_topic matches hole_topic; ignoring to avoid republishing loop")
+
+        self._audio_subscription = None
+        self._audio_sample_rate = 16000
+        self._audio_channels = 1
+        if isinstance(backend, AudioAwareBackend):
+            audio_topic = self._declare_topic("audio_topic", "/audio/raw")
+            self._audio_sample_rate = int(self.declare_parameter("audio_sample_rate", 16000).value)
+            self._audio_channels = int(self.declare_parameter("audio_channels", 1).value)
+            self._audio_subscription = self.create_subscription(
+                UInt8MultiArray,
+                audio_topic,
+                self._handle_audio,
+                10,
+            )
+
+        self.get_logger().info(
+            "Ear node ready (backend=%s, hole_topic=%s)",
+            backend.__class__.__name__,
+            self._hole_topic,
+        )
+
+    def _declare_topic(self, name: str, default: str) -> str:
+        parameter = self.declare_parameter(name, default)
+        value = str(parameter.value).strip()
+        return value or default
+
+    def _create_backend(self) -> EarBackend:
+        backend_name = str(self.declare_parameter("backend", "console").value).strip().lower()
+        if backend_name in {"console", "stdin", "text"}:
+            return ConsoleEarBackend()
+        if backend_name in {"faster_whisper", "whisper"}:
+            try:
+                import faster_whisper  # type: ignore[import-not-found]
+            except ImportError:
+                self.get_logger().warning("faster-whisper backend requested but dependency is missing; falling back to console")
+                return ConsoleEarBackend()
+            model = str(self.declare_parameter("faster_whisper_model", "base").value).strip() or "base"
+            device = str(self.declare_parameter("faster_whisper_device", "cpu").value).strip() or "cpu"
+            compute_type = str(self.declare_parameter("faster_whisper_compute_type", "int8").value).strip() or "int8"
+            language_param = str(self.declare_parameter("faster_whisper_language", "").value).strip()
+            beam_size = self.declare_parameter("faster_whisper_beam_size", 5).value
+            beam_size_value = int(beam_size) if isinstance(beam_size, (int, float)) else 5
+            return FasterWhisperEarBackend(
+                model_size=model,
+                device=device,
+                compute_type=compute_type,
+                language=language_param or None,
+                beam_size=beam_size_value,
+            )
+        if backend_name in {"service", "asr", "websocket"}:
+            uri = str(self.declare_parameter("service_uri", "ws://127.0.0.1:8089/ws").value).strip() or "ws://127.0.0.1:8089/ws"
+            return ServiceASREarBackend(uri=uri)
+        self.get_logger().warning("Unknown backend '%s'; defaulting to console backend", backend_name)
+        return ConsoleEarBackend()
+
+    def _handle_text(self, msg: String) -> None:
+        text = msg.data.strip()
+        if not text:
+            return
+        self._publish_text(text)
+
+    def _handle_audio(self, msg: UInt8MultiArray) -> None:
+        if not msg.data:
+            return
+        pcm = bytes(msg.data)
+        self._worker.submit_audio(pcm, self._audio_sample_rate, self._audio_channels)
+
+    def _publish_text(self, text: str) -> None:
+        ros_msg = String()
+        ros_msg.data = text
+        self._publisher.publish(ros_msg)
+        self.get_logger().info("Heard: %s", text)
+
+    def destroy_node(self) -> bool:
+        self._worker.stop()
+        return super().destroy_node()
+
+
+def main(args: list[str] | None = None) -> None:
+    rclpy.init(args=args)
+    node = EarNode()
+    executor = MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        node.get_logger().info("Ear node interrupted; shutting down")
+    finally:
+        executor.remove_node(node)
+        node.destroy_node()
+        rclpy.shutdown()

--- a/modules/ear/packages/ear/ear/worker.py
+++ b/modules/ear/packages/ear/ear/worker.py
@@ -1,0 +1,76 @@
+"""Utility for running ear backends in a managed thread."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+
+from .backends import AudioAwareBackend, EarBackend
+
+PublishCallback = Callable[[str], None]
+
+
+class EarWorker:
+    """Run a transcription backend on a background thread."""
+
+    def __init__(
+        self,
+        *,
+        backend: EarBackend,
+        publisher: PublishCallback,
+        logger: logging.Logger | None,
+    ) -> None:
+        self._backend = backend
+        self._publisher = publisher
+        self._logger = logger or logging.getLogger(__name__)
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started = False
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the worker thread if it is not already running."""
+
+        with self._lock:
+            if self._started:
+                return
+            self._thread = threading.Thread(target=self._run, name="EarWorker", daemon=True)
+            self._thread.start()
+            self._started = True
+
+    def stop(self) -> None:
+        """Signal the backend to stop and wait for the thread to exit."""
+
+        with self._lock:
+            if not self._started:
+                return
+            self._stop_event.set()
+            if isinstance(self._backend, AudioAwareBackend):
+                try:
+                    self._backend.close()
+                except Exception:  # pragma: no cover - defensive logging
+                    self._logger.exception("Failed to close audio backend cleanly")
+            thread = self._thread
+            if thread is not None:
+                thread.join(timeout=5)
+            self._thread = None
+            self._started = False
+            self._stop_event = threading.Event()
+
+    def _run(self) -> None:
+        try:
+            self._backend.run(self._publisher, self._stop_event)
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Ear backend terminated with an error")
+        finally:
+            with self._lock:
+                self._started = False
+
+    def submit_audio(self, pcm: bytes, sample_rate: int, channels: int) -> None:
+        """Submit PCM audio to the backend if supported."""
+
+        if isinstance(self._backend, AudioAwareBackend):
+            self._backend.submit_audio(pcm, sample_rate, channels)
+        else:
+            self._logger.warning("Backend %s does not accept audio", self._backend)

--- a/modules/ear/packages/ear/package.xml
+++ b/modules/ear/packages/ear/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ear</name>
+  <version>0.1.0</version>
+  <description>Ear module providing flexible transcription backends.</description>
+  <maintainer email="pete@psyched.local">Psyched Maintainers</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>python3-websockets</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+</package>

--- a/modules/ear/packages/ear/setup.py
+++ b/modules/ear/packages/ear/setup.py
@@ -1,0 +1,26 @@
+from setuptools import find_packages, setup
+
+package_name = 'ear'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=find_packages(exclude=['tests']),
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools', 'numpy>=1.24,<3', 'websockets>=12,<13'],
+    extras_require={'faster-whisper': ['faster-whisper>=0.10,<1.0']},
+    zip_safe=True,
+    maintainer='Psyched Maintainers',
+    maintainer_email='pete@psyched.local',
+    description='Ear module that collects text from multiple transcription backends.',
+    license='Apache-2.0',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'ear_service = ear.cli:main',
+        ],
+    },
+)

--- a/modules/ear/packages/ear/tests/test_backends.py
+++ b/modules/ear/packages/ear/tests/test_backends.py
@@ -1,0 +1,79 @@
+"""Tests for ear backends and workers."""
+
+from __future__ import annotations
+
+import io
+import threading
+from collections.abc import Callable
+
+import pytest
+
+from ear.backends import ConsoleEarBackend
+from ear.worker import EarWorker
+
+
+class _PublishCollector:
+    """Helper that records published transcripts for assertions."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._items: list[str] = []
+
+    def __call__(self, text: str) -> None:
+        with self._lock:
+            self._items.append(text)
+
+    @property
+    def items(self) -> list[str]:
+        with self._lock:
+            return list(self._items)
+
+
+def test_console_backend_emits_non_empty_lines() -> None:
+    """Console backend should strip whitespace and ignore blank lines."""
+
+    input_stream = io.StringIO(" Hello\n\nworld  \n   \nBYE\n")
+    output_stream = io.StringIO()
+    backend = ConsoleEarBackend(input_stream=input_stream, output_stream=output_stream)
+    stop_event = threading.Event()
+    published: list[str] = []
+
+    backend.run(published.append, stop_event)
+
+    assert published == ["Hello", "world", "BYE"]
+    prompt_text = output_stream.getvalue()
+    assert "\u001b[" in prompt_text  # ANSI color prefix
+    assert prompt_text.endswith("\u001b[0m")
+
+
+class _BlockingBackend:
+    """Backend used to verify worker start/stop semantics."""
+
+    def __init__(self) -> None:
+        self.stop_event: threading.Event | None = None
+        self.started = threading.Event()
+        self._publish: Callable[[str], None] | None = None
+
+    def run(self, publish: Callable[[str], None], stop_event: threading.Event) -> None:  # pragma: no cover - interface
+        self._publish = publish
+        self.stop_event = stop_event
+        self.started.set()
+        stop_event.wait()
+        publish("done")
+
+
+def test_worker_stops_backend_on_shutdown() -> None:
+    """EarWorker should signal stop and wait for the backend to finish."""
+
+    backend = _BlockingBackend()
+    collector = _PublishCollector()
+    worker = EarWorker(backend=backend, publisher=collector, logger=None)
+
+    worker.start()
+    backend.started.wait(timeout=1)
+    assert backend.started.is_set()
+
+    worker.stop()
+
+    assert collector.items == ["done"]
+    assert backend.stop_event is not None and backend.stop_event.is_set()

--- a/modules/ear/shutdown_unit.sh
+++ b/modules/ear/shutdown_unit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATTERN="ros2 run ear ear_service"
+
+if pgrep -f "$PATTERN" >/dev/null 2>&1; then
+  echo "[ear/shutdown] Stopping $PATTERN"
+  pkill -TERM -f "$PATTERN" || true
+fi
+
+for _ in {1..10}; do
+  if ! pgrep -f "$PATTERN" >/dev/null 2>&1; then
+    echo "[ear/shutdown] Ear service stopped"
+    exit 0
+  fi
+  sleep 1
+done
+
+pkill -KILL -f "$PATTERN" || true
+echo "[ear/shutdown] Forced kill"


### PR DESCRIPTION
## Summary
- add a new ear ROS 2 module with configurable backends for console input, local faster-whisper transcription, and the ASR websocket service
- implement a reusable EarWorker helper and launch/shutdown scripts for managing the transcription service
- cover the console backend and worker lifecycle with unit tests and package metadata

## Testing
- PYTHONPATH=modules/ear/packages/ear:$PYTHONPATH pytest modules/ear/packages/ear/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e0a405c1e4832086d6bdc03ca9f853