### PR TITLE
Use apt-get for provisioning

### DIFF
--- a/tools/bootstrap/bootstrap.sh
+++ b/tools/bootstrap/bootstrap.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 # --------------------------------------------------------------------
 
 # 1. Update & upgrade
-sudo apt update && sudo apt upgrade -y
+sudo apt-get update && sudo apt-get upgrade -y
 
 # 2. Essentials: compiler, Python (for ROS tooling), editors
-sudo apt install -y \
+sudo apt-get install -y \
   curl git build-essential make \
   python3-full python3-pip python3-venv python-is-python3 \
   shellcheck micro mc ripgrep
@@ -24,7 +24,7 @@ if ! grep -Fx "$local_path_export" "$HOME/.bashrc" >/dev/null 2>&1; then
 fi
 
 # 3. mDNS support (Avahi)
-sudo apt install -y avahi-daemon avahi-utils libnss-mdns
+sudo apt-get install -y avahi-daemon avahi-utils libnss-mdns
 
 # Ensure /etc/nsswitch.conf has mdns entries
 ensure_mdns_hosts_entry() {
@@ -89,12 +89,12 @@ ensure_mdns_hosts_entry
 ensure_mdns_service
 
 # 4. Convenience tools
-if ! sudo apt install -y unzip 1>&2; then
+if ! sudo apt-get install -y unzip 1>&2; then
     echo "Warning: failed to install unzip; continuing" >&2
 fi
 
 # 5. ROS colcon tooling
-sudo apt install -y python3-colcon-*
+sudo apt-get install -y python3-colcon-*
 
 # 6. Deno runtime
 install_deno() {

--- a/tools/bootstrap/install_cuda.sh
+++ b/tools/bootstrap/install_cuda.sh
@@ -31,8 +31,8 @@ fi
 
 export LANG=en_US.UTF-8
 
-${SUDO[@]} apt update
-${SUDO[@]} apt install -y ca-certificates curl gnupg lsb-release software-properties-common
+${SUDO[@]} apt-get update
+${SUDO[@]} apt-get install -y ca-certificates curl gnupg lsb-release software-properties-common
 
 . /etc/os-release
 if [[ "${ID}" != "ubuntu" ]]; then
@@ -57,7 +57,7 @@ ${SUDO[@]} chmod a+r "${KEYRING_PATH}"
 echo "deb [signed-by=${KEYRING_PATH}] ${REPO_URL} /" | \
   ${SUDO[@]} tee /etc/apt/sources.list.d/cuda-${REPO_ID}.list >/dev/null
 
-${SUDO[@]} apt update
+${SUDO[@]} apt-get update
 
 CUDA_PACKAGES=(
   cuda-toolkit-12-4
@@ -65,7 +65,7 @@ CUDA_PACKAGES=(
 )
 
 echo "Installing CUDA packages: ${CUDA_PACKAGES[*]}"
-${SUDO[@]} apt install -y "${CUDA_PACKAGES[@]}"
+${SUDO[@]} apt-get install -y "${CUDA_PACKAGES[@]}"
 
 echo "CUDA installation complete. Recommended post-install steps:"
 echo "  - Reboot the system to load the NVIDIA kernel modules."

--- a/tools/bootstrap/install_deno.sh
+++ b/tools/bootstrap/install_deno.sh
@@ -39,8 +39,8 @@ fi
 
 if ! command -v unzip >/dev/null 2>&1; then
   echo "Installing unzip dependency..."
-  ${SUDO[@]} apt update
-  ${SUDO[@]} apt install -y unzip
+  ${SUDO[@]} apt-get update
+  ${SUDO[@]} apt-get install -y unzip
 fi
 
 TMPDIR=$(mktemp -d)

--- a/tools/bootstrap/install_docker.sh
+++ b/tools/bootstrap/install_docker.sh
@@ -20,8 +20,8 @@ echo "Provisioning Docker Engine and Docker Compose (plugin) from Docker's offic
 
 export LANG=en_US.UTF-8
 
-${SUDO[@]} apt update
-${SUDO[@]} apt install -y ca-certificates curl gnupg lsb-release
+${SUDO[@]} apt-get update
+${SUDO[@]} apt-get install -y ca-certificates curl gnupg lsb-release
 
 echo "Setting up Docker apt repository and GPG key..."
 
@@ -40,10 +40,10 @@ fi
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${OS_CODENAME} stable" \
   | ${SUDO[@]} tee /etc/apt/sources.list.d/docker.list >/dev/null
 
-${SUDO[@]} apt update
+${SUDO[@]} apt-get update
 
 echo "Installing docker packages..."
-${SUDO[@]} apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+${SUDO[@]} apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 echo "Enabling and starting docker service..."
 ${SUDO[@]} systemctl enable --now docker

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -29,17 +29,17 @@ echo "Provisioning ROS 2 ${ROS_DISTRO} using Debian packages..."
 
 export LANG=en_US.UTF-8
 
-"${SUDO[@]}" apt update
-"${SUDO[@]}" apt install -y locales
+"${SUDO[@]}" apt-get update
+"${SUDO[@]}" apt-get install -y locales
 "${SUDO[@]}" locale-gen en_US en_US.UTF-8
 "${SUDO[@]}" update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 locale
 
-"${SUDO[@]}" apt install -y software-properties-common
+"${SUDO[@]}" apt-get install -y software-properties-common
 "${SUDO[@]}" add-apt-repository -y universe
-"${SUDO[@]}" apt update
-"${SUDO[@]}" apt install -y curl ca-certificates
+"${SUDO[@]}" apt-get update
+"${SUDO[@]}" apt-get install -y curl ca-certificates
 
 echo "Setting up ROS 2 apt repository..."
 
@@ -52,10 +52,10 @@ echo "Installing ROS 2 ${ROS_DISTRO} packages..."
 
 # Install only minimal ROS2 base (no desktop/GUI/Qt dependencies)
 "${SUDO[@]}" dpkg -i /tmp/ros2-apt-source.deb
-"${SUDO[@]}" apt update
-"${SUDO[@]}" apt upgrade -y
+"${SUDO[@]}" apt-get update
+"${SUDO[@]}" apt-get upgrade -y
 
-"${SUDO[@]}" apt install -y \
+"${SUDO[@]}" apt-get install -y \
   ros-${ROS_DISTRO}-ros-base \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
   python3-colcon-common-extensions \

--- a/tools/psh/lib/deps/cuda.ts
+++ b/tools/psh/lib/deps/cuda.ts
@@ -15,13 +15,13 @@ export async function installCuda(context: ProvisionContext): Promise<void> {
   });
 
   await context.step("Install CUDA prerequisites", async (step) => {
-    await step.exec(["apt", "update"], {
+    await step.exec(["apt-get", "update"], {
       sudo: true,
-      description: "apt update",
+      description: "apt-get update",
     });
     await step.exec(
       [
-        "apt",
+        "apt-get",
         "install",
         "-y",
         "ca-certificates",
@@ -75,9 +75,9 @@ export async function installCuda(context: ProvisionContext): Promise<void> {
         sudo: true,
         description: "install cuda apt source",
       });
-      await step.exec(["apt", "update"], {
+      await step.exec(["apt-get", "update"], {
         sudo: true,
-        description: "apt update (cuda)",
+        description: "apt-get update (cuda)",
       });
     } finally {
       await safeRemove(tmpDir);
@@ -86,7 +86,7 @@ export async function installCuda(context: ProvisionContext): Promise<void> {
 
   await context.step("Install CUDA packages", async (step) => {
     const packages = ["cuda-toolkit-12-4", "nvidia-driver-535"];
-    await step.exec(["apt", "install", "-y", ...packages], {
+    await step.exec(["apt-get", "install", "-y", ...packages], {
       sudo: true,
       description: "install cuda packages",
     });

--- a/tools/psh/lib/deps/docker.ts
+++ b/tools/psh/lib/deps/docker.ts
@@ -4,13 +4,13 @@ import { detectUbuntuCodename, fetchBinary, safeRemove } from "./os.ts";
 
 export async function installDocker(context: ProvisionContext): Promise<void> {
   await context.step("Install Docker prerequisites", async (step) => {
-    await step.exec(["apt", "update"], {
+    await step.exec(["apt-get", "update"], {
       sudo: true,
-      description: "apt update",
+      description: "apt-get update",
     });
     await step.exec(
       [
-        "apt",
+        "apt-get",
         "install",
         "-y",
         "ca-certificates",
@@ -66,9 +66,9 @@ export async function installDocker(context: ProvisionContext): Promise<void> {
         sudo: true,
         description: "install docker apt source",
       });
-      await step.exec(["apt", "update"], {
+      await step.exec(["apt-get", "update"], {
         sudo: true,
-        description: "apt update (docker)",
+        description: "apt-get update (docker)",
       });
     } finally {
       await safeRemove(tmpDir);
@@ -78,7 +78,7 @@ export async function installDocker(context: ProvisionContext): Promise<void> {
   await context.step("Install Docker Engine", async (step) => {
     await step.exec(
       [
-        "apt",
+        "apt-get",
         "install",
         "-y",
         "docker-ce",

--- a/tools/psh/lib/deps/ros2.ts
+++ b/tools/psh/lib/deps/ros2.ts
@@ -45,13 +45,13 @@ export async function installRos2(context: ProvisionContext): Promise<void> {
   });
 
   await context.step("Install ROS 2 prerequisites", async (step) => {
-    await step.exec(["apt", "update"], {
+    await step.exec(["apt-get", "update"], {
       sudo: true,
-      description: "apt update",
+      description: "apt-get update",
     });
     await step.exec(
       [
-        "apt",
+        "apt-get",
         "install",
         "-y",
         "ca-certificates",
@@ -61,7 +61,7 @@ export async function installRos2(context: ProvisionContext): Promise<void> {
         "locales",
         "software-properties-common",
       ],
-      { sudo: true, description: "apt install prerequisites" },
+      { sudo: true, description: "apt-get install prerequisites" },
     );
     await step.exec(["add-apt-repository", "-y", "universe"], {
       sudo: true,
@@ -124,9 +124,9 @@ export async function installRos2(context: ProvisionContext): Promise<void> {
         sudo: true,
         description: "install ROS apt source",
       });
-      await step.exec(["apt", "update"], {
+      await step.exec(["apt-get", "update"], {
         sudo: true,
-        description: "apt update (ros2)",
+        description: "apt-get update (ros2)",
       });
     } finally {
       await safeRemove(tmpDir);
@@ -142,9 +142,9 @@ export async function installRos2(context: ProvisionContext): Promise<void> {
         "python3-colcon-common-extensions",
         "python3-rosdep",
       ];
-      await step.exec(["apt", "install", "-y", ...packages], {
+      await step.exec(["apt-get", "install", "-y", ...packages], {
         sudo: true,
-        description: "apt install ros packages",
+        description: "apt-get install ros packages",
       });
     },
   );

--- a/tools/psh/lib/deps/util_test.ts
+++ b/tools/psh/lib/deps/util_test.ts
@@ -2,27 +2,27 @@ import { assertEquals, assertThrows } from "$std/testing/asserts.ts";
 import { applySudo } from "./util.ts";
 
 Deno.test("applySudo keeps args unchanged for root", () => {
-  const result = applySudo(["apt", "update"], {
+  const result = applySudo(["apt-get", "update"], {
     requireSudo: true,
     isRoot: true,
     sudoPath: undefined,
   });
-  assertEquals(result, ["apt", "update"]);
+  assertEquals(result, ["apt-get", "update"]);
 });
 
 Deno.test("applySudo prefixes sudo when available", () => {
-  const result = applySudo(["apt", "update"], {
+  const result = applySudo(["apt-get", "update"], {
     requireSudo: true,
     isRoot: false,
     sudoPath: "/usr/bin/sudo",
   });
-  assertEquals(result, ["/usr/bin/sudo", "apt", "update"]);
+  assertEquals(result, ["/usr/bin/sudo", "apt-get", "update"]);
 });
 
 Deno.test("applySudo throws when required but unavailable", () => {
   assertThrows(
     () => {
-      applySudo(["apt", "update"], {
+      applySudo(["apt-get", "update"], {
         requireSudo: true,
         isRoot: false,
         sudoPath: undefined,
@@ -34,10 +34,10 @@ Deno.test("applySudo throws when required but unavailable", () => {
 });
 
 Deno.test("applySudo leaves args when sudo not required", () => {
-  const result = applySudo(["apt", "update"], {
+  const result = applySudo(["apt-get", "update"], {
     requireSudo: false,
     isRoot: false,
     sudoPath: undefined,
   });
-  assertEquals(result, ["apt", "update"]);
+  assertEquals(result, ["apt-get", "update"]);
 });


### PR DESCRIPTION
## Summary
- replace all bootstrap shell script invocations of `apt` with `apt-get`
- update `psh` dependency installers to run `apt-get` commands and fix the accompanying unit tests
- ensure descriptions reference `apt-get` to reflect the new commands

## Testing
- `deno test --config deno.json lib/deps/util_test.ts` *(fails: `deno` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1438a7f948320b4468b3c28b381b5