### PR TITLE
Prevent catkin package conflict in ROS installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Always prefer running the smallest relevant command set.
 - **Workspace resets:** `tools/clean_workspace` wipes `work/` and relinks local ROS/Python packages. Run it (or `psh clean`) whenever package paths drift instead of tweaking build directories manually.
 - **Deno TLS certificates:** When fetching dependencies during `deno task test`, set `DENO_TLS_CA_STORE=system` if you encounter TLS certificate errors in restricted environments.
 - **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
+- **APT CLI stability:** Provisioning scripts must use `apt-get` (not `apt`) to avoid behaviour changes and interactive warnings during automation.
 
 ## Useful references
 

--- a/tests/install_ros2_script_test.sh
+++ b/tests/install_ros2_script_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Behavioural check ensuring the ROS 2 installer guards against known dpkg conflicts.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+ROS_INSTALLER="${ROOT_DIR}/tools/provision/install_ros2.sh"
+
+if [[ ! -f "${ROS_INSTALLER}" ]]; then
+  echo "Expected installer script at ${ROS_INSTALLER} is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'apt-get remove -y python3-catkin-pkg' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must remove python3-catkin-pkg before installing ROS 2 base packages." >&2
+  exit 1
+fi
+
+REMOVE_LINE=$(grep -Fn 'apt-get remove -y python3-catkin-pkg' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
+INSTALL_LINE=$(grep -Fn 'ros-${ROS_DISTRO:-\${ROS_DISTRO}}-ros-base' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
+
+if [[ -z "${INSTALL_LINE}" ]]; then
+  INSTALL_LINE=$(grep -Fn 'ros-${ROS_DISTRO}-ros-base' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
+fi
+
+if [[ -z "${INSTALL_LINE}" ]]; then
+  echo "Failed to detect ros-base installation line in install_ros2.sh." >&2
+  exit 1
+fi
+
+if (( REMOVE_LINE >= INSTALL_LINE )); then
+  echo "python3-catkin-pkg removal must happen before ros-base installation to avoid dpkg conflicts." >&2
+  exit 1
+fi

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -55,6 +55,16 @@ echo "Installing ROS 2 ${ROS_DISTRO} packages..."
 "${SUDO[@]}" apt-get update
 "${SUDO[@]}" apt-get upgrade -y
 
+# Remove the legacy python3-catkin-pkg package if present. The ROS apt
+# repository ships python3-catkin-pkg-modules which owns the same files, and
+# leaving both installed triggers a dpkg conflict during provisioning.
+if dpkg -s python3-catkin-pkg >/dev/null 2>&1; then
+  echo "Removing conflicting python3-catkin-pkg package before installing ROS 2 base packages..."
+  "${SUDO[@]}" apt-get remove -y python3-catkin-pkg
+  "${SUDO[@]}" apt-get install -y -f
+  "${SUDO[@]}" dpkg --configure -a
+fi
+
 "${SUDO[@]}" apt-get install -y \
   ros-${ROS_DISTRO}-ros-base \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \


### PR DESCRIPTION
## Summary
- remove the legacy python3-catkin-pkg package before installing ROS 2 base packages and run fix-up steps
- document the apt-get requirement for automation in the agent handbook
- add a regression test that ensures the installer keeps the removal ahead of the ros-base installation

## Testing
- bash tests/install_ros2_script_test.sh
- bash tests/psyched_env_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e14488038483209fd4f80efe7b60bb