### PR TITLE
Stop installing colcon Debian packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Always prefer running the smallest relevant command set.
 - **Deno TLS certificates:** When fetching dependencies during `deno task test`, set `DENO_TLS_CA_STORE=system` if you encounter TLS certificate errors in restricted environments.
 - **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
 - **APT CLI stability:** Provisioning scripts must use `apt-get` (not `apt`) to avoid behaviour changes and interactive warnings during automation.
+- **ROS tooling packages:** Avoid installing `python3-colcon-*` or other catkin/colcon Debian packages; rely on ros-base and rosdep instead to prevent dpkg conflicts on Pete's hosts.
 
 ## Useful references
 

--- a/tests/install_ros2_script_test.sh
+++ b/tests/install_ros2_script_test.sh
@@ -32,3 +32,8 @@ if (( REMOVE_LINE >= INSTALL_LINE )); then
   echo "python3-catkin-pkg removal must happen before ros-base installation to avoid dpkg conflicts." >&2
   exit 1
 fi
+
+if grep -Fq 'python3-colcon' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must not install python3-colcon-* packages." >&2
+  exit 1
+fi

--- a/tools/bootstrap/bootstrap.sh
+++ b/tools/bootstrap/bootstrap.sh
@@ -93,8 +93,7 @@ if ! sudo apt-get install -y unzip 1>&2; then
     echo "Warning: failed to install unzip; continuing" >&2
 fi
 
-# 5. ROS colcon tooling
-sudo apt-get install -y python3-colcon-*
+# 5. ROS tooling intentionally minimal; avoid installing python3-colcon-* to prevent catkin conflicts
 
 # 6. Deno runtime
 install_deno() {

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -68,7 +68,6 @@ fi
 "${SUDO[@]}" apt-get install -y \
   ros-${ROS_DISTRO}-ros-base \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-  python3-colcon-common-extensions \
   python3-rosdep
 
 if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then

--- a/tools/psh/lib/deps/ros2.ts
+++ b/tools/psh/lib/deps/ros2.ts
@@ -31,6 +31,14 @@ export function renderRosProfile(distro: string): string {
   ].join("\n");
 }
 
+export function buildRosBasePackages(distro: string): string[] {
+  return [
+    `ros-${distro}-ros-base`,
+    `ros-${distro}-rmw-cyclonedds-cpp`,
+    "python3-rosdep",
+  ];
+}
+
 export async function installRos2(context: ProvisionContext): Promise<void> {
   const rosDistro = determineRosDistro({ env: Deno.env.toObject() });
   const rosRoot = `/opt/ros/${rosDistro}`;
@@ -136,12 +144,7 @@ export async function installRos2(context: ProvisionContext): Promise<void> {
   await context.step(
     `Install ROS 2 ${rosDistro} base packages`,
     async (step) => {
-      const packages = [
-        `ros-${rosDistro}-ros-base`,
-        `ros-${rosDistro}-rmw-cyclonedds-cpp`,
-        "python3-colcon-common-extensions",
-        "python3-rosdep",
-      ];
+      const packages = buildRosBasePackages(rosDistro);
       await step.exec(["apt-get", "install", "-y", ...packages], {
         sudo: true,
         description: "apt-get install ros packages",

--- a/tools/psh/lib/deps/ros2_test.ts
+++ b/tools/psh/lib/deps/ros2_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "$std/testing/asserts.ts";
-import { determineRosDistro, renderRosProfile } from "./ros2.ts";
+import {
+  buildRosBasePackages,
+  determineRosDistro,
+  renderRosProfile,
+} from "./ros2.ts";
 
 Deno.test("determineRosDistro respects env override", () => {
   const value = determineRosDistro({ env: { ROS_DISTRO: "jazzy" } });
@@ -16,4 +20,13 @@ Deno.test("renderRosProfile emits consistent template", () => {
   const expected =
     `# ROS 2 defaults provisioned by psh\nexport LANG=en_US.UTF-8\nexport RMW_IMPLEMENTATION=rmw_cyclonedds_cpp\nexport ROS_DOMAIN_ID=0\nexport ROS_LOCALHOST_ONLY=0\n# shellcheck disable=SC1091\n. /opt/ros/humble/setup.bash\n`;
   assertEquals(script, expected);
+});
+
+Deno.test("ROS base package set excludes colcon tooling", () => {
+  const packages = buildRosBasePackages("jazzy");
+  assertEquals(packages, [
+    "ros-jazzy-ros-base",
+    "ros-jazzy-rmw-cyclonedds-cpp",
+    "python3-rosdep",
+  ]);
 });


### PR DESCRIPTION
## Summary
- document that we avoid installing python3-colcon Debian packages during provisioning
- remove python3-colcon-common-extensions from the ROS installers and reuse a shared helper for the base package list
- extend installer tests to fail if colcon packages are reintroduced

## Testing
- `bash tests/install_ros2_script_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68e14c209c848320a88f0c65dbe35fbc