### PR TITLE
Streamline bootstrap and gate module setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Always prefer running the smallest relevant command set.
 - **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
 - **APT CLI stability:** Provisioning scripts must use `apt-get` (not `apt`) to avoid behaviour changes and interactive warnings during automation.
 - **ROS tooling packages:** Avoid installing `python3-colcon-*` or other catkin/colcon Debian packages; rely on ros-base and rosdep instead to prevent dpkg conflicts on Pete's hosts.
+- **Post-bootstrap reboot:** `./setup` now writes a reboot-required sentinel. `psh mod setup` refuses to run until the machine is restarted, so plan to reboot immediately after the bootstrap completes.
 
 ## Useful references
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Supporting utilities live under `tools/` and the `psh` CLI: a Deno-powered orche
 ```bash
 git clone https://github.com/dancxjo/psyched.git
 cd psyched
-./setup  # installs system dependencies, registers the Deno-based psh CLI, and opens the provisioning wizard
+./setup  # installs core dependencies, registers the Deno-based psh CLI, and opens the provisioning wizard
 ```
 
-`./setup` installs build toolchains (Python, ROS dependencies), configures mDNS, prepares Deno, and launches the interactive `psh` wizard (equivalent to running `psh` with no arguments). From there you can apply the host profile that triggers any bootstrap scripts declared in `hosts/*.toml`.
+`./setup` installs just the tools required to run `psh`, configures mDNS, prepares Deno, and launches the interactive `psh` wizard (equivalent to running `psh` with no arguments). Once the wizard completes **reboot the machine before running `psh mod setup`**—the bootstrap writes a reboot sentinel that module setup respects to keep ROS tooling cleanly staged.
 
 ### 2. Provision additional machines (optional)
 

--- a/tools/psh/lib/module.ts
+++ b/tools/psh/lib/module.ts
@@ -4,6 +4,7 @@ import { walkSync } from "$std/fs/walk.ts";
 import { colors } from "$cliffy/ansi/colors.ts";
 import { $ } from "$dax";
 import { modulesRoot, repoRoot, workspaceRoot, workspaceSrc } from "./paths.ts";
+import { ensureRebootCompleted } from "./reboot_guard.ts";
 
 const PID_DIR = join(workspaceRoot(), ".psh");
 const PILOT_MANIFEST = "fresh.gen.ts";
@@ -773,6 +774,7 @@ function isPidRunning(pid: number): boolean {
 }
 
 export async function setupModules(modules: string[]): Promise<void> {
+  ensureRebootCompleted();
   for (const module of modules) {
     await setupModule(module);
   }

--- a/tools/psh/lib/reboot_guard.ts
+++ b/tools/psh/lib/reboot_guard.ts
@@ -1,0 +1,90 @@
+import { join } from "$std/path/mod.ts";
+
+export class RebootRequiredError extends Error {
+  constructor(message = "System reboot required before continuing.") {
+    super(message);
+    this.name = "RebootRequiredError";
+  }
+}
+
+export interface EnsureRebootOptions {
+  sentinelPath?: string;
+  readBootTime?: () => number;
+}
+
+function defaultSentinelPath(): string {
+  const override = Deno.env.get("PSYCHED_REBOOT_SENTINEL");
+  if (override && override.length > 0) {
+    return override;
+  }
+  const xdgState = Deno.env.get("XDG_STATE_HOME");
+  if (xdgState && xdgState.length > 0) {
+    return join(xdgState, "psyched", "reboot-required");
+  }
+  const home = Deno.env.get("HOME");
+  if (home && home.length > 0) {
+    return join(home, ".local", "state", "psyched", "reboot-required");
+  }
+  return join(Deno.cwd(), ".psyched", "reboot-required");
+}
+
+function detectBootTime(): number {
+  try {
+    const stat = Deno.readTextFileSync("/proc/stat");
+    for (const line of stat.split("\n")) {
+      if (line.startsWith("btime")) {
+        const [, value] = line.trim().split(/\s+/);
+        const parsed = Number(value);
+        if (!Number.isNaN(parsed)) {
+          return parsed;
+        }
+      }
+    }
+  } catch (_error) {
+    // Fallback below.
+  }
+  return Math.floor(Date.now() / 1000);
+}
+
+function readSentinel(path: string): number | null {
+  try {
+    const content = Deno.readTextFileSync(path).trim();
+    if (!content) {
+      return null;
+    }
+    const parsed = Number(content);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function removeSentinel(path: string): void {
+  try {
+    Deno.removeSync(path);
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+}
+
+export function ensureRebootCompleted(
+  options: EnsureRebootOptions = {},
+): void {
+  const sentinelPath = options.sentinelPath ?? defaultSentinelPath();
+  const sentinelBootTime = readSentinel(sentinelPath);
+  if (sentinelBootTime === null) {
+    return;
+  }
+  const currentBootTime = options.readBootTime?.() ?? detectBootTime();
+  if (currentBootTime <= sentinelBootTime) {
+    throw new RebootRequiredError(
+      "Reboot required before running module setup. Please restart the system and rerun this command.",
+    );
+  }
+  removeSentinel(sentinelPath);
+}

--- a/tools/psh/lib/reboot_guard_test.ts
+++ b/tools/psh/lib/reboot_guard_test.ts
@@ -1,0 +1,35 @@
+import { assertEquals, assertThrows } from "$std/testing/asserts.ts";
+import { ensureRebootCompleted, RebootRequiredError } from "./reboot_guard.ts";
+
+Deno.test("guard passes when sentinel is missing", () => {
+  ensureRebootCompleted({
+    sentinelPath: `${Deno.makeTempDirSync()}/absent`,
+    readBootTime: () => 123,
+  });
+});
+
+Deno.test("guard blocks when reboot has not happened", () => {
+  const dir = Deno.makeTempDirSync();
+  const sentinel = `${dir}/reboot-required`;
+  Deno.writeTextFileSync(sentinel, "123\n");
+  assertThrows(
+    () => ensureRebootCompleted({
+      sentinelPath: sentinel,
+      readBootTime: () => 123,
+    }),
+    RebootRequiredError,
+    "reboot",
+  );
+  assertEquals(Deno.readTextFileSync(sentinel).trim(), "123");
+});
+
+Deno.test("guard clears sentinel once rebooted", () => {
+  const dir = Deno.makeTempDirSync();
+  const sentinel = `${dir}/reboot-required`;
+  Deno.writeTextFileSync(sentinel, "123\n");
+  ensureRebootCompleted({
+    sentinelPath: sentinel,
+    readBootTime: () => 456,
+  });
+  assertThrows(() => Deno.statSync(sentinel));
+});


### PR DESCRIPTION
## Summary
- collapse bootstrap apt installs into a single transaction, drop non-essential packages, and write a reboot sentinel before launching `psh`
- trim the ROS 2 installer to the minimal package set, add automatic bashrc sourcing, and reuse the new sentinel defaults
- guard `psh mod setup` behind a reboot check with accompanying unit tests and documentation updates

## Testing
- bash tests/install_ros2_script_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1a8ce9e0c8320bb5b16d71d4c921d