### PR TITLE
Keep psh up from terminating launched modules

### DIFF
--- a/tools/psh/lib/module_test.ts
+++ b/tools/psh/lib/module_test.ts
@@ -1,5 +1,15 @@
-import { assert, assertArrayIncludes } from "$std/testing/asserts.ts";
-import { listModules, moduleStatuses } from "./module.ts";
+import {
+  assert,
+  assertArrayIncludes,
+  assertStringIncludes,
+} from "$std/testing/asserts.ts";
+import { join } from "$std/path/mod.ts";
+import {
+  composeLaunchCommand,
+  listModules,
+  moduleStatuses,
+} from "./module.ts";
+import { repoRoot } from "./paths.ts";
 
 Deno.test("listModules discovers known modules", () => {
   const modules = listModules();
@@ -17,4 +27,27 @@ Deno.test("moduleStatuses reports state for each module", () => {
       assert(typeof status.pid === "number");
     }
   }
+});
+
+Deno.test("composeLaunchCommand uses prefixed tee logging", () => {
+  const command = composeLaunchCommand({
+    envCommands: ["source /tmp/env"],
+    launchScript: "/tmp/launch.sh",
+    logFile: "/var/log/demo module.log",
+    module: "demo module",
+  });
+  const prefixScript = join(repoRoot(), "tools", "psh", "scripts", "prefix_logs.sh");
+  assertStringIncludes(command, "source /tmp/env && exec bash '/tmp/launch.sh'");
+  assertStringIncludes(command, `> >('${prefixScript}' 'demo module' 'stdout' | tee -a '/var/log/demo module.log')`);
+  assertStringIncludes(command, `2> >('${prefixScript}' 'demo module' 'stderr' | tee -a '/var/log/demo module.log' >&2)`);
+});
+
+Deno.test("composeLaunchCommand escapes single quotes", () => {
+  const command = composeLaunchCommand({
+    envCommands: [],
+    launchScript: "/tmp/launch.sh",
+    logFile: "/var/log/demo.log",
+    module: "rocky's rig",
+  });
+  assertStringIncludes(command, `'rocky'"'"'s rig'`);
 });

--- a/tools/psh/scripts/prefix_logs.sh
+++ b/tools/psh/scripts/prefix_logs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Prefix each line from stdin with the module name and a stream-specific
+# colour. Intended to be used inside process substitutions, e.g.:
+#   exec bash launch.sh \
+#     > >(tools/psh/scripts/prefix_logs.sh module stdout | tee -a module.log)
+#
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  printf 'usage: %s <module> <stream>\n' "${0}" >&2
+  exit 64
+fi
+
+module_name=$1
+stream_name=$2
+shift 2
+
+# ANSI escape codes for dim (stdout) and red (stderr) highlighting.
+case "$stream_name" in
+  stdout)
+    color_start="\033[2m"
+    ;;
+  stderr)
+    color_start="\033[31m"
+    ;;
+  *)
+    color_start=""
+    ;;
+esac
+color_end="\033[0m"
+
+# Mirror stdin to stdout with the module-prefixed annotation while ensuring
+# trailing partial lines are flushed.
+while IFS= read -r line || [[ -n "$line" ]]; do
+  printf '%b[%s] %s%b\n' "$color_start" "$module_name" "$line" "$color_end"
+done


### PR DESCRIPTION
## Summary
- compose module launch commands with tee-based logging so stdout/stderr stay attached after `psh` exits
- add a reusable prefixing helper script that mirrors output to both the console and per-module logs
- cover the new launch command builder with tests, including shell-escaping edge cases

## Testing
- Not run (Deno CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1e5073abc832096dc58260b42b4d6