### PR TITLE
Install ros-dev-tools in ROS 2 setup scripts

### DIFF
--- a/tests/install_ros2_script_test.sh
+++ b/tests/install_ros2_script_test.sh
@@ -33,6 +33,12 @@ if (( REMOVE_LINE >= INSTALL_LINE )); then
   exit 1
 fi
 
+if ! grep -Fq 'ros-${ROS_DISTRO:-\${ROS_DISTRO}}-ros-dev-tools' "${ROS_INSTALLER}" && \
+   ! grep -Fq 'ros-${ROS_DISTRO}-ros-dev-tools' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must install ros-<distro>-ros-dev-tools alongside ros-base." >&2
+  exit 1
+fi
+
 if grep -Fq 'python3-colcon' "${ROS_INSTALLER}"; then
   echo "install_ros2.sh must not install python3-colcon-* packages." >&2
   exit 1

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -66,8 +66,10 @@ if dpkg -s python3-catkin-pkg >/dev/null 2>&1; then
   "${SUDO[@]}" dpkg --configure -a
 fi
 
+# ros-dev-tools pulls in colcon and other build tooling required by the Psyched stack.
 "${SUDO[@]}" apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-ros-base \
+  ros-${ROS_DISTRO}-ros-dev-tools \
   python3-rosdep
 
 if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then


### PR DESCRIPTION
## Summary
- ensure the ROS 2 bootstrap installer installs ros-dev-tools alongside ros-base for required build tooling
- extend the installer regression test to assert ros-dev-tools is included

## Testing
- tests/install_ros2_script_test.sh


------
https://chatgpt.com/codex/tasks/task_e_68e1e89503cc8320bcec73c538c2bc9d