### PR TITLE
Keep module launch logs alive after CLI exits

### DIFF
--- a/tools/psh/lib/module_test.ts
+++ b/tools/psh/lib/module_test.ts
@@ -4,11 +4,7 @@ import {
   assertStringIncludes,
 } from "$std/testing/asserts.ts";
 import { join } from "$std/path/mod.ts";
-import {
-  composeLaunchCommand,
-  listModules,
-  moduleStatuses,
-} from "./module.ts";
+import { composeLaunchCommand, listModules, moduleStatuses } from "./module.ts";
 import { repoRoot } from "./paths.ts";
 
 Deno.test("listModules discovers known modules", () => {
@@ -29,17 +25,55 @@ Deno.test("moduleStatuses reports state for each module", () => {
   }
 });
 
-Deno.test("composeLaunchCommand uses prefixed tee logging", () => {
+Deno.test("composeLaunchCommand directs streams through the prefix helper", () => {
   const command = composeLaunchCommand({
     envCommands: ["source /tmp/env"],
     launchScript: "/tmp/launch.sh",
     logFile: "/var/log/demo module.log",
     module: "demo module",
+    ttyPath: null,
   });
-  const prefixScript = join(repoRoot(), "tools", "psh", "scripts", "prefix_logs.sh");
-  assertStringIncludes(command, "source /tmp/env && exec bash '/tmp/launch.sh'");
-  assertStringIncludes(command, `> >('${prefixScript}' 'demo module' 'stdout' | tee -a '/var/log/demo module.log')`);
-  assertStringIncludes(command, `2> >('${prefixScript}' 'demo module' 'stderr' | tee -a '/var/log/demo module.log' >&2)`);
+  const prefixScript = join(
+    repoRoot(),
+    "tools",
+    "psh",
+    "scripts",
+    "prefix_logs.sh",
+  );
+  assertStringIncludes(
+    command,
+    "source /tmp/env && exec bash '/tmp/launch.sh'",
+  );
+  assertStringIncludes(
+    command,
+    `> >('${prefixScript}' 'demo module' 'stdout' '/var/log/demo module.log')`,
+  );
+  assertStringIncludes(
+    command,
+    `2> >('${prefixScript}' 'demo module' 'stderr' '/var/log/demo module.log')`,
+  );
+});
+
+Deno.test("composeLaunchCommand includes tty forwarding when provided", () => {
+  const command = composeLaunchCommand({
+    envCommands: [],
+    launchScript: "/tmp/launch.sh",
+    logFile: "/var/log/demo module.log",
+    module: "demo module",
+    ttyPath: "/dev/pts/9",
+    callerPid: 42,
+  });
+  const prefixScript = join(
+    repoRoot(),
+    "tools",
+    "psh",
+    "scripts",
+    "prefix_logs.sh",
+  );
+  assertStringIncludes(
+    command,
+    `> >('${prefixScript}' 'demo module' 'stdout' '/var/log/demo module.log' '/dev/pts/9' '42')`,
+  );
 });
 
 Deno.test("composeLaunchCommand escapes single quotes", () => {

--- a/tools/psh/scripts/prefix_logs.sh
+++ b/tools/psh/scripts/prefix_logs.sh
@@ -1,39 +1,89 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# Prefix each line from stdin with the module name and a stream-specific
-# colour. Intended to be used inside process substitutions, e.g.:
-#   exec bash launch.sh \
-#     > >(tools/psh/scripts/prefix_logs.sh module stdout | tee -a module.log)
+# Prefix each line from stdin with the module name and mirror it into the log
+# file. Optionally forward coloured output to a controlling TTY while the
+# original `psh` process is alive. Intended usage:
 #
+#   exec bash launch.sh \
+#     > >(tools/psh/scripts/prefix_logs.sh module stdout module.log "$TTY" "$PSH_PID")
 
 set -euo pipefail
 
-if [[ $# -lt 2 ]]; then
-  printf 'usage: %s <module> <stream>\n' "${0}" >&2
+if [[ $# -lt 3 ]]; then
+  printf 'usage: %s <module> <stream> <log-file> [tty-path] [caller-pid]\n' "$0" >&2
   exit 64
 fi
 
 module_name=$1
 stream_name=$2
-shift 2
+log_file=$3
+tty_path=${4-}
+caller_pid=${5-}
 
-# ANSI escape codes for dim (stdout) and red (stderr) highlighting.
 case "$stream_name" in
   stdout)
     color_start="\033[2m"
+    stream_suffix=""
     ;;
   stderr)
     color_start="\033[31m"
+    stream_suffix="[stderr]"
     ;;
   *)
     color_start=""
+    stream_suffix=""
     ;;
 esac
 color_end="\033[0m"
+if [[ -z "$color_start" ]]; then
+  color_end=""
+fi
 
-# Mirror stdin to stdout with the module-prefixed annotation while ensuring
-# trailing partial lines are flushed.
+log_prefix="[$module_name]${stream_suffix:+$stream_suffix}"
+
+# shellcheck disable=SC2094
+exec 3>>"$log_file"
+
+tty_active=0
+
+open_tty() {
+  if [[ -z "$tty_path" || $tty_active -eq 1 ]]; then
+    return
+  fi
+  if [[ -n "$caller_pid" ]] && ! kill -0 "$caller_pid" 2>/dev/null; then
+    tty_path=""
+    return
+  fi
+  # shellcheck disable=SC2094
+  exec 4>>"$tty_path"
+  tty_active=1
+}
+
+close_tty() {
+  if [[ $tty_active -eq 1 ]]; then
+    exec 4>&-
+    tty_active=0
+  fi
+}
+
+open_tty || true
+
 while IFS= read -r line || [[ -n "$line" ]]; do
-  printf '%b[%s] %s%b\n' "$color_start" "$module_name" "$line" "$color_end"
+  printf '%s %s\n' "$log_prefix" "$line" >&3
+
+  if [[ $tty_active -eq 1 && -n "$caller_pid" ]] && ! kill -0 "$caller_pid" 2>/dev/null; then
+    close_tty
+    tty_path=""
+  fi
+
+  if [[ $tty_active -eq 0 ]]; then
+    open_tty || true
+  fi
+
+  if [[ $tty_active -eq 1 ]]; then
+    printf '%b%s %s%b\n' "$color_start" "$log_prefix" "$line" "$color_end" >&4
+  fi
 done
+
+close_tty


### PR DESCRIPTION
## Summary
- update the module launch command builder to pass log file, tty, and caller PID information into the prefixing helper instead of tee-based pipes
- rewrite the prefix_logs.sh helper to append directly to the module log file and optionally mirror output to the tty only while psh is running
- expand composeLaunchCommand tests to cover the new argument flow and tty forwarding support

## Testing
- DENO_TLS_CA_STORE=system deno test --allow-all lib/module_test.ts
- deno lint lib/module.ts lib/module_test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1e8d818048320b645c9b4500814f2