### PR TITLE
Ensure ROS distro defaults reach module provisioning

### DIFF
--- a/env/psyched_env.sh
+++ b/env/psyched_env.sh
@@ -54,6 +54,14 @@ fi
 export PSYCHED_ROS_DISTRO
 export PSYCHED_ROS_SETUP
 
+# Ensure ROS tooling invoked from non-interactive shells (like the Deno-based
+# psh CLI) inherits the active ROS distribution even when the caller did not
+# export ROS_DISTRO explicitly. This mirrors the defaults installed into
+# /etc/profile.d/ros2-defaults.sh by the provisioning scripts.
+if [[ -z "${ROS_DISTRO:-}" ]]; then
+  export ROS_DISTRO="${PSYCHED_ROS_DISTRO}"
+fi
+
 psyched::log() {
   local level="$1"
   shift || true

--- a/tests/install_ros2_script_test.sh
+++ b/tests/install_ros2_script_test.sh
@@ -17,7 +17,10 @@ if ! grep -Fq 'apt-get remove -y python3-catkin-pkg' "${ROS_INSTALLER}"; then
 fi
 
 REMOVE_LINE=$(grep -Fn 'apt-get remove -y python3-catkin-pkg' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
+
+set +o pipefail
 INSTALL_LINE=$(grep -Fn 'ros-${ROS_DISTRO:-\${ROS_DISTRO}}-ros-base' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
+set -o pipefail
 
 if [[ -z "${INSTALL_LINE}" ]]; then
   INSTALL_LINE=$(grep -Fn 'ros-${ROS_DISTRO}-ros-base' "${ROS_INSTALLER}" | head -n1 | cut -d: -f1)
@@ -36,6 +39,11 @@ fi
 if ! grep -Fq 'ros-${ROS_DISTRO:-\${ROS_DISTRO}}-ros-dev-tools' "${ROS_INSTALLER}" && \
    ! grep -Fq 'ros-${ROS_DISTRO}-ros-dev-tools' "${ROS_INSTALLER}"; then
   echo "install_ros2.sh must install ros-<distro>-ros-dev-tools alongside ros-base." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'export ROS_DISTRO=${ROS_DISTRO}' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must export ROS_DISTRO in the default profile to support module provisioning." >&2
   exit 1
 fi
 

--- a/tests/psyched_env_test.sh
+++ b/tests/psyched_env_test.sh
@@ -61,6 +61,19 @@ SCRIPT
   [[ "${PSYCHED_TEST_MARKER}" == "workspace" ]]
 }
 
+test_sets_ros_distro_default() {
+  unset ROS_DISTRO || true
+  source "${ENV_SCRIPT}"
+  [[ "${ROS_DISTRO:-}" == "kilted" ]]
+}
+
+test_preserves_existing_ros_distro() {
+  export ROS_DISTRO="jazzy"
+  source "${ENV_SCRIPT}"
+  [[ "${ROS_DISTRO:-}" == "jazzy" ]]
+  [[ "${PSYCHED_ROS_DISTRO}" == "jazzy" ]]
+}
+
 test_activate_falls_back_to_ros() {
   source "${ENV_SCRIPT}"
   unset PSYCHED_TEST_MARKER || true
@@ -95,6 +108,8 @@ WORKSPACE
 scenario "exports default workspace paths" test_exports_defaults
 scenario "detects workspace setup file" test_workspace_setup_detection
 scenario "sources workspace setup script" test_source_workspace_exports_variables
+scenario "sets ROS_DISTRO when unset" test_sets_ros_distro_default
+scenario "preserves caller-provided ROS_DISTRO" test_preserves_existing_ros_distro
 scenario "falls back to ROS setup" test_activate_falls_back_to_ros
 scenario "prefers workspace over ROS when available" test_activate_prefers_workspace
 

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -85,6 +85,7 @@ export LANG=en_US.UTF-8
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 export ROS_DOMAIN_ID=0
 export ROS_LOCALHOST_ONLY=0
+export ROS_DISTRO=${ROS_DISTRO}
 PROFILE
 
 "${SUDO[@]}" chmod 644 /etc/profile.d/ros2-defaults.sh


### PR DESCRIPTION
## Summary
- ensure the environment helpers export ROS_DISTRO when unset so CLI runs inherit the active distro
- verify the ros2 installer profile exports ROS_DISTRO and harden the tests accordingly
- extend the env helper test coverage for ROS_DISTRO propagation

## Testing
- tests/install_ros2_script_test.sh
- tests/psyched_env_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e35ffb89c483209cc2e16bd376feb0