### PR TITLE
Restore colcon via isolated virtualenv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Always prefer running the smallest relevant command set.
 - **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
 - **APT CLI stability:** Provisioning scripts must use `apt-get` (not `apt`) to avoid behaviour changes and interactive warnings during automation.
 - **ROS tooling packages:** Avoid installing `python3-colcon-*` or other catkin/colcon Debian packages; rely on ros-base and rosdep instead to prevent dpkg conflicts on Pete's hosts.
+- **Colcon virtualenv:** The ROS installers create `/opt/ros/<distro>/colcon-venv` and symlink `/usr/local/bin/colcon` into it. Reuse that environment instead of layering additional pip/apt colcon installs.
 - **Post-bootstrap reboot:** `./setup` now writes a reboot-required sentinel. `psh mod setup` refuses to run until the machine is restarted, so plan to reboot immediately after the bootstrap completes.
 
 ## Useful references

--- a/tests/install_ros2_script_test.sh
+++ b/tests/install_ros2_script_test.sh
@@ -51,3 +51,13 @@ if grep -Fq 'python3-colcon' "${ROS_INSTALLER}"; then
   echo "install_ros2.sh must not install python3-colcon-* packages." >&2
   exit 1
 fi
+
+if ! grep -Fq 'colcon-common-extensions' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must provision colcon via pip-installed common extensions." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'colcon-venv' "${ROS_INSTALLER}"; then
+  echo "install_ros2.sh must isolate colcon into a dedicated virtual environment to avoid package conflicts." >&2
+  exit 1
+fi

--- a/tools/bootstrap/install_ros2.sh
+++ b/tools/bootstrap/install_ros2.sh
@@ -34,6 +34,8 @@ export LANG=en_US.UTF-8
   ca-certificates \
   curl \
   locales \
+  python3-pip \
+  python3-venv \
   software-properties-common
 "${SUDO[@]}" locale-gen en_US en_US.UTF-8
 "${SUDO[@]}" update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
@@ -71,6 +73,28 @@ fi
   ros-${ROS_DISTRO}-ros-base \
   ros-${ROS_DISTRO}-ros-dev-tools \
   python3-rosdep
+
+COLCON_VENV="/opt/ros/${ROS_DISTRO}/colcon-venv"
+COLCON_BIN="${COLCON_VENV}/bin/colcon"
+
+echo "Installing colcon into dedicated virtual environment at ${COLCON_VENV}..."
+"${SUDO[@]}" mkdir -p "${COLCON_VENV}"
+if [[ ! -f "${COLCON_VENV}/pyvenv.cfg" ]]; then
+  "${SUDO[@]}" python3 -m venv "${COLCON_VENV}"
+fi
+
+if [[ ! -x "${COLCON_VENV}/bin/pip" ]]; then
+  "${SUDO[@]}" "${COLCON_VENV}/bin/python" -m ensurepip --upgrade
+fi
+
+"${SUDO[@]}" "${COLCON_VENV}/bin/pip" install --no-cache-dir --upgrade pip
+"${SUDO[@]}" "${COLCON_VENV}/bin/pip" install --no-cache-dir --upgrade \
+  colcon-core \
+  colcon-common-extensions
+
+if [[ ! -L /usr/local/bin/colcon ]] || [[ "$(readlink -f /usr/local/bin/colcon 2>/dev/null)" != "${COLCON_BIN}" ]]; then
+  "${SUDO[@]}" ln -sf "${COLCON_BIN}" /usr/local/bin/colcon
+fi
 
 if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
   "${SUDO[@]}" rosdep init


### PR DESCRIPTION
## Summary
- install python3-pip/venv and set up an `/opt/ros/<distro>/colcon-venv` with `colcon-core` and `colcon-common-extensions`, exposing the CLI via `/usr/local/bin/colcon`
- document the virtualenv expectation in the workspace handbook
- extend the ROS installer test to enforce the new colcon provisioning approach

## Testing
- tests/install_ros2_script_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3e38211a483209872428bd4c5140f