### PR TITLE
Improve bootstrap reboot guard and ROS packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Welcome to the Psyched workspace. This guide summarizes everything an automated 
 | `modules/pilot/frontend/` | Deno Fresh app for the pilot console. |
 | `modules/<name>/module.toml` | Module manifest consumed by `psh`. Also defines bootstrap git repos and pilot overlays. |
 | `tools/bootstrap/` & `tools/provision/` | Host bootstrap scripts invoked by `psh host setup`. |
-| `setup` | Top-level bootstrap script. Installs dependencies, installs the Deno-based `psh` wrapper, and launches the provisioning wizard. |
+| `setup` | Top-level bootstrap script. Installs dependencies, installs the Deno-based `psh` wrapper, and instructs you to reboot before running `psh`. |
 | `hosts/*.toml` | Host manifests. Prefer `provision.installers = ["ros2", …]` over shell scripts and run `psh host setup --verbose` for detailed logs. Deno is bootstrapped by `setup`. |
 
 ## Build & test checklist

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Supporting utilities live under `tools/` and the `psh` CLI: a Deno-powered orche
 ```bash
 git clone https://github.com/dancxjo/psyched.git
 cd psyched
-./setup  # installs core dependencies, registers the Deno-based psh CLI, and opens the provisioning wizard
+./setup  # installs core dependencies, registers the Deno-based psh CLI, then asks you to reboot
 ```
 
-`./setup` installs just the tools required to run `psh`, configures mDNS, prepares Deno, and launches the interactive `psh` wizard (equivalent to running `psh` with no arguments). Once the wizard completes **reboot the machine before running `psh mod setup`**—the bootstrap writes a reboot sentinel that module setup respects to keep ROS tooling cleanly staged.
+`./setup` installs just the tools required to run `psh`, configures mDNS, prepares Deno, and writes a reboot sentinel. **Reboot immediately after the bootstrap finishes, then run `psh` to continue provisioning.** The sentinel keeps ROS tooling cleanly staged by blocking module setup until the system has restarted.
 
 ### 2. Provision additional machines (optional)
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,7 +20,7 @@ export PSY_HOSTNAME=motherbrain   # or forebrain
 docker compose -f docker/compose.yml up --build
 
 # The setup script will install tools (inside the container), register the psh wrapper,
-# and open an interactive provisioning wizard. It’s OK if some steps fail in tests.
+# and then ask you to reboot before running `psh` to continue provisioning. It’s OK if some steps fail in tests.
 ```
 
 To run interactively without tailing logs:

--- a/modules/ear/packages/ear/CMakeLists.txt
+++ b/modules/ear/packages/ear/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.16)
+project(ear)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_tests(${PROJECT_NAME}_pytest tests)
+endif()
+
+ament_package()

--- a/modules/ear/packages/ear/package.xml
+++ b/modules/ear/packages/ear/package.xml
@@ -7,10 +7,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>python3-websockets</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 </package>

--- a/tests/reboot_sentinel_test.sh
+++ b/tests/reboot_sentinel_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../tools/bootstrap/reboot_helpers.sh
+source "${repo_root}/tools/bootstrap/reboot_helpers.sh"
+
+failures=0
+
+echo "Given the reboot helper library"
+
+scenario() {
+    local name="$1"
+    shift
+    if ( set -euo pipefail; "$@" ); then
+        printf '✔ %s\n' "$name"
+    else
+        printf '✖ %s\n' "$name"
+        failures=$((failures + 1))
+    fi
+}
+
+with_temp_sentinel() {
+    local callback="$1"
+    shift
+    local tmp status
+    tmp="$(mktemp -d)"
+    export PSYCHED_REBOOT_SENTINEL="${tmp}/sentinel"
+    status=0
+    "$callback" "$@" || status=$?
+    unset PSYCHED_REBOOT_SENTINEL
+    rm -rf "${tmp}"
+    return ${status}
+}
+
+test_no_sentinel_required() {
+    with_temp_sentinel __test_no_sentinel_impl
+}
+
+__test_no_sentinel_impl() {
+    unset PSYCHED_FAKE_BOOT_TIME || true
+    if ! psyched_bootstrap::require_reboot_if_pending; then
+        return 1
+    fi
+}
+
+test_removes_stale_sentinel() {
+    with_temp_sentinel __test_remove_impl
+}
+
+__test_remove_impl() {
+    export PSYCHED_FAKE_BOOT_TIME=200
+    psyched_bootstrap::write_reboot_sentinel "${PSYCHED_REBOOT_SENTINEL}" 150
+    if ! psyched_bootstrap::require_reboot_if_pending; then
+        return 1
+    fi
+    if [[ -f "${PSYCHED_REBOOT_SENTINEL}" ]]; then
+        echo "Expected sentinel to be removed after detecting reboot" >&2
+        return 1
+    fi
+    unset PSYCHED_FAKE_BOOT_TIME
+}
+
+test_detects_pending_reboot() {
+    with_temp_sentinel __test_pending_impl
+}
+
+__test_pending_impl() {
+    export PSYCHED_FAKE_BOOT_TIME=150
+    psyched_bootstrap::write_reboot_sentinel "${PSYCHED_REBOOT_SENTINEL}" 200
+    if psyched_bootstrap::require_reboot_if_pending; then
+        echo "Expected reboot requirement when current boot time <= sentinel" >&2
+        return 1
+    fi
+    if [[ ! -f "${PSYCHED_REBOOT_SENTINEL}" ]]; then
+        echo "Sentinel should remain when reboot still required" >&2
+        return 1
+    fi
+    unset PSYCHED_FAKE_BOOT_TIME
+}
+
+scenario "no sentinel allows bootstrap to continue" test_no_sentinel_required
+scenario "completed reboot clears sentinel automatically" test_removes_stale_sentinel
+scenario "pending reboot blocks provisioning" test_detects_pending_reboot
+
+if (( failures > 0 )); then
+    printf '\n%d scenario(s) failed.\n' "$failures" >&2
+    exit 1
+fi
+
+printf '\nAll scenarios passed.\n'

--- a/tools/bootstrap/reboot_helpers.sh
+++ b/tools/bootstrap/reboot_helpers.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Helpers for managing the reboot sentinel written by the Psyched bootstrap.
+# These utilities allow setup scripts to detect pending reboot requirements
+# before running expensive provisioning steps.
+
+# Determine the path to the reboot sentinel file. The location mirrors the
+# logic used by the Deno-based guard so behaviour stays consistent across
+# languages.
+psyched_bootstrap::reboot_sentinel_path() {
+    local override="${PSYCHED_REBOOT_SENTINEL:-}"
+    if [[ -n "${override}" ]]; then
+        printf '%s\n' "${override}"
+        return 0
+    fi
+
+    local xdg_state="${XDG_STATE_HOME:-}"
+    if [[ -n "${xdg_state}" ]]; then
+        printf '%s\n' "${xdg_state%/}/psyched/reboot-required"
+        return 0
+    fi
+
+    local home="${HOME:-}"
+    if [[ -n "${home}" ]]; then
+        printf '%s\n' "${home%/}/.local/state/psyched/reboot-required"
+        return 0
+    fi
+
+    printf '%s/.psyched/reboot-required\n' "${PWD}"
+}
+
+# Read the system boot time. For testing we allow overriding via the
+# PSYCHED_FAKE_BOOT_TIME environment variable.
+psyched_bootstrap::current_boot_time() {
+    if [[ -n "${PSYCHED_FAKE_BOOT_TIME:-}" ]]; then
+        printf '%s\n' "${PSYCHED_FAKE_BOOT_TIME}"
+        return 0
+    fi
+
+    local boot_time
+    boot_time="$(awk '/^btime/ {print $2}' /proc/stat 2>/dev/null || true)"
+    if [[ -n "${boot_time}" ]]; then
+        printf '%s\n' "${boot_time}"
+        return 0
+    fi
+
+    date +%s
+}
+
+# Read the sentinel timestamp from disk.
+#
+# Arguments:
+#   $1 (optional): Path to the sentinel file.
+# Returns:
+#   0 with the timestamp printed to stdout when present; non-zero when missing
+#   or invalid.
+psyched_bootstrap::read_reboot_sentinel() {
+    local path="${1:-}"
+    if [[ -z "${path}" ]]; then
+        path="$(psyched_bootstrap::reboot_sentinel_path)"
+    fi
+
+    if [[ ! -f "${path}" ]]; then
+        return 1
+    fi
+
+    local contents
+    contents="$(tr -d '\n\r[:space:]' < "${path}")"
+    if [[ -z "${contents}" || ! "${contents}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    printf '%s\n' "${contents}"
+}
+
+# Ensure a reboot has occurred since the sentinel was created.
+#
+# The function returns success when it is safe to continue provisioning and
+# failure when a reboot is still required. When a fresh boot is detected the
+# sentinel is removed automatically to mirror the Deno guard behaviour.
+psyched_bootstrap::require_reboot_if_pending() {
+    local sentinel_path
+    sentinel_path="$(psyched_bootstrap::reboot_sentinel_path)"
+
+    local sentinel_time
+    if ! sentinel_time="$(psyched_bootstrap::read_reboot_sentinel "${sentinel_path}" 2>/dev/null)"; then
+        return 0
+    fi
+
+    local boot_time
+    boot_time="$(psyched_bootstrap::current_boot_time)"
+
+    if [[ -z "${boot_time}" || -z "${sentinel_time}" ]]; then
+        return 1
+    fi
+
+    if (( boot_time <= sentinel_time )); then
+        return 1
+    fi
+
+    rm -f "${sentinel_path}"
+    return 0
+}
+
+# Write the reboot sentinel with the provided boot time (defaults to the
+# current boot time) so subsequent runs know that a restart is required before
+# provisioning modules.
+psyched_bootstrap::write_reboot_sentinel() {
+    local sentinel_path="${1:-}"
+    if [[ -z "${sentinel_path}" ]]; then
+        sentinel_path="$(psyched_bootstrap::reboot_sentinel_path)"
+    fi
+
+    local boot_time="${2:-}"
+    if [[ -z "${boot_time}" ]]; then
+        boot_time="$(psyched_bootstrap::current_boot_time)"
+    fi
+
+    mkdir -p "$(dirname "${sentinel_path}")"
+    printf '%s\n' "${boot_time}" > "${sentinel_path}"
+}

--- a/tools/psh/lib/deps/ros2_test.ts
+++ b/tools/psh/lib/deps/ros2_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "$std/testing/asserts.ts";
 import {
+  buildColconProvisionPlan,
   buildRosBasePackages,
   determineRosDistro,
   renderRosProfile,
@@ -29,4 +30,14 @@ Deno.test("ROS base package set excludes colcon tooling", () => {
     "ros-jazzy-rmw-cyclonedds-cpp",
     "python3-rosdep",
   ]);
+});
+
+Deno.test("colcon provisioning plan mirrors install script", () => {
+  const plan = buildColconProvisionPlan("jazzy");
+  assertEquals(plan.venvPath, "/opt/ros/jazzy/colcon-venv");
+  assertEquals(plan.pythonBin, "/opt/ros/jazzy/colcon-venv/bin/python");
+  assertEquals(plan.pipBin, "/opt/ros/jazzy/colcon-venv/bin/pip");
+  assertEquals(plan.colconBin, "/opt/ros/jazzy/colcon-venv/bin/colcon");
+  assertEquals(plan.symlinkPath, "/usr/local/bin/colcon");
+  assertEquals(plan.packages, ["colcon-core", "colcon-common-extensions"]);
 });


### PR DESCRIPTION
## Summary
- add a reusable reboot sentinel helper, guard the bootstrap scripts, and update docs to tell operators to reboot before running `psh`
- teach the ROS 2 installer to provision colcon via its dedicated virtualenv and cover the behaviour with unit tests
- turn the ear module into a proper ROS 2 Python package with a CMakeLists.txt and pytest integration

## Testing
- bash tests/reboot_sentinel_test.sh
- PYTHONPATH=modules/ear/packages/ear:$PYTHONPATH pytest modules/ear/packages/ear/tests
- deno test *(fails: deno not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f0a7329c8320a338c55ebef5402d