### PR TITLE
Add docker simulation command to psh

### DIFF
--- a/tools/psh/lib/docker_env.ts
+++ b/tools/psh/lib/docker_env.ts
@@ -1,0 +1,78 @@
+import { CommandBuilder } from "$dax";
+
+/**
+ * Shell script executed inside the Ubuntu simulation container.
+ *
+ * It ensures the `pete` user exists before handing over an interactive login
+ * shell for manual testing.
+ */
+const SIMULATION_SCRIPT = [
+  "id -u pete >/dev/null 2>&1 || useradd -M -s /bin/bash -d /home/pete pete",
+  "chown -R pete:pete /home/pete/psyched",
+  "exec su - pete -s /bin/bash -l",
+].join(" && ");
+
+/**
+ * Options for constructing the docker simulation command.
+ */
+export interface DockerSimulationOptions {
+  /**
+   * Workspace directory to mount into the container. Defaults to the current
+   * working directory.
+   */
+  workspace?: string;
+}
+
+/**
+ * Build the docker command used to spawn the Ubuntu 24.04 simulation
+ * environment.
+ *
+ * @example
+ * ```ts
+ * const command = buildDockerSimulationCommand({ workspace: "/work" });
+ * // command[0] === "docker"
+ * ```
+ */
+export function buildDockerSimulationCommand(
+  options: DockerSimulationOptions = {},
+): string[] {
+  const workspace = options.workspace ?? Deno.cwd();
+  return [
+    "docker",
+    "run",
+    "--rm",
+    "-it",
+    "-v",
+    `${workspace}:/home/pete/psyched:rw`,
+    "-w",
+    "/home/pete/psyched",
+    "--user",
+    "root",
+    "ubuntu:24.04",
+    "bash",
+    "-lc",
+    SIMULATION_SCRIPT,
+  ];
+}
+
+/**
+ * Launch the Ubuntu simulation container, streaming stdio for interactive use.
+ */
+export async function launchDockerSimulation(
+  options: DockerSimulationOptions = {},
+): Promise<void> {
+  const args = buildDockerSimulationCommand(options);
+  const builder = new CommandBuilder().command(args)
+    .stdin("inherit")
+    .stdout("inherit")
+    .stderr("inherit")
+    .noThrow();
+  const result = await builder.spawn();
+  if (result.code !== 0) {
+    throw new Error(`docker exited with code ${result.code}`);
+  }
+}
+
+export const __test__ = {
+  SIMULATION_SCRIPT,
+};

--- a/tools/psh/lib/docker_env_test.ts
+++ b/tools/psh/lib/docker_env_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "$std/assert/mod.ts";
+import { buildDockerSimulationCommand } from "./docker_env.ts";
+
+Deno.test("buildDockerSimulationCommand returns expected docker invocation", () => {
+  const command = buildDockerSimulationCommand({ workspace: "/workdir" });
+  const expected = [
+    "docker",
+    "run",
+    "--rm",
+    "-it",
+    "-v",
+    "/workdir:/home/pete/psyched:rw",
+    "-w",
+    "/home/pete/psyched",
+    "--user",
+    "root",
+    "ubuntu:24.04",
+    "bash",
+    "-lc",
+    "id -u pete >/dev/null 2>&1 || useradd -M -s /bin/bash -d /home/pete pete && chown -R pete:pete /home/pete/psyched && exec su - pete -s /bin/bash -l",
+  ];
+  assertEquals(command, expected);
+});

--- a/tools/psh/main.ts
+++ b/tools/psh/main.ts
@@ -3,6 +3,7 @@ import { colors } from "$cliffy/ansi/colors.ts";
 import { runWizard } from "./lib/wizard.ts";
 import { provisionHost } from "./lib/host.ts";
 import { buildWorkspace } from "./lib/build.ts";
+import { launchDockerSimulation } from "./lib/docker_env.ts";
 import {
   bringModulesDown,
   bringModulesUp,
@@ -43,6 +44,19 @@ async function main() {
 
   const hostCommand = new Command()
     .description("Host provisioning commands");
+
+  root
+    .command("docker")
+    .description(
+      "Launch an Ubuntu 24.04 container with the workspace mounted",
+    )
+    .option(
+      "--workspace <path:string>",
+      "Override the workspace directory mounted at /home/pete/psyched",
+    )
+    .action(async ({ workspace }: { workspace?: string }) => {
+      await launchDockerSimulation({ workspace });
+    });
 
   root
     .command("up [targets...:string]")


### PR DESCRIPTION
## Summary
- add a docker simulation helper that reproduces the documented ubuntu container
- expose the helper through a new `psh docker` command for quick environment setup
- cover the command builder with a unit test to guard the docker invocation

## Testing
- `deno test` *(fails: deno is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4419dc2a083209488b221d0064b5d