### PR TITLE
Handle missing host configs with an interactive wizard

### DIFF
--- a/tools/psh/lib/reboot_guard.ts
+++ b/tools/psh/lib/reboot_guard.ts
@@ -83,7 +83,7 @@ export function ensureRebootCompleted(
   const currentBootTime = options.readBootTime?.() ?? detectBootTime();
   if (currentBootTime <= sentinelBootTime) {
     throw new RebootRequiredError(
-      "Reboot required before running module setup. Please restart the system and rerun this command.",
+      "Reboot required before running module setup. Please reboot the system and rerun this command.",
     );
   }
   removeSentinel(sentinelPath);

--- a/tools/psh/lib/service_test.ts
+++ b/tools/psh/lib/service_test.ts
@@ -1,5 +1,10 @@
 import { assert, assertEquals } from "$std/testing/asserts.ts";
-import { ServiceConfig, ServiceShellOptions, __test__, listServices } from "./service.ts";
+import {
+  __test__,
+  listServices,
+  ServiceConfig,
+  ServiceShellOptions,
+} from "./service.ts";
 
 const { buildShellArgs } = __test__;
 
@@ -61,6 +66,8 @@ Deno.test("buildShellArgs honors overrides", () => {
     "-p",
     "ros2-dev",
     "exec",
+    "-u",
+    "2000:2000",
     "workspace",
     "bash",
     "-lc",

--- a/tools/psh/lib/wizard.ts
+++ b/tools/psh/lib/wizard.ts
@@ -1,8 +1,102 @@
 import { colors } from "$cliffy/ansi/colors.ts";
-import { Confirm, Select } from "$cliffy/prompt/mod.ts";
-import { availableHosts, provisionHost, readHostConfig } from "./host.ts";
+import { Checkbox, Confirm, Select } from "$cliffy/prompt/mod.ts";
+import {
+  availableHosts,
+  loadHostConfig,
+  provisionHost,
+  provisionHostProfile,
+} from "./host.ts";
+import type { HostConfig, ModuleDirective, ServiceDirective } from "./host.ts";
 
-export async function runWizard(): Promise<void> {
+interface WizardOptions {
+  detectedHostname?: string;
+  interactiveToggles?: boolean;
+}
+
+type ModuleToggle = { setup: boolean; launch: boolean };
+type ServiceToggle = { setup: boolean; up: boolean };
+
+function collectModuleToggles(
+  modules: ModuleDirective[] | undefined,
+  setupSelection: Set<string>,
+  launchSelection: Set<string>,
+): Map<string, ModuleToggle> {
+  const toggles = new Map<string, ModuleToggle>();
+  if (!modules?.length) return toggles;
+  for (const module of modules) {
+    const setup = setupSelection.has(module.name);
+    const launch = launchSelection.has(module.name);
+    if (!setup && !launch) continue;
+    toggles.set(module.name, { setup, launch });
+  }
+  return toggles;
+}
+
+function collectServiceToggles(
+  services: ServiceDirective[] | undefined,
+  setupSelection: Set<string>,
+  upSelection: Set<string>,
+): Map<string, ServiceToggle> {
+  const toggles = new Map<string, ServiceToggle>();
+  if (!services?.length) return toggles;
+  for (const service of services) {
+    const setup = setupSelection.has(service.name);
+    const up = upSelection.has(service.name);
+    if (!setup && !up) continue;
+    toggles.set(service.name, { setup, up });
+  }
+  return toggles;
+}
+
+function cloneConfig(config: HostConfig): HostConfig {
+  if (typeof structuredClone === "function") {
+    return structuredClone(config);
+  }
+  return JSON.parse(JSON.stringify(config)) as HostConfig;
+}
+
+function applyModuleToggles(
+  modules: ModuleDirective[] | undefined,
+  toggles: Map<string, ModuleToggle>,
+): ModuleDirective[] {
+  if (!modules?.length) return [];
+  const next: ModuleDirective[] = [];
+  for (const module of modules) {
+    const toggle = toggles.get(module.name);
+    if (!toggle) continue;
+    if (!toggle.setup && !toggle.launch) continue;
+    next.push({
+      ...module,
+      setup: toggle.setup,
+      launch: toggle.launch,
+    });
+  }
+  return next;
+}
+
+function applyServiceToggles(
+  services: ServiceDirective[] | undefined,
+  toggles: Map<string, ServiceToggle>,
+): ServiceDirective[] {
+  if (!services?.length) return [];
+  const next: ServiceDirective[] = [];
+  for (const service of services) {
+    const toggle = toggles.get(service.name);
+    if (!toggle) continue;
+    if (!toggle.setup && !toggle.up) continue;
+    next.push({
+      ...service,
+      setup: toggle.setup,
+      up: toggle.up,
+    });
+  }
+  return next;
+}
+
+export async function runWizard(options: WizardOptions = {}): Promise<void> {
+  const detectedHostname = options.detectedHostname ?? Deno.hostname();
+  const interactiveToggles = options.interactiveToggles ?? false;
+
   console.log(colors.bold(colors.magenta("Psyched Provisioning Wizard")));
   console.log(
     "Let's prepare this host with the correct modules and services.\n",
@@ -14,16 +108,19 @@ export async function runWizard(): Promise<void> {
     return;
   }
 
-  const defaultHost = hosts.includes(Deno.hostname())
-    ? Deno.hostname()
+  const defaultHost = hosts.includes(detectedHostname)
+    ? detectedHostname
     : hosts[0];
-  const hostname = await Select.prompt({
-    message: "Select the host profile to apply",
+  const hostname = await Select.prompt<string>({
+    message: interactiveToggles
+      ? `Select the host profile to apply to '${detectedHostname}'`
+      : "Select the host profile to apply",
     options: hosts.map((name) => ({ name, value: name })),
     default: defaultHost,
   });
 
-  const config = readHostConfig(hostname);
+  const { path: configPath, config: originalConfig } = loadHostConfig(hostname);
+  const config = cloneConfig(originalConfig);
   console.log(colors.cyan(`\nHost '${hostname}' provisions:`));
   if (config.modules?.length) {
     console.log(colors.green("  Modules:"));
@@ -54,6 +151,73 @@ export async function runWizard(): Promise<void> {
     }
   }
 
+  let modules = config.modules ?? [];
+  let services = config.services ?? [];
+
+  if (interactiveToggles) {
+    console.log();
+    if (modules.length) {
+      const setupSelection = new Set(
+        await Checkbox.prompt<string>({
+          message: "Select modules to run setup for",
+          options: modules.map((module) => ({
+            name: module.name,
+            value: module.name,
+            checked: module.setup !== false,
+          })),
+        }),
+      );
+      const launchSelection = new Set(
+        await Checkbox.prompt<string>({
+          message: "Select modules to launch after provisioning",
+          options: modules.map((module) => ({
+            name: module.name,
+            value: module.name,
+            checked: Boolean(module.launch),
+          })),
+        }),
+      );
+      const toggles = collectModuleToggles(
+        modules,
+        setupSelection,
+        launchSelection,
+      );
+      modules = applyModuleToggles(modules, toggles);
+    }
+
+    if (services.length) {
+      const setupSelection = new Set(
+        await Checkbox.prompt<string>({
+          message: "Select services to run setup for",
+          options: services.map((service) => ({
+            name: service.name,
+            value: service.name,
+            checked: service.setup !== false,
+          })),
+        }),
+      );
+      const upSelection = new Set(
+        await Checkbox.prompt<string>({
+          message: "Select services to start after provisioning",
+          options: services.map((service) => ({
+            name: service.name,
+            value: service.name,
+            checked: Boolean(service.up),
+          })),
+        }),
+      );
+      const toggles = collectServiceToggles(
+        services,
+        setupSelection,
+        upSelection,
+      );
+      services = applyServiceToggles(services, toggles);
+    }
+
+    config.modules = modules;
+    config.services = services;
+  }
+
   const verbose = await Confirm.prompt({
     message: "Show detailed logs during provisioning?",
     default: false,
@@ -69,9 +233,28 @@ export async function runWizard(): Promise<void> {
     return;
   }
 
-  await provisionHost(hostname, { verbose });
+  if (interactiveToggles) {
+    await provisionHostProfile({
+      detectedHostname,
+      profileName: hostname,
+      configPath,
+      config,
+      options: {
+        verbose,
+        includeModules: config.modules?.length ? true : false,
+        includeServices: config.services?.length ? true : false,
+      },
+    });
+  } else {
+    await provisionHost(hostname, { verbose });
+  }
   console.log(colors.bold(colors.green("\nAll done!")));
   console.log(
     "Next steps: launch everything with `psh up` (or scope it with `psh up <name>`). Use `psh down` to stop targets when you're done.",
   );
 }
+
+export const __test__ = {
+  applyModuleToggles,
+  applyServiceToggles,
+};

--- a/tools/psh/lib/wizard_test.ts
+++ b/tools/psh/lib/wizard_test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "$std/testing/asserts.ts";
+import { __test__ } from "./wizard.ts";
+
+const {
+  applyModuleToggles,
+  applyServiceToggles,
+} = __test__;
+
+Deno.test("applyModuleToggles keeps env and depends_on while filtering", () => {
+  const modules = [
+    { name: "alpha", setup: true, launch: false, env: { A: "1" }, depends_on: ["ros2"] },
+    { name: "beta", setup: true, launch: true },
+    { name: "gamma", setup: false, launch: false },
+  ];
+
+  const toggles = new Map([
+    ["alpha", { setup: true, launch: false }],
+    ["beta", { setup: false, launch: true }],
+  ]);
+
+  const result = applyModuleToggles(modules, toggles);
+  assertEquals(result, [
+    { name: "alpha", setup: true, launch: false, env: { A: "1" }, depends_on: ["ros2"] },
+    { name: "beta", setup: false, launch: true },
+  ]);
+});
+
+Deno.test("applyServiceToggles drops services without selections", () => {
+  const services = [
+    { name: "tts", setup: true, up: true },
+    { name: "llm", setup: false, up: true },
+  ];
+
+  const toggles = new Map([
+    ["tts", { setup: true, up: false }],
+  ]);
+
+  const result = applyServiceToggles(services, toggles);
+  assertEquals(result, [
+    { name: "tts", setup: true, up: false },
+  ]);
+});


### PR DESCRIPTION
## Summary
- introduce a dedicated host configuration error and a reusable host profile provisioning helper
- extend the provisioning wizard with module/service toggles and invoke it automatically when a host profile is missing
- add regression coverage for the new wizard helpers and align existing tests with the updated behaviour

## Testing
- DENO_TLS_CA_STORE=system deno test --allow-all

------
https://chatgpt.com/codex/tasks/task_e_68e46b1baac08320bdcc09970d48a011