### PR TITLE
Improve module launch diagnostics

### DIFF
--- a/tools/psh/main.ts
+++ b/tools/psh/main.ts
@@ -62,9 +62,10 @@ async function main() {
     .command("up [targets...:string]")
     .description("Launch modules and services")
     .option("--service", "Prefer services when resolving ambiguous names")
+    .option("-v, --verbose", "Show detailed launch diagnostics")
     .action(
       async (
-        { service }: { service?: boolean },
+        { service, verbose }: { service?: boolean; verbose?: boolean },
         ...targets: string[]
       ) => {
         const { modules, services } = resolveTargetBatches(targets, {
@@ -74,7 +75,7 @@ async function main() {
           await bringServiceUp(svc);
         }
         if (modules.length) {
-          await bringModulesUp(modules);
+          await bringModulesUp(modules, { verbose });
         }
       },
     );
@@ -175,9 +176,10 @@ async function main() {
   moduleCommand
     .command("up [modules...:string]")
     .description("Launch module processes")
-    .action(async (_, ...modules: string[]) => {
+    .option("-v, --verbose", "Show detailed launch diagnostics")
+    .action(async ({ verbose }: { verbose?: boolean }, ...modules: string[]) => {
       const targets = modules.length ? modules : listModules();
-      await bringModulesUp(targets);
+      await bringModulesUp(targets, { verbose });
     });
 
   moduleCommand


### PR DESCRIPTION
## Summary
- add a --verbose flag to `psh up` and `psh mod up` so operators can request extra launch detail
- extend module launching to pre-create log files, emit detailed diagnostics, and surface early exit summaries
- expose helpers for diagnostics/exit summaries with unit tests covering the new formatting helpers

## Testing
- `deno fmt main.ts lib/module.ts lib/module_test.ts` *(fails: deno not installed in container)*
- `deno test` *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e9857bd8832096bfeed4f4d97ff9