### PR TITLE
Remove unused ear pytest configuration

### DIFF
--- a/modules/ear/packages/ear/CMakeLists.txt
+++ b/modules/ear/packages/ear/CMakeLists.txt
@@ -6,9 +6,4 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_tests(${PROJECT_NAME}_pytest tests)
-endif()
-
 ament_package()


### PR DESCRIPTION
## Summary
- remove the unused pytest configuration block from the ear package CMakeLists file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ecad7290832096238e2f01e757f6