### PR TITLE
Add visceral health module

### DIFF
--- a/modules/viscera/AGENTS.md
+++ b/modules/viscera/AGENTS.md
@@ -1,0 +1,7 @@
+# Viscera module guidelines
+
+- Provide comprehensive type annotations, descriptive docstrings, and inline examples for each public API.
+- Keep feelers decoupled and pure; they should only depend on the provided :class:`SystemState` snapshot.
+- Run `PYTHONPATH=modules/viscera/packages/viscera:$PYTHONPATH pytest modules/viscera/packages/viscera/tests` after modifying code in this module.
+- Prefer standard library facilities for system metrics and make optional integrations (such as ``psutil``) defensive.
+- Record noteworthy heuristics or future follow-ups as comments near the relevant code paths instead of relying on external notes.

--- a/modules/viscera/launch_unit.sh
+++ b/modules/viscera/launch_unit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INTERVAL=${VISCERA_INTERVAL:-5.0}
+LIMIT_ARGS=()
+if [[ -n "${VISCERA_SENTIMENT_LIMIT:-}" ]]; then
+  LIMIT_ARGS=("--limit" "${VISCERA_SENTIMENT_LIMIT}")
+fi
+
+ros2 run viscera viscera_monitor -- --interval "${INTERVAL}" "${LIMIT_ARGS[@]}" &
+
+wait -n

--- a/modules/viscera/module.toml
+++ b/modules/viscera/module.toml
@@ -1,0 +1,9 @@
+[unit.viscera]
+apt = []
+pip = []
+launch = "modules/viscera/launch_unit.sh"
+shutdown = "modules/viscera/shutdown_unit.sh"
+
+[unit.viscera.ros]
+workspace = "."
+packages = ["viscera"]

--- a/modules/viscera/packages/viscera/CMakeLists.txt
+++ b/modules/viscera/packages/viscera/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(viscera)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+ament_package()

--- a/modules/viscera/packages/viscera/package.xml
+++ b/modules/viscera/packages/viscera/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>viscera</name>
+  <version>0.1.0</version>
+  <description>Biologically inspired narratives for Pete's internal state.</description>
+  <maintainer email="pete@psyched.local">Psyched Maintainers</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/modules/viscera/packages/viscera/resource/viscera
+++ b/modules/viscera/packages/viscera/resource/viscera
@@ -1,0 +1,1 @@
+viscera

--- a/modules/viscera/packages/viscera/setup.py
+++ b/modules/viscera/packages/viscera/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+
+package_name = "viscera"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["tests"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Psyched Maintainers",
+    maintainer_email="pete@psyched.local",
+    description="Biologically inspired narratives for Pete's internal state.",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "viscera_monitor = viscera.cli:main",
+        ]
+    },
+)

--- a/modules/viscera/packages/viscera/tests/test_feelers.py
+++ b/modules/viscera/packages/viscera/tests/test_feelers.py
@@ -1,0 +1,114 @@
+"""Behaviour driven tests for the viscera emotional mapper."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from viscera.feelers import hunger_feeler, load_feeler, stability_feeler
+from viscera.monitor import SystemMetricsProbe, Viscera
+from viscera.state import BatteryState, FootState, SystemState
+
+
+def make_state(**kwargs) -> SystemState:
+    """Helper to build a :class:`~viscera.state.SystemState` with sane defaults."""
+    defaults = dict(
+        timestamp=datetime.now(timezone.utc),
+        battery=BatteryState(charge_fraction=0.5, is_charging=False),
+        cpu_load=0.2,
+        memory_load=0.2,
+        disk_fill_level=0.2,
+        foot=None,
+    )
+    defaults.update(kwargs)
+    return SystemState(**defaults)
+
+
+class TestHungerFeeler:
+    """Scenarios for the hunger feeler lifecycle."""
+
+    def test_appetite_grows_before_fatigue(self) -> None:
+        """Battery charge maps to nuanced feelings rather than binary alerts."""
+        state = make_state(battery=BatteryState(charge_fraction=0.62, is_charging=False))
+        sentiments = hunger_feeler(state)
+        assert any(
+            "appetite" in sentiment.narrative.lower()
+            for sentiment in sentiments
+        ), sentiments
+
+    def test_panicky_phase_before_lethargy(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.28, is_charging=False))
+        sentiments = hunger_feeler(state)
+        assert any(
+            "weak and a bit panicky" in sentiment.narrative.lower()
+            for sentiment in sentiments
+        ), sentiments
+
+    def test_lethargy_when_energy_is_critical(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.08, is_charging=False))
+        sentiments = hunger_feeler(state)
+        assert any(
+            "lethargic" in sentiment.narrative.lower()
+            for sentiment in sentiments
+        ), sentiments
+
+
+class TestLoadFeeler:
+    """Stress mapping for computational resource pressure."""
+
+    def test_disk_bloat_feels_nauseous(self) -> None:
+        state = make_state(disk_fill_level=0.95)
+        sentiments = load_feeler(state)
+        assert any(
+            "nauseous" in sentiment.narrative.lower()
+            for sentiment in sentiments
+        ), sentiments
+
+
+class TestStabilityFeeler:
+    """Foot telemetry influences balance-related feelings."""
+
+    def test_unstable_footing_creates_wobbliness(self) -> None:
+        foot_state = FootState(hazard_contacts=2, is_slipping=True, contact_confidence=0.2)
+        state = make_state(foot=foot_state)
+        sentiments = stability_feeler(state)
+        assert any(
+            "wobbly" in sentiment.narrative.lower()
+            for sentiment in sentiments
+        ), sentiments
+
+
+class TestVisceraCoordinator:
+    """Integration scenarios for the high level coordinator."""
+
+    def test_feelings_are_sorted_by_intensity(self) -> None:
+        state = make_state(
+            battery=BatteryState(charge_fraction=0.12, is_charging=False),
+            disk_fill_level=0.93,
+        )
+        viscera = Viscera(feelers=[hunger_feeler, load_feeler])
+        sentiments = viscera.feelings(state)
+        assert sentiments == sorted(sentiments, key=lambda s: s.intensity, reverse=True)
+
+    def test_narrative_projection(self) -> None:
+        state = make_state(
+            battery=BatteryState(charge_fraction=0.12, is_charging=False),
+            disk_fill_level=0.93,
+        )
+        viscera = Viscera(feelers=[hunger_feeler, load_feeler])
+        narrative: List[str] = viscera.narrate(state)
+        assert all(sentence.endswith(".") for sentence in narrative)
+        assert any("nauseous" in sentence.lower() for sentence in narrative)
+
+
+class TestSystemMetricsProbe:
+    """Ensure we can sample metrics without psutil being present."""
+
+    def test_fallback_sampling(self) -> None:
+        probe = SystemMetricsProbe(psutil_module=None, foot_state_provider=lambda: FootState(hazard_contacts=1))
+        snapshot = probe.sample()
+        assert 0.0 <= (snapshot.cpu_load or 0.0) <= 1.0
+        assert 0.0 <= (snapshot.memory_load or 0.0) <= 1.0
+        assert 0.0 <= (snapshot.disk_fill_level or 0.0) <= 1.0
+        assert snapshot.foot is not None
+        assert snapshot.foot.hazard_contacts == 1
+

--- a/modules/viscera/packages/viscera/viscera/__init__.py
+++ b/modules/viscera/packages/viscera/viscera/__init__.py
@@ -1,0 +1,21 @@
+"""Viscera exposes biologically inspired system health narratives."""
+from __future__ import annotations
+
+from .feelers import DEFAULT_FEELERS, Feeler, hunger_feeler, load_feeler, stability_feeler
+from .monitor import SystemMetricsProbe, Viscera
+from .sentiment import Sentiment
+from .state import BatteryState, FootState, SystemState
+
+__all__ = [
+    "BatteryState",
+    "DEFAULT_FEELERS",
+    "Feeler",
+    "FootState",
+    "Sentiment",
+    "SystemMetricsProbe",
+    "SystemState",
+    "Viscera",
+    "hunger_feeler",
+    "load_feeler",
+    "stability_feeler",
+]

--- a/modules/viscera/packages/viscera/viscera/cli.py
+++ b/modules/viscera/packages/viscera/viscera/cli.py
@@ -1,0 +1,53 @@
+"""Command line entry point for sampling and narrating viscera feelings."""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Iterable
+
+from .feelers import DEFAULT_FEELERS
+from .monitor import SystemMetricsProbe, Viscera
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Narrate Pete's visceral status.")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Seconds between samples (default: 5.0)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of sentiments to print per cycle.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point for the ``viscera_monitor`` console script."""
+
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    probe = SystemMetricsProbe()
+    viscera = Viscera(feelers=DEFAULT_FEELERS, probe=probe, sentiment_limit=args.limit)
+
+    try:
+        while True:
+            state = probe.sample()
+            for sentence in viscera.narrate(state):
+                print(sentence)
+            time.sleep(max(0.1, args.interval))
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive guard for CLI users.
+        print(f"[viscera] error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - script guard.
+    sys.exit(main())

--- a/modules/viscera/packages/viscera/viscera/feelers.py
+++ b/modules/viscera/packages/viscera/viscera/feelers.py
@@ -1,0 +1,232 @@
+"""Composable feelers translating raw metrics into bodily narratives."""
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Sequence
+
+from .sentiment import Sentiment
+from .state import BatteryState, FootState, SystemState
+
+Feeler = Callable[[SystemState], Sequence[Sentiment]]
+
+
+def _ensure_sentences(sentiments: Iterable[Sentiment]) -> List[Sentiment]:
+    """Return a list of sentiments whose narratives end with a period."""
+    normalised: List[Sentiment] = []
+    for sentiment in sentiments:
+        narrative = sentiment.narrative
+        if not narrative.endswith("."):
+            narrative = f"{narrative}."
+        if narrative == sentiment.narrative:
+            normalised.append(sentiment)
+        else:
+            normalised.append(
+                Sentiment(
+                    name=sentiment.name,
+                    intensity=sentiment.intensity,
+                    narrative=narrative,
+                    evidence=sentiment.evidence,
+                    tags=sentiment.tags,
+                )
+            )
+    return normalised
+
+
+def hunger_feeler(state: SystemState) -> List[Sentiment]:
+    """Map :class:`~viscera.state.BatteryState` to hunger related feelings."""
+
+    battery: BatteryState = state.battery
+    level = battery.charge_fraction
+    if level is None:
+        return []
+
+    sentiments: List[Sentiment] = []
+    if level >= 0.8:
+        sentiments.append(
+            Sentiment(
+                name="satiated",
+                intensity=0.25,
+                narrative="I feel nourished and steady.",
+                evidence={"battery_fraction": level},
+                tags=("energy", "rested"),
+            )
+        )
+    elif level >= 0.55:
+        sentiments.append(
+            Sentiment(
+                name="appetite",
+                intensity=0.45,
+                narrative="I feel a healthy appetite blooming for a top-up.",
+                evidence={"battery_fraction": level},
+                tags=("energy", "hunger"),
+            )
+        )
+    elif level >= 0.4:
+        sentiments.append(
+            Sentiment(
+                name="hungry",
+                intensity=0.6,
+                narrative="I feel hunger nibbling at my focus.",
+                evidence={"battery_fraction": level},
+                tags=("energy", "hunger"),
+            )
+        )
+    elif level >= 0.18:
+        sentiments.append(
+            Sentiment(
+                name="anxious_hunger",
+                intensity=0.75,
+                narrative="I feel weak and a bit panicky; my reserves are fading.",
+                evidence={"battery_fraction": level},
+                tags=("energy", "hunger", "stress"),
+            )
+        )
+    else:
+        sentiments.append(
+            Sentiment(
+                name="lethargic",
+                intensity=0.95,
+                narrative="I feel lethargic. Please plug me in soon.",
+                evidence={"battery_fraction": level},
+                tags=("energy", "critical"),
+            )
+        )
+
+    if battery.is_charging:
+        charge_narrative = (
+            "A calm relief drifts through me as fresh energy flows in"
+            if level < 0.4
+            else "I can taste fresh electrons settling in"
+        )
+        sentiments.append(
+            Sentiment(
+                name="recharging",
+                intensity=0.5 if level < 0.4 else 0.35,
+                narrative=charge_narrative,
+                evidence={"battery_fraction": level, "is_charging": True},
+                tags=("energy", "relief"),
+            )
+        )
+
+    return _ensure_sentences(sentiments)
+
+
+def load_feeler(state: SystemState) -> List[Sentiment]:
+    """Translate CPU, memory, and disk utilisation into visceral reactions."""
+
+    sentiments: List[Sentiment] = []
+
+    if state.cpu_load is not None:
+        if state.cpu_load >= 0.88:
+            sentiments.append(
+                Sentiment(
+                    name="overclocked",
+                    intensity=0.8,
+                    narrative="I feel overheated; my thoughts are racing.",
+                    evidence={"cpu_load": state.cpu_load},
+                    tags=("focus", "stress"),
+                )
+            )
+        elif state.cpu_load >= 0.65:
+            sentiments.append(
+                Sentiment(
+                    name="focused",
+                    intensity=0.55,
+                    narrative="I feel intensely focused on many tasks.",
+                    evidence={"cpu_load": state.cpu_load},
+                    tags=("focus",),
+                )
+            )
+
+    if state.memory_load is not None:
+        if state.memory_load >= 0.9:
+            sentiments.append(
+                Sentiment(
+                    name="foggy",
+                    intensity=0.78,
+                    narrative="I feel foggy; my mind is cluttered with memories.",
+                    evidence={"memory_load": state.memory_load},
+                    tags=("memory", "stress"),
+                )
+            )
+        elif state.memory_load >= 0.75:
+            sentiments.append(
+                Sentiment(
+                    name="stretching",
+                    intensity=0.52,
+                    narrative="I feel stretched, juggling many recollections.",
+                    evidence={"memory_load": state.memory_load},
+                    tags=("memory",),
+                )
+            )
+
+    if state.disk_fill_level is not None:
+        if state.disk_fill_level >= 0.92:
+            sentiments.append(
+                Sentiment(
+                    name="nauseous",
+                    intensity=0.9,
+                    narrative="I feel nauseous; my storage is painfully bloated.",
+                    evidence={"disk_fill_level": state.disk_fill_level},
+                    tags=("storage", "stress"),
+                )
+            )
+        elif state.disk_fill_level >= 0.8:
+            sentiments.append(
+                Sentiment(
+                    name="bloated",
+                    intensity=0.65,
+                    narrative="I feel bloated; my archives are pressing outward.",
+                    evidence={"disk_fill_level": state.disk_fill_level},
+                    tags=("storage",),
+                )
+            )
+
+    return _ensure_sentences(sentiments)
+
+
+def stability_feeler(state: SystemState) -> List[Sentiment]:
+    """Interpret foot telemetry to judge balance and comfort."""
+
+    foot: FootState | None = state.foot
+    if foot is None:
+        return []
+
+    sentiments: List[Sentiment] = []
+    if foot.is_slipping:
+        confidence = 1.0 - (foot.contact_confidence or 0.0)
+        intensity = min(1.0, 0.6 + 0.4 * confidence)
+        sentiments.append(
+            Sentiment(
+                name="wobbly",
+                intensity=intensity,
+                narrative="I feel wobbly; my footing is uncertain.",
+                evidence={
+                    "is_slipping": foot.is_slipping,
+                    "contact_confidence": foot.contact_confidence,
+                },
+                tags=("balance", "hazard"),
+            )
+        )
+
+    if foot.hazard_contacts > 0:
+        intensity = min(1.0, 0.35 + 0.1 * foot.hazard_contacts)
+        sentiments.append(
+            Sentiment(
+                name="guarded",
+                intensity=intensity,
+                narrative="I feel guarded; something keeps brushing my foot.",
+                evidence={"hazard_contacts": foot.hazard_contacts},
+                tags=("balance", "awareness"),
+            )
+        )
+
+    return _ensure_sentences(sentiments)
+
+
+DEFAULT_FEELERS: Sequence[Feeler] = (
+    hunger_feeler,
+    load_feeler,
+    stability_feeler,
+)
+
+__all__ = ["Feeler", "DEFAULT_FEELERS", "hunger_feeler", "load_feeler", "stability_feeler"]

--- a/modules/viscera/packages/viscera/viscera/monitor.py
+++ b/modules/viscera/packages/viscera/viscera/monitor.py
@@ -1,0 +1,155 @@
+"""Coordinate feelers and capture the sensory snapshot backing them."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+import shutil
+from typing import Callable, Dict, List, Optional, Sequence
+
+from .feelers import DEFAULT_FEELERS, Feeler
+from .sentiment import Sentiment
+from .state import BatteryState, FootState, SystemState
+
+
+def _clamp(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    return max(0.0, min(1.0, value))
+
+
+@dataclass
+class SystemMetricsProbe:
+    """Sample host metrics with optional ``psutil`` acceleration."""
+
+    psutil_module: object | None = None
+    mount_point: str = "/"
+    foot_state_provider: Optional[Callable[[], Optional[FootState]]] = None
+    clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc)
+
+    def __post_init__(self) -> None:
+        if self.psutil_module is None:
+            try:  # pragma: no cover - import guarded for environments without psutil.
+                import psutil  # type: ignore
+            except Exception:  # pragma: no cover - import failure is acceptable.
+                psutil = None  # type: ignore
+            self.psutil_module = psutil
+
+    def sample(self) -> SystemState:
+        """Collect a :class:`SystemState` snapshot."""
+
+        battery = self._sample_battery()
+        cpu = self._sample_cpu()
+        memory = self._sample_memory()
+        disk = self._sample_disk()
+        foot = self.foot_state_provider() if self.foot_state_provider else None
+        timestamp = self.clock()
+        return SystemState(
+            timestamp=timestamp,
+            battery=battery,
+            cpu_load=cpu,
+            memory_load=memory,
+            disk_fill_level=disk,
+            foot=foot,
+        )
+
+    # Sampling helpers -------------------------------------------------
+    def _sample_battery(self) -> BatteryState:
+        psutil = self.psutil_module
+        if psutil is None or not hasattr(psutil, "sensors_battery"):
+            return BatteryState()
+        battery = psutil.sensors_battery()
+        if battery is None:
+            return BatteryState()
+        percent = getattr(battery, "percent", None)
+        fraction = None if percent is None else _clamp(percent / 100.0)
+        is_plugged = getattr(battery, "power_plugged", None)
+        return BatteryState(charge_fraction=fraction, is_charging=is_plugged)
+
+    def _sample_cpu(self) -> Optional[float]:
+        psutil = self.psutil_module
+        if psutil is not None and hasattr(psutil, "cpu_percent"):
+            try:
+                return _clamp(psutil.cpu_percent(interval=None) / 100.0)
+            except Exception:
+                pass
+        try:
+            load_averages = os.getloadavg()
+            cpu_count = os.cpu_count() or 1
+            return _clamp(load_averages[0] / cpu_count)
+        except (AttributeError, OSError):
+            return None
+
+    def _sample_memory(self) -> Optional[float]:
+        psutil = self.psutil_module
+        if psutil is not None and hasattr(psutil, "virtual_memory"):
+            try:
+                return _clamp(psutil.virtual_memory().percent / 100.0)
+            except Exception:
+                pass
+        try:
+            page_size = os.sysconf("SC_PAGE_SIZE")
+            phys_pages = os.sysconf("SC_PHYS_PAGES")
+            avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+        except (AttributeError, ValueError, OSError):
+            return None
+        total = page_size * phys_pages
+        available = page_size * avail_pages
+        if total <= 0:
+            return None
+        used_ratio = 1.0 - (available / total)
+        return _clamp(used_ratio)
+
+    def _sample_disk(self) -> Optional[float]:
+        try:
+            usage = shutil.disk_usage(self.mount_point)
+        except (FileNotFoundError, PermissionError, OSError):
+            return None
+        if usage.total <= 0:
+            return None
+        return _clamp(usage.used / usage.total)
+
+
+class Viscera:
+    """Coordinate feelers and produce sorted sentiments."""
+
+    def __init__(
+        self,
+        feelers: Sequence[Feeler] | None = None,
+        *,
+        probe: Optional[SystemMetricsProbe] = None,
+        sentiment_limit: Optional[int] = None,
+    ) -> None:
+        self._feelers: Sequence[Feeler] = feelers or DEFAULT_FEELERS
+        self._probe = probe
+        self._sentiment_limit = sentiment_limit
+
+    def sample(self) -> SystemState:
+        """Request a state snapshot from the configured probe."""
+
+        if self._probe is None:
+            raise RuntimeError("No probe configured; supply a SystemMetricsProbe or a manual state")
+        return self._probe.sample()
+
+    def feelings(self, state: Optional[SystemState] = None) -> List[Sentiment]:
+        """Return aggregated sentiments for *state* sorted by intensity."""
+
+        snapshot = state or self.sample()
+        aggregated: Dict[str, Sentiment] = {}
+        for feeler in self._feelers:
+            for sentiment in feeler(snapshot):
+                existing = aggregated.get(sentiment.name)
+                if existing is None or sentiment.intensity > existing.intensity:
+                    aggregated[sentiment.name] = sentiment
+        ordered = sorted(aggregated.values(), key=lambda s: s.intensity, reverse=True)
+        if self._sentiment_limit is not None:
+            return ordered[: self._sentiment_limit]
+        return ordered
+
+    def narrate(self, state: Optional[SystemState] = None) -> List[str]:
+        """Return the narrative components of :meth:`feelings`."""
+
+        return [sentiment.narrative for sentiment in self.feelings(state)]
+
+
+__all__ = ["SystemMetricsProbe", "Viscera"]

--- a/modules/viscera/packages/viscera/viscera/sentiment.py
+++ b/modules/viscera/packages/viscera/viscera/sentiment.py
@@ -1,0 +1,55 @@
+"""Sentiment representations emitted by the viscera module."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Tuple
+
+
+@dataclass(frozen=True)
+class Sentiment:
+    """Narrative that describes how Pete feels about a subsystem.
+
+    Parameters
+    ----------
+    name:
+        Machine friendly identifier for the feeling.
+    intensity:
+        Normalised strength between ``0`` (background) and ``1`` (urgent).
+    narrative:
+        Human readable sentence that can be surfaced in higher reasoning layers.
+    evidence:
+        Optional key/value pairs explaining what data triggered the feeling.
+    tags:
+        Semantic hints (e.g. ``("energy", "hunger")``) that other modules can
+        consume.
+
+    Examples
+    --------
+    >>> Sentiment(name="content", intensity=0.2, narrative="I feel content.")
+    Sentiment(name='content', intensity=0.2, narrative='I feel content.', evidence={}, tags=())
+    """
+
+    name: str
+    intensity: float
+    narrative: str
+    evidence: Mapping[str, object] = field(default_factory=dict)
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.intensity <= 1.0:
+            raise ValueError("Sentiment intensity must be in the [0.0, 1.0] range")
+        object.__setattr__(self, "evidence", dict(self.evidence))
+        object.__setattr__(self, "tags", tuple(self.tags))
+
+    def with_intensity(self, intensity: float) -> "Sentiment":
+        """Return a new :class:`Sentiment` with a different intensity."""
+        return Sentiment(
+            name=self.name,
+            intensity=intensity,
+            narrative=self.narrative,
+            evidence=self.evidence,
+            tags=self.tags,
+        )
+
+
+__all__ = ["Sentiment"]

--- a/modules/viscera/packages/viscera/viscera/state.py
+++ b/modules/viscera/packages/viscera/viscera/state.py
@@ -1,0 +1,72 @@
+"""System-level state definitions consumed by viscera feelers."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+def _clamp(value: Optional[float]) -> Optional[float]:
+    """Return *value* constrained to ``[0.0, 1.0]`` when provided."""
+    if value is None:
+        return None
+    return max(0.0, min(1.0, value))
+
+
+@dataclass(frozen=True)
+class BatteryState:
+    """Snapshot of the robot's energy reserves.
+
+    The charge fraction is always coerced into the ``[0, 1]`` range so feelers can
+    reason about the value without defensive checks.
+
+    Examples
+    --------
+    >>> state = BatteryState(charge_fraction=1.3, is_charging=True)
+    >>> state.charge_fraction
+    1.0
+    >>> state.is_charging
+    True
+    """
+
+    charge_fraction: Optional[float] = None
+    is_charging: Optional[bool] = None
+    temperature_c: Optional[float] = None
+    health_fraction: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "charge_fraction", _clamp(self.charge_fraction))
+        object.__setattr__(self, "health_fraction", _clamp(self.health_fraction))
+
+
+@dataclass(frozen=True)
+class FootState:
+    """Summarises proprioceptive cues coming from Pete's foot sensors."""
+
+    hazard_contacts: int = 0
+    is_slipping: bool = False
+    contact_confidence: Optional[float] = None
+    temperature_c: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "contact_confidence", _clamp(self.contact_confidence))
+
+
+@dataclass(frozen=True)
+class SystemState:
+    """Aggregated sensor view that feelers consume."""
+
+    timestamp: datetime
+    battery: BatteryState = field(default_factory=BatteryState)
+    cpu_load: Optional[float] = None
+    memory_load: Optional[float] = None
+    disk_fill_level: Optional[float] = None
+    foot: Optional[FootState] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cpu_load", _clamp(self.cpu_load))
+        object.__setattr__(self, "memory_load", _clamp(self.memory_load))
+        object.__setattr__(self, "disk_fill_level", _clamp(self.disk_fill_level))
+
+
+__all__ = ["BatteryState", "FootState", "SystemState"]

--- a/modules/viscera/shutdown_unit.sh
+++ b/modules/viscera/shutdown_unit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATTERN="ros2 run viscera viscera_monitor"
+
+if pgrep -f "$PATTERN" >/dev/null 2>&1; then
+  echo "[viscera/shutdown] Stopping $PATTERN"
+  pkill -TERM -f "$PATTERN" || true
+fi
+
+for _ in {1..10}; do
+  if ! pgrep -f "$PATTERN" >/dev/null 2>&1; then
+    echo "[viscera/shutdown] Viscera monitor stopped"
+    exit 0
+  fi
+  sleep 1
+fi
+
+pkill -KILL -f "$PATTERN" || true
+echo "[viscera/shutdown] Forced kill"


### PR DESCRIPTION
## Summary
- add the new viscera module with hunger, load, and stability feelers that turn metrics into sentiments
- introduce a system metrics probe, CLI entry point, and module wiring for ROS launch/shutdown scripts
- cover the feeler lifecycle and probe sampling with focused pytest scenarios

## Testing
- `PYTHONPATH=modules/viscera/packages/viscera:$PYTHONPATH pytest modules/viscera/packages/viscera/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68e5a1a75eec8320af24564949d77420