### PR TITLE
Fix pilot frontend module status imports

### DIFF
--- a/modules/pilot/frontend/lib/server/module_status.ts
+++ b/modules/pilot/frontend/lib/server/module_status.ts
@@ -1,0 +1,155 @@
+import { fromFileUrl, join } from "$std/path/mod.ts";
+
+/**
+ * Options for customizing how module status information is discovered.
+ *
+ * These hooks primarily exist to make the helpers testable: production code
+ * relies on the defaults that resolve paths relative to this source file.
+ */
+export interface ModuleStatusOptions {
+  /**
+   * Absolute path to the repository root. Defaults to the root detected from
+   * this file's location (../../../../../).
+   */
+  repoRoot?: string;
+  /**
+   * Absolute path to the workspace directory. Defaults to `<repo>/work`.
+   */
+  workspaceRoot?: string;
+  /**
+   * Absolute path to the modules directory. Defaults to `<repo>/modules`.
+   */
+  modulesRoot?: string;
+}
+
+/**
+ * Status reported for each module controlled by `psh`.
+ */
+export interface ModuleStatus {
+  name: string;
+  status: "running" | "stopped";
+  pid?: number;
+}
+
+const DEFAULT_REPO_ROOT = fromFileUrl(
+  new URL("../../../../../", import.meta.url),
+);
+const DEFAULT_WORKSPACE_ROOT = join(DEFAULT_REPO_ROOT, "work");
+const DEFAULT_MODULES_ROOT = join(DEFAULT_REPO_ROOT, "modules");
+
+function determineRepoRoot(options: ModuleStatusOptions): string {
+  return options.repoRoot ?? DEFAULT_REPO_ROOT;
+}
+
+function determineWorkspaceRoot(
+  repoRoot: string,
+  options: ModuleStatusOptions,
+): string {
+  if (options.workspaceRoot) return options.workspaceRoot;
+  if (repoRoot === DEFAULT_REPO_ROOT) return DEFAULT_WORKSPACE_ROOT;
+  return join(repoRoot, "work");
+}
+
+function determineModulesRoot(
+  repoRoot: string,
+  options: ModuleStatusOptions,
+): string {
+  if (options.modulesRoot) return options.modulesRoot;
+  if (repoRoot === DEFAULT_REPO_ROOT) return DEFAULT_MODULES_ROOT;
+  return join(repoRoot, "modules");
+}
+
+function pidDirectory(workspaceRoot: string): string {
+  return join(workspaceRoot, ".psh");
+}
+
+function modulePidPath(workspaceRoot: string, module: string): string {
+  return join(pidDirectory(workspaceRoot), `${module}.pid`);
+}
+
+function readPid(workspaceRoot: string, module: string): number | null {
+  try {
+    const contents = Deno.readTextFileSync(modulePidPath(workspaceRoot, module))
+      .trim();
+    if (!contents) return null;
+    const parsed = Number(contents);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function clearPid(workspaceRoot: string, module: string): void {
+  try {
+    Deno.removeSync(modulePidPath(workspaceRoot, module));
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+}
+
+function isPidRunning(pid: number): boolean {
+  try {
+    Deno.statSync(`/proc/${pid}`);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function listModules(modulesRoot: string): string[] {
+  try {
+    const names: string[] = [];
+    for (const entry of Deno.readDirSync(modulesRoot)) {
+      if (entry.isDirectory) names.push(entry.name);
+    }
+    names.sort();
+    return names;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Inspect the repository workspace to determine the launch status of modules.
+ *
+ * The detection logic mirrors the subset of `tools/psh/lib/module.ts` required
+ * by the frontend without pulling the entire CLI dependency graph into the
+ * browser bundle. Each status reflects the presence of a PID file under
+ * `<workspace>/.psh` and whether the process is still running.
+ *
+ * When a stale PID file is encountered the helper clears it to ensure future
+ * reads do not report the module as running.
+ */
+export function moduleStatuses(
+  options: ModuleStatusOptions = {},
+): ModuleStatus[] {
+  const repoRoot = determineRepoRoot(options);
+  const workspaceRoot = determineWorkspaceRoot(repoRoot, options);
+  const modulesRoot = determineModulesRoot(repoRoot, options);
+  const results: ModuleStatus[] = [];
+
+  for (const name of listModules(modulesRoot)) {
+    const pid = readPid(workspaceRoot, name);
+    if (pid && isPidRunning(pid)) {
+      results.push({ name, status: "running", pid });
+      continue;
+    }
+    if (pid) {
+      clearPid(workspaceRoot, name);
+    }
+    results.push({ name, status: "stopped" });
+  }
+
+  return results;
+}

--- a/modules/pilot/frontend/lib/server/module_status_test.ts
+++ b/modules/pilot/frontend/lib/server/module_status_test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "$std/assert/mod.ts";
+import { join } from "$std/path/mod.ts";
+import { moduleStatuses } from "./module_status.ts";
+
+Deno.test("returns running and stopped module statuses", () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const modulesDir = join(tempDir, "modules");
+    const workspaceDir = join(tempDir, "work");
+    Deno.mkdirSync(modulesDir, { recursive: true });
+    Deno.mkdirSync(workspaceDir, { recursive: true });
+    Deno.mkdirSync(join(workspaceDir, ".psh"), { recursive: true });
+
+    // Create two modules to exercise both branches.
+    Deno.mkdirSync(join(modulesDir, "alpha"));
+    Deno.mkdirSync(join(modulesDir, "bravo"));
+
+    // alpha is running: record the current process PID.
+    const runningPid = Deno.pid;
+    Deno.writeTextFileSync(
+      join(workspaceDir, ".psh", "alpha.pid"),
+      `${runningPid}\n`,
+    );
+
+    // bravo has a stale PID that should be cleared.
+    Deno.writeTextFileSync(join(workspaceDir, ".psh", "bravo.pid"), "999999\n");
+
+    const statuses = moduleStatuses({
+      repoRoot: tempDir,
+      modulesRoot: modulesDir,
+      workspaceRoot: workspaceDir,
+    });
+
+    assertEquals(statuses, [
+      { name: "alpha", status: "running", pid: runningPid },
+      { name: "bravo", status: "stopped" },
+    ]);
+
+    // The stale PID should be removed to avoid future false positives.
+    let removed = false;
+    try {
+      Deno.statSync(join(workspaceDir, ".psh", "bravo.pid"));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        removed = true;
+      } else {
+        throw error;
+      }
+    }
+    assertEquals(removed, true);
+  } finally {
+    Deno.removeSync(tempDir, { recursive: true });
+  }
+});

--- a/modules/pilot/frontend/routes/api/psh/mod/list.ts
+++ b/modules/pilot/frontend/routes/api/psh/mod/list.ts
@@ -1,12 +1,23 @@
 import { define } from "../../../../utils.ts";
-import { moduleStatuses } from "../../../../../../../tools/psh/lib/module.ts";
+import { moduleStatuses } from "../../../lib/server/module_status.ts";
 
 export const handler = define.handlers({
   GET() {
-    const statuses = moduleStatuses();
-    return new Response(JSON.stringify({ ok: true, statuses }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    try {
+      const statuses = moduleStatuses();
+      return new Response(JSON.stringify({ ok: true, statuses }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    } catch (error) {
+      console.error("Failed to load module statuses", error);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Failed to load module statuses" }),
+        {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
   },
 });

--- a/modules/pilot/pilot/utils.ts
+++ b/modules/pilot/pilot/utils.ts
@@ -1,0 +1,1 @@
+export { define } from "../frontend/utils.ts";


### PR DESCRIPTION
## Summary
- add a frontend-local module status helper that mirrors the CLI logic without pulling Deno-only dependencies into the bundle
- expose the helper via the API route with error handling and re-export shared utilities for the pilot overlay
- cover the helper with a focused unit test to ensure running and stale PID cases stay correct

## Testing
- DENO_TLS_CA_STORE=system deno lint --config /tmp/deno_fmt.json modules/pilot/frontend/lib/server/module_status.ts modules/pilot/frontend/lib/server/module_status_test.ts modules/pilot/frontend/routes/api/psh/mod/list.ts modules/pilot/pilot/utils.ts
- DENO_TLS_CA_STORE=system deno test --allow-read --allow-write --config /tmp/deno_fmt.json modules/pilot/frontend/lib/server/module_status_test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5a6016e2883209276a6692a85f0a1