### PR TITLE
Align pilot cockpit port configuration

### DIFF
--- a/modules/pilot/README.md
+++ b/modules/pilot/README.md
@@ -2,7 +2,7 @@
 
 The pilot module delivers Pete's browser-based cockpit. It is split into two pieces:
 
-- **Backend:** `modules/pilot/packages/pilot/pilot_cockpit` is an `ament_python` package that exposes a websocket bridge at `ws://0.0.0.0:8088/ws`. The bridge is implemented with `rclpy` + `asyncio` + `websockets` and mirrors cockpit messages to ROS topics (`/conversation`, `/cmd_vel`). Telemetry from `/audio/transcript/final`, `/imu/data`, and the Foot drivetrain is fanned out to any subscribed clients.
+- **Backend:** `modules/pilot/packages/pilot/pilot_cockpit` is an `ament_python` package that exposes a websocket bridge at `ws://0.0.0.0:8088/ws` by default. Override the port via the `PILOT_COCKPIT_PORT` environment variable (propagated by the `ros2` service) to keep the frontend and backend aligned. The bridge is implemented with `rclpy` + `asyncio` + `websockets` and mirrors cockpit messages to ROS topics (`/conversation`, `/cmd_vel`). Telemetry from `/audio/transcript/final`, `/imu/data`, and the Foot drivetrain is fanned out to any subscribed clients.
 - **Frontend:** `modules/pilot/frontend` is a Deno Fresh application that renders the cockpit UI and consumes the websocket bridge via `lib/cockpit.ts`.
 
 ## Developing the backend

--- a/modules/pilot/frontend/lib/cockpit.ts
+++ b/modules/pilot/frontend/lib/cockpit.ts
@@ -1,4 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import {
+  defaultCockpitUrl,
+  globalWindow,
+  isBrowser,
+  readBootstrappedConfig,
+} from "./cockpit_url.ts";
 
 export type ConnectionStatus =
   | "idle"
@@ -38,23 +44,7 @@ interface SubscribeOptions {
   replay?: boolean;
 }
 
-const globalWindow = typeof globalThis === "object" && "window" in globalThis
-  ? (globalThis as typeof globalThis & { window: Window }).window
-  : undefined;
-
-const isBrowser = Boolean(globalWindow?.WebSocket);
-
 const DEFAULT_RECONNECT_DELAY_MS = 2000;
-
-function defaultCockpitUrl(): string {
-  if (!isBrowser || !globalWindow) {
-    return "";
-  }
-  const { protocol, hostname, port } = globalWindow.location;
-  const wsProtocol = protocol === "https:" ? "wss" : "ws";
-  const inferredPort = port === "" ? "8088" : port === "8000" ? "8088" : port;
-  return `${wsProtocol}://${hostname}:${inferredPort}/ws`;
-}
 
 export class CockpitClient {
   private socket: WebSocket | null = null;
@@ -416,3 +406,8 @@ export function useCockpitTopic<T = unknown>(
     [topic, payload, status, error, client],
   );
 }
+
+export const __test__ = {
+  defaultCockpitUrl,
+  readBootstrappedConfig,
+};

--- a/modules/pilot/frontend/lib/cockpit_test.ts
+++ b/modules/pilot/frontend/lib/cockpit_test.ts
@@ -1,0 +1,92 @@
+/// <reference lib="dom" />
+
+import { assertEquals } from "https://deno.land/std@0.216.0/testing/asserts.ts";
+
+type BrowserOptions = {
+  protocol?: string;
+  hostname?: string;
+  port?: string;
+  dataset?: Record<string, string | undefined>;
+};
+
+async function withBrowserEnv(
+  options: BrowserOptions,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previousWindow = (globalThis as { window?: Window }).window;
+  const previousDocument = (globalThis as { document?: Document }).document;
+
+  const dataset: Record<string, string> = {};
+  for (const [key, value] of Object.entries(options.dataset ?? {})) {
+    if (value) {
+      dataset[key] = value;
+    }
+  }
+
+  const body = {
+    dataset: dataset as unknown as DOMStringMap,
+  } as unknown as HTMLBodyElement;
+  const document = { body } as unknown as Document;
+  const windowStub = {
+    location: {
+      protocol: options.protocol ?? "http:",
+      hostname: options.hostname ?? "localhost",
+      port: options.port ?? "",
+    },
+    document,
+    WebSocket: class WebSocketStub {} as unknown as typeof WebSocket,
+  } as unknown as Window;
+
+  (globalThis as { window?: Window }).window = windowStub;
+  (globalThis as { document?: Document }).document = document;
+
+  try {
+    await run();
+  } finally {
+    if (previousWindow === undefined) {
+      delete (globalThis as { window?: Window }).window;
+    } else {
+      (globalThis as { window?: Window }).window = previousWindow;
+    }
+    if (previousDocument === undefined) {
+      delete (globalThis as { document?: Document }).document;
+    } else {
+      (globalThis as { document?: Document }).document = previousDocument;
+    }
+  }
+}
+
+async function importCockpitModule() {
+  const cacheBust = crypto.randomUUID();
+  return await import(`./cockpit_url.ts?cache=${cacheBust}`);
+}
+
+Deno.test("defaults to bridge port 8088 when dev server runs on 8000", async () => {
+  await withBrowserEnv({ port: "8000" }, async () => {
+    const { __test__ } = await importCockpitModule();
+    const url = __test__.defaultCockpitUrl();
+    assertEquals(url, "ws://localhost:8088/ws");
+  });
+});
+
+Deno.test("uses bootstrapped cockpit port when provided", async () => {
+  await withBrowserEnv({
+    port: "8000",
+    dataset: { cockpitPort: "9090" },
+  }, async () => {
+    const { __test__ } = await importCockpitModule();
+    const url = __test__.defaultCockpitUrl();
+    assertEquals(url, "ws://localhost:9090/ws");
+  });
+});
+
+Deno.test("prefers explicit cockpit URL overrides", async () => {
+  await withBrowserEnv({
+    port: "8000",
+    dataset: { cockpitUrl: "wss://pete.local:9443/bridge" },
+  }, async () => {
+    const { __test__ } = await importCockpitModule();
+    const url = __test__.defaultCockpitUrl();
+    assertEquals(url, "wss://pete.local:9443/bridge");
+  });
+});

--- a/modules/pilot/frontend/lib/cockpit_url.ts
+++ b/modules/pilot/frontend/lib/cockpit_url.ts
@@ -1,0 +1,66 @@
+interface CockpitBootstrapConfig {
+  host?: string;
+  port?: string;
+  protocol?: string;
+  url?: string;
+}
+
+export const globalWindow = typeof globalThis === "object" &&
+    "window" in globalThis
+  ? (globalThis as typeof globalThis & { window: Window }).window
+  : undefined;
+
+export const isBrowser = Boolean(globalWindow?.WebSocket);
+
+export function readBootstrappedConfig(): CockpitBootstrapConfig | undefined {
+  if (!isBrowser || !globalWindow?.document?.body?.dataset) {
+    return undefined;
+  }
+  const dataset = globalWindow.document.body.dataset;
+  const sanitize = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+  const config: CockpitBootstrapConfig = {
+    host: sanitize(dataset.cockpitHost),
+    port: sanitize(dataset.cockpitPort),
+    protocol: sanitize(dataset.cockpitProtocol),
+    url: sanitize(dataset.cockpitUrl),
+  };
+  return Object.values(config).some((value) => value !== undefined)
+    ? config
+    : undefined;
+}
+
+export function defaultCockpitUrl(): string {
+  if (!isBrowser || !globalWindow) {
+    return "";
+  }
+  const { protocol, hostname, port } = globalWindow.location;
+  const bootstrap = readBootstrappedConfig();
+  if (bootstrap?.url) {
+    return bootstrap.url;
+  }
+  const normalisedProtocol = (() => {
+    const raw = bootstrap?.protocol?.toLowerCase();
+    if (!raw) return protocol === "https:" ? "wss" : "ws";
+    if (raw === "ws" || raw === "wss") return raw;
+    if (raw === "https" || raw === "https:") return "wss";
+    if (raw === "http" || raw === "http:") return "ws";
+    return raw;
+  })();
+  const inferredPort = (() => {
+    if (bootstrap?.port) return bootstrap.port;
+    if (port === "" || port === undefined) return "8088";
+    if (port === "8000") return "8088";
+    return port;
+  })();
+  const targetHost = bootstrap?.host ?? hostname;
+  const portSegment = inferredPort ? `:${inferredPort}` : "";
+  return `${normalisedProtocol}://${targetHost}${portSegment}/ws`;
+}
+
+export const __test__ = {
+  defaultCockpitUrl,
+  readBootstrappedConfig,
+};

--- a/modules/pilot/frontend/main.ts
+++ b/modules/pilot/frontend/main.ts
@@ -1,7 +1,28 @@
 import "$std/dotenv/load.ts";
 
 import { App, staticFiles } from "fresh";
-import type { State } from "./utils.ts";
+import type { CockpitConfig, State } from "./utils.ts";
+
+function readCockpitConfigFromEnv(): CockpitConfig | undefined {
+  const sanitize = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+
+  const config: CockpitConfig = {
+    url: sanitize(Deno.env.get("PILOT_COCKPIT_URL")),
+    host: sanitize(Deno.env.get("PILOT_COCKPIT_HOST")),
+    port: sanitize(Deno.env.get("PILOT_COCKPIT_PORT")),
+    protocol: sanitize(Deno.env.get("PILOT_COCKPIT_PROTOCOL")),
+  };
+
+  const entries = Object.entries(config).filter(([, value]) =>
+    value !== undefined
+  );
+  return entries.length
+    ? Object.fromEntries(entries) as CockpitConfig
+    : undefined;
+}
 
 export const app = new App<State>();
 
@@ -13,6 +34,12 @@ app.use(async (ctx) => {
       version: Deno.env.get("PILOT_VERSION") ??
         Deno.env.get("PSYCHED_BUILD_VERSION") ?? "dev",
     };
+  }
+  if (!ctx.state.cockpit) {
+    const config = readCockpitConfigFromEnv();
+    if (config) {
+      ctx.state.cockpit = config;
+    }
   }
   return await ctx.next();
 });

--- a/modules/pilot/frontend/routes/_app.tsx
+++ b/modules/pilot/frontend/routes/_app.tsx
@@ -1,6 +1,7 @@
 import { define } from "../utils.ts";
 
-export default define.page(function App({ Component }) {
+export default define.page(function App({ Component, state }) {
+  const { cockpit } = state;
   return (
     <html lang="en">
       <head>
@@ -9,7 +10,12 @@ export default define.page(function App({ Component }) {
         <title>Psyched Pilot</title>
         <link rel="stylesheet" href="/styles.css" />
       </head>
-      <body>
+      <body
+        data-cockpit-host={cockpit?.host}
+        data-cockpit-port={cockpit?.port}
+        data-cockpit-protocol={cockpit?.protocol}
+        data-cockpit-url={cockpit?.url}
+      >
         <header class="site-header">
           <nav>
             <a href="/">Home</a>

--- a/modules/pilot/frontend/utils.ts
+++ b/modules/pilot/frontend/utils.ts
@@ -4,8 +4,16 @@ export interface BuildInfo {
   version?: string;
 }
 
+export interface CockpitConfig {
+  host?: string;
+  port?: string;
+  protocol?: string;
+  url?: string;
+}
+
 export interface State {
   buildInfo?: BuildInfo;
+  cockpit?: CockpitConfig;
 }
 
 const baseDefine = createDefine<State>();

--- a/modules/pilot/launch_unit.sh
+++ b/modules/pilot/launch_unit.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 FRONTEND_DIR="${ROOT_DIR}/modules/pilot/frontend"
 WORKSPACE_DIR="${PSYCHED_WORKSPACE_DIR:-${ROOT_DIR}/work}"
+COCKPIT_PORT="${PILOT_COCKPIT_PORT:-8088}"
+
+export PILOT_COCKPIT_PORT="${COCKPIT_PORT}"
 
 add_pythonpath_dir() {
   local dir="$1"
@@ -55,10 +58,12 @@ if ! command -v ros2 >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Starting Pilot cockpit backend..."
+echo "Starting Pilot cockpit backend on port ${COCKPIT_PORT}..."
 (
   cd "${ROOT_DIR}" &&
-    ros2 run pilot cockpit --log-level "${PILOT_LOG_LEVEL:-info}"
+    ros2 run pilot cockpit \
+      --port "${COCKPIT_PORT}" \
+      --log-level "${PILOT_LOG_LEVEL:-info}"
 ) &
 COCKPIT_PID=$!
 

--- a/services/ros2/service.toml
+++ b/services/ros2/service.toml
@@ -3,3 +3,4 @@ compose = "docker-compose.yml"
 description = "ROS 2 workspace container based on osrf/ros:humble-desktop"
 shell_service = "ros2"
 shell_command = ["/ros_entrypoint.sh", "bash"]
+env = { PILOT_COCKPIT_PORT = "${PILOT_COCKPIT_PORT:-8088}" }


### PR DESCRIPTION
## Summary
- propagate the cockpit websocket port via the ros2 service environment and launch script so the backend always binds the expected address
- expose the configured port (and optional host/scheme/url overrides) to the pilot frontend and centralise url inference in a shared helper
- cover the cockpit url resolution with browser-environment unit tests to guard against regressions

## Testing
- `DENO_TLS_CA_STORE=system deno test --no-lock --allow-read modules/pilot/frontend/lib/cockpit_test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e5d41b4268832089bf8659aa74aaea