### PR TITLE
feat: surface module and service dashboards on home page

### DIFF
--- a/modules/pilot/frontend/assets/styles.css
+++ b/modules/pilot/frontend/assets/styles.css
@@ -1,7 +1,11 @@
 :root {
   color-scheme: light dark;
   font-family:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   line-height: 1.5;
   background-color: #101418;
   color: #e8edf2;
@@ -55,7 +59,11 @@ body {
   padding: 1.75rem 2rem;
   border-radius: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(135deg, rgba(12, 18, 28, 0.95), rgba(18, 26, 38, 0.98));
+  background: linear-gradient(
+    135deg,
+    rgba(12, 18, 28, 0.95),
+    rgba(18, 26, 38, 0.98)
+  );
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
   --panel-accent: #ff9966;
   --panel-accent-soft: rgba(255, 153, 102, 0.28);
@@ -121,7 +129,11 @@ body {
   width: 18px;
   align-self: stretch;
   border-radius: 12px;
-  background: linear-gradient(180deg, var(--panel-accent), rgba(255, 255, 255, 0.08));
+  background: linear-gradient(
+    180deg,
+    var(--panel-accent),
+    rgba(255, 255, 255, 0.08)
+  );
   box-shadow: 0 0 22px var(--panel-accent-soft);
 }
 
@@ -222,6 +234,80 @@ body {
 
 .panel-grid--stretch {
   align-items: stretch;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.dashboard-tile__details {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  background: rgba(18, 26, 38, 0.85);
+  overflow: hidden;
+}
+
+.dashboard-tile__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dashboard-tile__summary::-webkit-details-marker {
+  display: none;
+}
+
+.dashboard-tile__summary::before {
+  content: "▸";
+  display: inline-flex;
+  width: 1.25rem;
+  justify-content: center;
+  transition: transform 0.2s ease-in-out;
+  color: var(--panel-accent, #71c9f8);
+}
+
+.dashboard-tile__details[open] .dashboard-tile__summary::before {
+  transform: rotate(90deg);
+}
+
+.dashboard-tile__overlay {
+  display: grid;
+  gap: 1.1rem;
+  padding: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  max-height: 420px;
+  overflow: auto;
+  background: rgba(10, 16, 24, 0.72);
+}
+
+.dashboard-tile__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
+}
+
+.dashboard-status-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.dashboard-status-badge__note {
+  font-size: 0.72rem;
+  opacity: 0.65;
+  max-width: 18rem;
+  text-align: right;
 }
 
 .card {
@@ -378,7 +464,11 @@ body {
 }
 
 .button--primary {
-  background: linear-gradient(135deg, rgba(113, 201, 248, 0.4), rgba(197, 141, 255, 0.5));
+  background: linear-gradient(
+    135deg,
+    rgba(113, 201, 248, 0.4),
+    rgba(197, 141, 255, 0.5)
+  );
   border-color: rgba(113, 201, 248, 0.35);
   color: #0c1420;
 }
@@ -390,7 +480,11 @@ body {
 }
 
 .button--danger {
-  background: linear-gradient(135deg, rgba(255, 154, 167, 0.5), rgba(240, 110, 225, 0.4));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 154, 167, 0.5),
+    rgba(240, 110, 225, 0.4)
+  );
   border-color: rgba(255, 94, 109, 0.45);
   color: #16090c;
 }
@@ -455,8 +549,16 @@ body {
 .status-indicator__detail {
   font-size: 0.75rem;
   opacity: 0.7;
-  font-family: "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco,
-    Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    "Fira Mono",
+    "SFMono-Regular",
+    ui-monospace,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
 }
 
 .stat-metric {
@@ -618,7 +720,11 @@ body {
   padding: 0.45rem 0.75rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  background: linear-gradient(135deg, rgba(113, 201, 248, 0.2), rgba(197, 141, 255, 0.3));
+  background: linear-gradient(
+    135deg,
+    rgba(113, 201, 248, 0.2),
+    rgba(197, 141, 255, 0.3)
+  );
   color: #fff;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
@@ -636,7 +742,11 @@ body {
   justify-content: center;
   border-radius: 0.9rem;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  background: radial-gradient(circle at center, rgba(113, 201, 248, 0.08), rgba(0, 0, 0, 0.6));
+  background: radial-gradient(
+    circle at center,
+    rgba(113, 201, 248, 0.08),
+    rgba(0, 0, 0, 0.6)
+  );
   min-height: 220px;
   overflow: hidden;
   padding: 0.75rem;
@@ -664,7 +774,11 @@ body {
   aspect-ratio: 1;
   border-radius: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: radial-gradient(circle at center, rgba(62, 87, 132, 0.18), rgba(5, 9, 15, 0.9));
+  background: radial-gradient(
+    circle at center,
+    rgba(62, 87, 132, 0.18),
+    rgba(5, 9, 15, 0.9)
+  );
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   cursor: grab;
   margin-top: 0.75rem;
@@ -673,7 +787,9 @@ body {
 
 .joystick--active {
   cursor: grabbing;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 12px 24px rgba(113, 201, 248, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 24px rgba(113, 201, 248, 0.18);
 }
 
 .joystick__thumb {
@@ -681,8 +797,15 @@ body {
   width: 22%;
   aspect-ratio: 1;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 153, 102, 0.8), rgba(240, 110, 225, 0.7));
-  transform: translate(calc((var(--stick-x, 0) + 1) * 50% - 50%), calc((var(--stick-y, 0) + 1) * 50% - 50%));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 153, 102, 0.8),
+    rgba(240, 110, 225, 0.7)
+  );
+  transform: translate(
+    calc((var(--stick-x, 0) + 1) * 50% - 50%),
+    calc((var(--stick-y, 0) + 1) * 50% - 50%)
+  );
   transition: transform 0.08s ease;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
 }

--- a/modules/pilot/frontend/components/DashboardTile.tsx
+++ b/modules/pilot/frontend/components/DashboardTile.tsx
@@ -1,0 +1,59 @@
+import type { ComponentChildren, ComponentType } from "preact";
+
+import { type Accent, Card } from "@pilot/components/dashboard.tsx";
+
+import DashboardStatusBadge from "../islands/DashboardStatusBadge.tsx";
+
+export interface DashboardTileProps {
+  name: string;
+  title: string;
+  description: string;
+  kind: "module" | "service";
+  accent: Accent;
+  href: string;
+  overlay: ComponentType<unknown>;
+  overlayProps?: Record<string, unknown>;
+  ctaLabel?: string;
+  helper?: ComponentChildren;
+}
+
+/**
+ * Compact card that pairs lifecycle telemetry with a collapsible overlay.
+ */
+export default function DashboardTile({
+  name,
+  title,
+  description,
+  kind,
+  accent,
+  href,
+  overlay: Overlay,
+  overlayProps = {},
+  ctaLabel,
+  helper,
+}: DashboardTileProps) {
+  const label = ctaLabel ??
+    (kind === "service" ? "Manage service" : "Open module");
+
+  return (
+    <Card
+      title={title}
+      subtitle={description}
+      tone={accent}
+      actions={<DashboardStatusBadge kind={kind} name={name} />}
+    >
+      {helper && <div class="dashboard-tile__helper">{helper}</div>}
+      <details class="dashboard-tile__details">
+        <summary class="dashboard-tile__summary">Show live overlay</summary>
+        <div class="dashboard-tile__overlay">
+          <Overlay {...overlayProps} />
+        </div>
+      </details>
+      <footer class="dashboard-tile__footer">
+        <a class="button button--small button--primary" href={href}>
+          {label}
+        </a>
+      </footer>
+    </Card>
+  );
+}

--- a/modules/pilot/frontend/islands/DashboardStatusBadge.tsx
+++ b/modules/pilot/frontend/islands/DashboardStatusBadge.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from "preact/hooks";
+
+import { Badge } from "@pilot/components/dashboard.tsx";
+import { usePshStatus } from "@pilot/lib/psh_status.ts";
+
+export interface DashboardStatusBadgeProps {
+  kind: "module" | "service";
+  name: string;
+  refreshIntervalMs?: number;
+}
+
+/**
+ * Live badge summarising the lifecycle state of a module or service.
+ *
+ * The badge polls the relevant `/api/psh` endpoint and surfaces the status as a
+ * colour-coded pill. When a fetch error occurs the badge switches to the
+ * "danger" palette and surfaces the error text below the badge.
+ */
+export default function DashboardStatusBadge({
+  kind,
+  name,
+  refreshIntervalMs,
+}: DashboardStatusBadgeProps) {
+  const status = usePshStatus(kind, name, { refreshIntervalMs });
+  const message = useMemo(() => {
+    if (status.error) return status.error;
+    if (status.description && status.description !== status.label) {
+      return status.description;
+    }
+    return undefined;
+  }, [status.description, status.error, status.label]);
+
+  return (
+    <div class="dashboard-status-badge">
+      <Badge label={status.label} tone={status.tone} pulse={status.loading} />
+      {message && <span class="dashboard-status-badge__note">{message}</span>}
+    </div>
+  );
+}

--- a/modules/pilot/frontend/lib/dashboard/tiles.test.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "$std/assert/assert_equals.ts";
+import { assertGreater } from "$std/assert/assert_greater.ts";
+import { assert } from "$std/assert/assert.ts";
+
+import { dashboardTiles, moduleTiles, serviceTiles } from "./tiles.ts";
+
+Deno.test("module tiles have unique names", () => {
+  const names = moduleTiles.map((tile) => tile.name);
+  const unique = new Set(names);
+  assertEquals(unique.size, names.length);
+});
+
+Deno.test("service tiles have unique names", () => {
+  const names = serviceTiles.map((tile) => tile.name);
+  const unique = new Set(names);
+  assertEquals(unique.size, names.length);
+});
+
+Deno.test("dashboard tiles expose overlays", () => {
+  assertGreater(moduleTiles.length, 0);
+  assertGreater(serviceTiles.length, 0);
+  for (const tile of dashboardTiles) {
+    assert(typeof tile.title === "string" && tile.title.length > 0);
+    assert(typeof tile.href === "string" && tile.href.startsWith("/"));
+    assertEquals(typeof tile.overlay, "function");
+  }
+});

--- a/modules/pilot/frontend/lib/dashboard/tiles.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.ts
@@ -1,0 +1,144 @@
+import type { ComponentType } from "preact";
+
+import type { Accent } from "@pilot/components/dashboard.tsx";
+
+import PilotOverviewIsland from "../../../pilot/islands/PilotOverviewIsland.tsx";
+import ImuTelemetryIsland from "../../../../imu/pilot/islands/ImuTelemetryIsland.tsx";
+import FootControlPanelIsland from "../../../../foot/pilot/islands/FootControlPanelIsland.tsx";
+import KinectStreamPanelIsland from "../../../../eye/pilot/islands/KinectStreamPanelIsland.tsx";
+import AsrServicePanelIsland from "../../../../../services/asr/pilot/islands/AsrServicePanelIsland.tsx";
+import GraphsServicePanelIsland from "../../../../../services/graphs/pilot/islands/GraphsServicePanelIsland.tsx";
+import LlmServicePanelIsland from "../../../../../services/llm/pilot/islands/LlmServicePanelIsland.tsx";
+import Ros2ServicePanelIsland from "../../../../../services/ros2/pilot/islands/Ros2ServicePanelIsland.tsx";
+import TtsServicePanelIsland from "../../../../../services/tts/pilot/islands/TtsServicePanelIsland.tsx";
+import VectorsServicePanelIsland from "../../../../../services/vectors/pilot/islands/VectorsServicePanelIsland.tsx";
+
+export type TileKind = "module" | "service";
+
+export interface DashboardTileDefinition {
+  name: string;
+  title: string;
+  description: string;
+  accent: Accent;
+  kind: TileKind;
+  href: string;
+  overlay: ComponentType<unknown>;
+  overlayProps?: Record<string, unknown>;
+  ctaLabel?: string;
+}
+
+/** Tiles rendered for each ROS module managed by the cockpit. */
+export const moduleTiles: ReadonlyArray<DashboardTileDefinition> = [
+  {
+    name: "pilot",
+    title: "Pilot module",
+    description:
+      "Websocket bridge health, cockpit version, and operator pings.",
+    accent: "amber",
+    kind: "module",
+    href: "/modules/pilot",
+    overlay: PilotOverviewIsland,
+    overlayProps: {
+      version: "dev",
+      description:
+        "Home for the cockpit websocket bridge and Fresh frontend. Monitor connectivity and broadcast heartbeats.",
+    },
+  },
+  {
+    name: "imu",
+    title: "IMU module",
+    description: "Orientation, acceleration, and angular velocity telemetry.",
+    accent: "magenta",
+    kind: "module",
+    href: "/modules/imu",
+    overlay: ImuTelemetryIsland,
+  },
+  {
+    name: "foot",
+    title: "Foot module",
+    description:
+      "Create drive base command console with live telemetry overlays.",
+    accent: "teal",
+    kind: "module",
+    href: "/modules/foot",
+    overlay: FootControlPanelIsland,
+  },
+  {
+    name: "eye",
+    title: "Eye module",
+    description: "Kinect RGB-D stream with payload diagnostics.",
+    accent: "cyan",
+    kind: "module",
+    href: "/modules/eye",
+    overlay: KinectStreamPanelIsland,
+  },
+] as const;
+
+/** Tiles rendered for dockerised services bootstrapped through psh. */
+export const serviceTiles: ReadonlyArray<DashboardTileDefinition> = [
+  {
+    name: "asr",
+    title: "ASR service",
+    description: "Streaming Whisper server for voice transcription.",
+    accent: "teal",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: AsrServicePanelIsland,
+    ctaLabel: "Manage ASR",
+  },
+  {
+    name: "graphs",
+    title: "Graphs service",
+    description: "Neo4j + Memgraph orchestration for semantic maps.",
+    accent: "magenta",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: GraphsServicePanelIsland,
+    ctaLabel: "Manage graphs",
+  },
+  {
+    name: "llm",
+    title: "LLM service",
+    description: "Language model runtime powering conversational skills.",
+    accent: "violet",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: LlmServicePanelIsland,
+    ctaLabel: "Manage LLM",
+  },
+  {
+    name: "ros2",
+    title: "ROS 2 bridge",
+    description: "Dockerised ROS 2 workspace helpers and tooling.",
+    accent: "amber",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: Ros2ServicePanelIsland,
+    ctaLabel: "Manage ROS 2",
+  },
+  {
+    name: "tts",
+    title: "TTS service",
+    description: "Text-to-speech stack for the voice module.",
+    accent: "cyan",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: TtsServicePanelIsland,
+    ctaLabel: "Manage TTS",
+  },
+  {
+    name: "vectors",
+    title: "Vector store",
+    description: "Embedding database for semantic memory and retrieval.",
+    accent: "teal",
+    kind: "service",
+    href: "/psh/srv",
+    overlay: VectorsServicePanelIsland,
+    ctaLabel: "Manage vectors",
+  },
+] as const;
+
+export const dashboardTiles: ReadonlyArray<DashboardTileDefinition> = [
+  ...moduleTiles,
+  ...serviceTiles,
+];

--- a/modules/pilot/frontend/lib/psh_status.ts
+++ b/modules/pilot/frontend/lib/psh_status.ts
@@ -1,0 +1,286 @@
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
+
+import type { BadgeTone } from "@pilot/components/dashboard.tsx";
+
+export type ModuleStatusRecord = {
+  name: string;
+  status: "running" | "stopped";
+  pid?: number;
+};
+
+export type ServiceStatusRecord = {
+  name: string;
+  status: "running" | "stopped" | "error";
+  description?: string;
+};
+
+type ResourceKind = "module" | "service";
+
+type StatusRecord = ModuleStatusRecord | ServiceStatusRecord;
+
+type StatusResponse<T> = {
+  ok: boolean;
+  statuses?: T[];
+  error?: string;
+};
+
+interface StatusCache<T extends StatusRecord> {
+  data: T[] | null;
+  promise: Promise<T[]> | null;
+  timestamp: number;
+}
+
+const DEFAULT_REFRESH_INTERVAL_MS = 15_000;
+
+const moduleCache: StatusCache<ModuleStatusRecord> = {
+  data: null,
+  promise: null,
+  timestamp: 0,
+};
+
+const serviceCache: StatusCache<ServiceStatusRecord> = {
+  data: null,
+  promise: null,
+  timestamp: 0,
+};
+
+const MODULE_LABELS: Record<ModuleStatusRecord["status"], string> = {
+  running: "Running",
+  stopped: "Stopped",
+};
+
+const MODULE_TONES: Record<ModuleStatusRecord["status"], BadgeTone> = {
+  running: "ok",
+  stopped: "warn",
+};
+
+const SERVICE_LABELS: Record<ServiceStatusRecord["status"], string> = {
+  running: "Running",
+  stopped: "Stopped",
+  error: "Error",
+};
+
+const SERVICE_TONES: Record<ServiceStatusRecord["status"], BadgeTone> = {
+  running: "ok",
+  stopped: "warn",
+  error: "danger",
+};
+
+function cacheFor(kind: ResourceKind): StatusCache<StatusRecord> {
+  return kind === "module"
+    ? moduleCache as StatusCache<StatusRecord>
+    : serviceCache as StatusCache<StatusRecord>;
+}
+
+function endpointFor(kind: ResourceKind): string {
+  return kind === "module" ? "/api/psh/mod/list" : "/api/psh/srv/list";
+}
+
+async function fetchStatuses<T extends StatusRecord>(
+  kind: ResourceKind,
+  force = false,
+): Promise<T[]> {
+  const cache = cacheFor(kind) as StatusCache<T>;
+  if (!force && cache.data) {
+    return cache.data;
+  }
+  if (!force && cache.promise) {
+    return cache.promise;
+  }
+
+  if (force) {
+    cache.data = null;
+  }
+
+  const request = fetch(endpointFor(kind))
+    .then(async (response): Promise<T[]> => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const payload = await response.json() as StatusResponse<T>;
+      if (!payload.ok || !payload.statuses) {
+        throw new Error(payload.error ?? "Unknown status response");
+      }
+      cache.data = payload.statuses;
+      cache.timestamp = Date.now();
+      return payload.statuses;
+    })
+    .finally(() => {
+      cache.promise = null;
+    });
+
+  cache.promise = request;
+  return request;
+}
+
+interface UsePshStatusOptions {
+  /** Milliseconds between automatic refreshes. Defaults to 15 seconds. */
+  refreshIntervalMs?: number;
+}
+
+export interface UsePshStatusResult {
+  status?: string;
+  label: string;
+  tone: BadgeTone;
+  loading: boolean;
+  description?: string;
+  error?: string;
+  lastUpdated?: number;
+  refresh: () => void;
+}
+
+function mapModuleBadge(
+  status: ModuleStatusRecord | undefined,
+): Pick<UsePshStatusResult, "label" | "tone" | "description" | "status"> {
+  if (!status) {
+    return {
+      status: undefined,
+      label: "Not found",
+      tone: "danger",
+      description: "Module is not provisioned",
+    };
+  }
+
+  return {
+    status: status.status,
+    label: MODULE_LABELS[status.status] ?? "Unknown",
+    tone: MODULE_TONES[status.status] ?? "neutral",
+    description: status.pid ? `PID ${status.pid}` : undefined,
+  };
+}
+
+function mapServiceBadge(
+  status: ServiceStatusRecord | undefined,
+): Pick<UsePshStatusResult, "label" | "tone" | "description" | "status"> {
+  if (!status) {
+    return {
+      status: undefined,
+      label: "Not found",
+      tone: "danger",
+      description: "Service manifest missing",
+    };
+  }
+
+  return {
+    status: status.status,
+    label: SERVICE_LABELS[status.status] ?? "Unknown",
+    tone: SERVICE_TONES[status.status] ?? "neutral",
+    description: status.description,
+  };
+}
+
+/**
+ * Reactively read lifecycle information for a module or service managed by
+ * `psh`.
+ *
+ * The hook polls the appropriate `/api/psh/(mod|srv)/list` endpoint and caches
+ * the response so concurrent dashboard widgets do not trigger duplicate
+ * requests. Consumers receive the current status label, badge tone, and a
+ * refresh callback they can surface in their UI.
+ *
+ * @example
+ * ```tsx
+ * const status = usePshStatus("service", "asr");
+ * return <Badge label={status.label} tone={status.tone} />;
+ * ```
+ */
+export function usePshStatus(
+  kind: ResourceKind,
+  name: string,
+  options: UsePshStatusOptions = {},
+): UsePshStatusResult {
+  const [state, setState] = useState<UsePshStatusResult>(() => ({
+    status: undefined,
+    label: "Loading",
+    tone: "info",
+    loading: true,
+    description: undefined,
+    error: undefined,
+    lastUpdated: undefined,
+    refresh: () => undefined,
+  }));
+
+  const refreshInterval = options.refreshIntervalMs ??
+    DEFAULT_REFRESH_INTERVAL_MS;
+
+  const load = useCallback(async (force = false) => {
+    setState((previous) => ({ ...previous, loading: true, error: undefined }));
+    try {
+      const statuses = await fetchStatuses<StatusRecord>(kind, force);
+      if (kind === "module") {
+        const match = (statuses as ModuleStatusRecord[])
+          .find((entry) => entry.name === name);
+        const mapped = mapModuleBadge(match);
+        setState({
+          ...mapped,
+          loading: false,
+          error: undefined,
+          lastUpdated: Date.now(),
+          refresh: () => {
+            void load(true);
+          },
+        });
+        return;
+      }
+
+      const match = (statuses as ServiceStatusRecord[])
+        .find((entry) => entry.name === name);
+      const mapped = mapServiceBadge(match);
+      setState({
+        ...mapped,
+        loading: false,
+        error: undefined,
+        lastUpdated: Date.now(),
+        refresh: () => {
+          void load(true);
+        },
+      });
+    } catch (error) {
+      setState({
+        status: undefined,
+        label: "Unavailable",
+        tone: "danger",
+        loading: false,
+        description: undefined,
+        error: String(error),
+        lastUpdated: Date.now(),
+        refresh: () => {
+          void load(true);
+        },
+      });
+    }
+  }, [kind, name]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      await load();
+    };
+
+    void run();
+
+    let timer: number | undefined;
+    if (Number.isFinite(refreshInterval) && refreshInterval > 0) {
+      timer = window.setInterval(() => {
+        if (!cancelled) {
+          void load(true);
+        }
+      }, refreshInterval);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+      }
+    };
+  }, [load, refreshInterval]);
+
+  return useMemo<UsePshStatusResult>(() => ({
+    ...state,
+    refresh: () => {
+      void load(true);
+    },
+  }), [load, state]);
+}

--- a/modules/pilot/frontend/routes/index.tsx
+++ b/modules/pilot/frontend/routes/index.tsx
@@ -1,67 +1,59 @@
-import { Panel, Card, type Accent } from "@pilot/components/dashboard.tsx";
+import { Card, Panel } from "@pilot/components/dashboard.tsx";
+
+import DashboardTile from "../components/DashboardTile.tsx";
+import { moduleTiles, serviceTiles } from "../lib/dashboard/tiles.ts";
 import { define } from "../utils.ts";
 
-interface ModuleLink {
-  slug: string;
-  name: string;
-  description: string;
-  tone: Accent;
-}
-
-const modules: ModuleLink[] = [
-  {
-    slug: "pilot",
-    name: "Pilot Module",
-    description:
-      "Status dashboard for the cockpit backend and websocket bridge.",
-    tone: "amber",
-  },
-  {
-    slug: "imu",
-    name: "IMU Module",
-    description:
-      "Read-only telemetry stream with orientation and velocity vectors.",
-    tone: "cyan",
-  },
-  {
-    slug: "foot",
-    name: "Foot Module",
-    description:
-      "Send manual commands and monitor Create drive base telemetry and faults.",
-    tone: "teal",
-  },
-  {
-    slug: "eye",
-    name: "Eye Module",
-    description: "Stream Kinect RGB-D telemetry for situational awareness.",
-    tone: "violet",
-  },
-];
-
 export default define.page(() => {
+  const moduleCount = moduleTiles.length;
+  const serviceCount = serviceTiles.length;
+
   return (
     <section class="content">
       <Panel
-        title="Psyched Pilot"
-        subtitle="Operator console for module diagnostics and orchestration"
+        title="Psyched cockpit"
+        subtitle="Live system overview for Pete's modules and services"
         accent="violet"
       >
         <div class="panel-grid panel-grid--stretch">
-          {modules.map((module) => (
-            <Card
-              key={module.slug}
-              title={module.name}
-              subtitle={module.description}
-              tone={module.tone}
-              footer={(
-                <a
-                  class="button button--primary"
-                  href={`/modules/${module.slug}`}
-                >
-                  Open module
-                </a>
-              )}
-            />
+          <Card title="Modules" subtitle="Managed by psh mod" tone="violet">
+            <p class="note">
+              {moduleCount} module{moduleCount === 1 ? "" : "s"}{" "}
+              exported a dashboard overlay. Expand a tile below to monitor or
+              control them without leaving the homepage.
+            </p>
+          </Card>
+          <Card title="Services" subtitle="Managed by psh srv" tone="cyan">
+            <p class="note">
+              {serviceCount} service{serviceCount === 1 ? "" : "s"}{" "}
+              expose live status from their docker compose stacks. Use the
+              cockpit controls to refresh or jump straight into lifecycle
+              tooling.
+            </p>
+          </Card>
+        </div>
+      </Panel>
+
+      <Panel
+        title="Module dashboards"
+        subtitle="Compact overlays sourced from each module's pilot bundle"
+        accent="teal"
+      >
+        <div class="dashboard-grid">
+          {moduleTiles.map((tile) => (
+            <DashboardTile key={tile.name} {...tile} />
+          ))}
+        </div>
+      </Panel>
+
+      <Panel
+        title="Service dashboards"
+        subtitle="Lifecycle telemetry for dockerised infrastructure"
+        accent="magenta"
+      >
+        <div class="dashboard-grid">
+          {serviceTiles.map((tile) => (
+            <DashboardTile key={tile.name} {...tile} />
           ))}
         </div>
       </Panel>

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -1,7 +1,11 @@
 :root {
   color-scheme: light dark;
   font-family:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   line-height: 1.5;
   background-color: #101418;
   color: #e8edf2;
@@ -55,7 +59,11 @@ body {
   padding: 1.75rem 2rem;
   border-radius: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(135deg, rgba(12, 18, 28, 0.95), rgba(18, 26, 38, 0.98));
+  background: linear-gradient(
+    135deg,
+    rgba(12, 18, 28, 0.95),
+    rgba(18, 26, 38, 0.98)
+  );
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
   --panel-accent: #ff9966;
   --panel-accent-soft: rgba(255, 153, 102, 0.28);
@@ -121,7 +129,11 @@ body {
   width: 18px;
   align-self: stretch;
   border-radius: 12px;
-  background: linear-gradient(180deg, var(--panel-accent), rgba(255, 255, 255, 0.08));
+  background: linear-gradient(
+    180deg,
+    var(--panel-accent),
+    rgba(255, 255, 255, 0.08)
+  );
   box-shadow: 0 0 22px var(--panel-accent-soft);
 }
 
@@ -222,6 +234,80 @@ body {
 
 .panel-grid--stretch {
   align-items: stretch;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.dashboard-tile__details {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  background: rgba(18, 26, 38, 0.85);
+  overflow: hidden;
+}
+
+.dashboard-tile__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dashboard-tile__summary::-webkit-details-marker {
+  display: none;
+}
+
+.dashboard-tile__summary::before {
+  content: "▸";
+  display: inline-flex;
+  width: 1.25rem;
+  justify-content: center;
+  transition: transform 0.2s ease-in-out;
+  color: var(--panel-accent, #71c9f8);
+}
+
+.dashboard-tile__details[open] .dashboard-tile__summary::before {
+  transform: rotate(90deg);
+}
+
+.dashboard-tile__overlay {
+  display: grid;
+  gap: 1.1rem;
+  padding: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  max-height: 420px;
+  overflow: auto;
+  background: rgba(10, 16, 24, 0.72);
+}
+
+.dashboard-tile__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
+}
+
+.dashboard-status-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.dashboard-status-badge__note {
+  font-size: 0.72rem;
+  opacity: 0.65;
+  max-width: 18rem;
+  text-align: right;
 }
 
 .card {
@@ -378,7 +464,11 @@ body {
 }
 
 .button--primary {
-  background: linear-gradient(135deg, rgba(113, 201, 248, 0.4), rgba(197, 141, 255, 0.5));
+  background: linear-gradient(
+    135deg,
+    rgba(113, 201, 248, 0.4),
+    rgba(197, 141, 255, 0.5)
+  );
   border-color: rgba(113, 201, 248, 0.35);
   color: #0c1420;
 }
@@ -390,7 +480,11 @@ body {
 }
 
 .button--danger {
-  background: linear-gradient(135deg, rgba(255, 154, 167, 0.5), rgba(240, 110, 225, 0.4));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 154, 167, 0.5),
+    rgba(240, 110, 225, 0.4)
+  );
   border-color: rgba(255, 94, 109, 0.45);
   color: #16090c;
 }
@@ -455,8 +549,16 @@ body {
 .status-indicator__detail {
   font-size: 0.75rem;
   opacity: 0.7;
-  font-family: "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco,
-    Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    "Fira Mono",
+    "SFMono-Regular",
+    ui-monospace,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
 }
 
 .stat-metric {
@@ -618,7 +720,11 @@ body {
   padding: 0.45rem 0.75rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  background: linear-gradient(135deg, rgba(113, 201, 248, 0.2), rgba(197, 141, 255, 0.3));
+  background: linear-gradient(
+    135deg,
+    rgba(113, 201, 248, 0.2),
+    rgba(197, 141, 255, 0.3)
+  );
   color: #fff;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
@@ -636,7 +742,11 @@ body {
   justify-content: center;
   border-radius: 0.9rem;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  background: radial-gradient(circle at center, rgba(113, 201, 248, 0.08), rgba(0, 0, 0, 0.6));
+  background: radial-gradient(
+    circle at center,
+    rgba(113, 201, 248, 0.08),
+    rgba(0, 0, 0, 0.6)
+  );
   min-height: 220px;
   overflow: hidden;
   padding: 0.75rem;
@@ -664,7 +774,11 @@ body {
   aspect-ratio: 1;
   border-radius: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: radial-gradient(circle at center, rgba(62, 87, 132, 0.18), rgba(5, 9, 15, 0.9));
+  background: radial-gradient(
+    circle at center,
+    rgba(62, 87, 132, 0.18),
+    rgba(5, 9, 15, 0.9)
+  );
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   cursor: grab;
   margin-top: 0.75rem;
@@ -673,7 +787,9 @@ body {
 
 .joystick--active {
   cursor: grabbing;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 12px 24px rgba(113, 201, 248, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 24px rgba(113, 201, 248, 0.18);
 }
 
 .joystick__thumb {
@@ -681,8 +797,15 @@ body {
   width: 22%;
   aspect-ratio: 1;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 153, 102, 0.8), rgba(240, 110, 225, 0.7));
-  transform: translate(calc((var(--stick-x, 0) + 1) * 50% - 50%), calc((var(--stick-y, 0) + 1) * 50% - 50%));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 153, 102, 0.8),
+    rgba(240, 110, 225, 0.7)
+  );
+  transform: translate(
+    calc((var(--stick-x, 0) + 1) * 50% - 50%),
+    calc((var(--stick-y, 0) + 1) * 50% - 50%)
+  );
   transition: transform 0.08s ease;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
 }

--- a/modules/pilot/pilot/components/ServiceOverview.tsx
+++ b/modules/pilot/pilot/components/ServiceOverview.tsx
@@ -1,0 +1,101 @@
+import type { ComponentChildren } from "preact";
+
+import { type Accent, Card, Panel } from "./dashboard.tsx";
+import { usePshStatus } from "@pilot/lib/psh_status.ts";
+
+export interface ServiceOverviewProps {
+  service: string;
+  title: string;
+  subtitle?: string;
+  accent?: Accent;
+  description?: string;
+  docUrl?: string;
+  children?: ComponentChildren;
+}
+
+/**
+ * Present high-level lifecycle information about a dockerised service.
+ *
+ * @example
+ * ```tsx
+ * <ServiceOverview service="asr" title="ASR" description="Speech-to-text" />
+ * ```
+ */
+export default function ServiceOverview({
+  service,
+  title,
+  subtitle,
+  accent = "teal",
+  description,
+  docUrl,
+  children,
+}: ServiceOverviewProps) {
+  const status = usePshStatus("service", service);
+
+  return (
+    <Panel
+      title={title}
+      subtitle={subtitle}
+      accent={accent}
+      badges={[{
+        label: status.label,
+        tone: status.tone,
+        pulse: status.loading,
+      }]}
+      actions={
+        <a class="button button--ghost" href="/psh/srv">
+          Open service console
+        </a>
+      }
+    >
+      <div class="panel-grid">
+        <Card title="Lifecycle" tone={accent}>
+          <dl class="stat-list">
+            <div class="stat-list__item">
+              <dt>Status</dt>
+              <dd>{status.label}</dd>
+            </div>
+            <div class="stat-list__item">
+              <dt>Identifier</dt>
+              <dd>{service}</dd>
+            </div>
+            <div class="stat-list__item">
+              <dt>Details</dt>
+              <dd>{status.description ?? description ?? "—"}</dd>
+            </div>
+            {status.error && (
+              <div class="stat-list__item">
+                <dt>Last error</dt>
+                <dd>{status.error}</dd>
+              </div>
+            )}
+          </dl>
+          <div class="button-group button-group--wrap">
+            <button
+              class="button button--primary"
+              type="button"
+              onClick={() => status.refresh()}
+              disabled={status.loading}
+            >
+              Refresh status
+            </button>
+            <a class="button button--ghost" href="/psh/srv">
+              Manage services
+            </a>
+            {docUrl && (
+              <a
+                class="button button--ghost"
+                href={docUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Documentation
+              </a>
+            )}
+          </div>
+        </Card>
+        {children}
+      </div>
+    </Panel>
+  );
+}

--- a/services/asr/pilot/components/AsrServicePanel.tsx
+++ b/services/asr/pilot/components/AsrServicePanel.tsx
@@ -1,0 +1,22 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function AsrServicePanel() {
+  return (
+    <ServiceOverview
+      service="asr"
+      title="ASR service"
+      subtitle="Streaming Whisper transcription"
+      accent="teal"
+      description="Transforms operator audio into text events for the ear module."
+    >
+      <Card title="Tips" tone="teal">
+        <p class="note">
+          Ensure the ASR models are downloaded before startup. Provisioning via
+          <code>psh srv setup asr</code> fetches the latest checkpoints.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/asr/pilot/islands/AsrServicePanelIsland.tsx
+++ b/services/asr/pilot/islands/AsrServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/AsrServicePanel.tsx";

--- a/services/graphs/pilot/components/GraphsServicePanel.tsx
+++ b/services/graphs/pilot/components/GraphsServicePanel.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function GraphsServicePanel() {
+  return (
+    <ServiceOverview
+      service="graphs"
+      title="Graphs service"
+      subtitle="Knowledge graph backends"
+      accent="magenta"
+      description="Runs Neo4j and Memgraph for situational awareness graphs."
+    >
+      <Card title="Usage" tone="magenta">
+        <p class="note">
+          The graphs stack exposes Bolt endpoints on the provisioned host.
+          Connect tooling such as Bloom or Cypher shell once the service badge
+          reports <strong>Running</strong>.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/graphs/pilot/islands/GraphsServicePanelIsland.tsx
+++ b/services/graphs/pilot/islands/GraphsServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/GraphsServicePanel.tsx";

--- a/services/llm/pilot/components/LlmServicePanel.tsx
+++ b/services/llm/pilot/components/LlmServicePanel.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function LlmServicePanel() {
+  return (
+    <ServiceOverview
+      service="llm"
+      title="LLM service"
+      subtitle="Conversational model runtime"
+      accent="violet"
+      description="Hosts large language model runtimes for dialogue orchestration."
+    >
+      <Card title="Deployment" tone="violet">
+        <p class="note">
+          The runtime exposes an OpenAI-compatible API once the container is up.
+          Point the voice or brain modules to the forwarded port to enable
+          conversations.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/llm/pilot/islands/LlmServicePanelIsland.tsx
+++ b/services/llm/pilot/islands/LlmServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/LlmServicePanel.tsx";

--- a/services/ros2/pilot/components/Ros2ServicePanel.tsx
+++ b/services/ros2/pilot/components/Ros2ServicePanel.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function Ros2ServicePanel() {
+  return (
+    <ServiceOverview
+      service="ros2"
+      title="ROS 2 bridge"
+      subtitle="Containerised workspace utilities"
+      accent="amber"
+      description="Bootstraps auxiliary ROS 2 tooling and remote shells."
+    >
+      <Card title="Notes" tone="amber">
+        <p class="note">
+          Use <code>psh srv up ros2</code>{" "}
+          before building modules that depend on Dockerised tooling such as{" "}
+          <code>rosdep</code> or auxiliary bridge nodes.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/ros2/pilot/islands/Ros2ServicePanelIsland.tsx
+++ b/services/ros2/pilot/islands/Ros2ServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/Ros2ServicePanel.tsx";

--- a/services/tts/pilot/components/TtsServicePanel.tsx
+++ b/services/tts/pilot/components/TtsServicePanel.tsx
@@ -1,0 +1,22 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function TtsServicePanel() {
+  return (
+    <ServiceOverview
+      service="tts"
+      title="TTS service"
+      subtitle="Voice synthesis backend"
+      accent="cyan"
+      description="Provides text-to-speech voices for the voice module."
+    >
+      <Card title="Voices" tone="cyan">
+        <p class="note">
+          Load custom voices by mounting additional models into the compose
+          stack. Refresh after syncing assets to see status updates.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/tts/pilot/islands/TtsServicePanelIsland.tsx
+++ b/services/tts/pilot/islands/TtsServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/TtsServicePanel.tsx";

--- a/services/vectors/pilot/components/VectorsServicePanel.tsx
+++ b/services/vectors/pilot/components/VectorsServicePanel.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@pilot/components/dashboard.tsx";
+
+import ServiceOverview from "../../../../modules/pilot/pilot/components/ServiceOverview.tsx";
+
+export default function VectorsServicePanel() {
+  return (
+    <ServiceOverview
+      service="vectors"
+      title="Vector store"
+      subtitle="Embedding memory backend"
+      accent="teal"
+      description="Maintains embeddings for retrieval augmented behaviours."
+    >
+      <Card title="Health" tone="teal">
+        <p class="note">
+          Monitor disk usage and ingestion health from this overlay. Use
+          <code>psh srv up vectors</code>{" "}
+          before triggering knowledge base synchronisation jobs.
+        </p>
+      </Card>
+    </ServiceOverview>
+  );
+}

--- a/services/vectors/pilot/islands/VectorsServicePanelIsland.tsx
+++ b/services/vectors/pilot/islands/VectorsServicePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/VectorsServicePanel.tsx";


### PR DESCRIPTION
## Summary
- add reusable dashboard tile and status badge components to the cockpit homepage
- expose service overview panels alongside module overlays so every module/service shares a dashboard island
- add shared PSH status hook with tests plus new ServiceOverview component for service-specific panels

## Testing
- deno test --config deno.json --no-lock --no-check lib/dashboard/tiles.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5f8e56b748320bbc0d4e87502514a