### PR TITLE
Add standard pilot overlays for modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,6 @@ Happy hacking!
 ## Miscellaneous
 ### Symlinks
 * Each module has its own pilot folder, which is linked into the main Fresh app by `psh mod setup <module>`. This allows modules to declare their own UI components and pages without merging everything into a single codebase.
+
+### Module overlays
+* Use the shared `ModuleOverview` component under `modules/pilot/pilot/components/ModuleOverview.tsx` when you only need standard lifecycle controls for a module. Its helper functions are covered by `ModuleOverview_test.ts`; run the tests with `deno test --config modules/pilot/pilot/deno.test.json`.

--- a/modules/chat/module.toml
+++ b/modules/chat/module.toml
@@ -8,6 +8,7 @@ patches = [
 ]
 launch = "modules/chat/launch_unit.sh"
 shutdown = "modules/chat/shutdown_unit.sh"
+pilot_control = "modules/chat/pilot/components/ChatModulePanel.tsx"
 
 [unit.chat.ros]
 workspace = "."

--- a/modules/chat/pilot/components/ChatModulePanel.tsx
+++ b/modules/chat/pilot/components/ChatModulePanel.tsx
@@ -1,0 +1,18 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION =
+  "Conversational agent orchestrating Pete's dialogue skills.";
+
+/**
+ * Lifecycle controls for the Chat module, delegating to {@link ModuleOverview}.
+ */
+export default function ChatModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="chat"
+      title="Chat module"
+      description={DESCRIPTION}
+      accent="violet"
+    />
+  );
+}

--- a/modules/chat/pilot/islands/ChatModulePanelIsland.tsx
+++ b/modules/chat/pilot/islands/ChatModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/ChatModulePanel.tsx";

--- a/modules/chat/pilot/routes/modules/chat.tsx
+++ b/modules/chat/pilot/routes/modules/chat.tsx
@@ -1,0 +1,9 @@
+import ChatModulePanel from "../../islands/ChatModulePanelIsland.tsx";
+
+export default function ChatModulePage() {
+  return (
+    <section class="content">
+      <ChatModulePanel />
+    </section>
+  );
+}

--- a/modules/ear/module.toml
+++ b/modules/ear/module.toml
@@ -6,6 +6,7 @@ apt = [
 pip = []
 launch = "modules/ear/launch_unit.sh"
 shutdown = "modules/ear/shutdown_unit.sh"
+pilot_control = "modules/ear/pilot/components/EarModulePanel.tsx"
 
 [unit.ear.ros]
 workspace = "."

--- a/modules/ear/pilot/components/EarModulePanel.tsx
+++ b/modules/ear/pilot/components/EarModulePanel.tsx
@@ -1,0 +1,15 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION = "Microphone ingestion and speech recognition interface.";
+
+/** Present lifecycle controls for the Ear audio capture module. */
+export default function EarModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="ear"
+      title="Ear module"
+      description={DESCRIPTION}
+      accent="cyan"
+    />
+  );
+}

--- a/modules/ear/pilot/islands/EarModulePanelIsland.tsx
+++ b/modules/ear/pilot/islands/EarModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/EarModulePanel.tsx";

--- a/modules/ear/pilot/routes/modules/ear.tsx
+++ b/modules/ear/pilot/routes/modules/ear.tsx
@@ -1,0 +1,9 @@
+import EarModulePanel from "../../islands/EarModulePanelIsland.tsx";
+
+export default function EarModulePage() {
+  return (
+    <section class="content">
+      <EarModulePanel />
+    </section>
+  );
+}

--- a/modules/faces/module.toml
+++ b/modules/faces/module.toml
@@ -7,6 +7,7 @@ pip = [
 patches = []
 launch = "modules/faces/launch_unit.sh"
 shutdown = "modules/faces/shutdown_unit.sh"
+pilot_control = "modules/faces/pilot/components/FacesModulePanel.tsx"
 
 [unit.faces.ros]
 workspace = "."

--- a/modules/faces/pilot/components/FacesModulePanel.tsx
+++ b/modules/faces/pilot/components/FacesModulePanel.tsx
@@ -1,0 +1,15 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION = "Face detection pipeline for presence and identity cues.";
+
+/** Surface lifecycle controls for the Faces perception module. */
+export default function FacesModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="faces"
+      title="Faces module"
+      description={DESCRIPTION}
+      accent="magenta"
+    />
+  );
+}

--- a/modules/faces/pilot/islands/FacesModulePanelIsland.tsx
+++ b/modules/faces/pilot/islands/FacesModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/FacesModulePanel.tsx";

--- a/modules/faces/pilot/routes/modules/faces.tsx
+++ b/modules/faces/pilot/routes/modules/faces.tsx
@@ -1,0 +1,9 @@
+import FacesModulePanel from "../../islands/FacesModulePanelIsland.tsx";
+
+export default function FacesModulePage() {
+  return (
+    <section class="content">
+      <FacesModulePanel />
+    </section>
+  );
+}

--- a/modules/gps/module.toml
+++ b/modules/gps/module.toml
@@ -12,6 +12,7 @@ patches = [
 ]
 launch = "modules/gps/launch_unit.sh"
 shutdown = "modules/gps/shutdown_unit.sh"
+pilot_control = "modules/gps/pilot/components/GpsModulePanel.tsx"
 
 [unit.gps.ros]
 workspace = "."

--- a/modules/gps/pilot/components/GpsModulePanel.tsx
+++ b/modules/gps/pilot/components/GpsModulePanel.tsx
@@ -1,0 +1,15 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION = "GNSS receiver integration for Pete's localization stack.";
+
+/** Lifecycle controls for the GPS hardware integration module. */
+export default function GpsModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="gps"
+      title="GPS module"
+      description={DESCRIPTION}
+      accent="amber"
+    />
+  );
+}

--- a/modules/gps/pilot/islands/GpsModulePanelIsland.tsx
+++ b/modules/gps/pilot/islands/GpsModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/GpsModulePanel.tsx";

--- a/modules/gps/pilot/routes/modules/gps.tsx
+++ b/modules/gps/pilot/routes/modules/gps.tsx
@@ -1,0 +1,9 @@
+import GpsModulePanel from "../../islands/GpsModulePanelIsland.tsx";
+
+export default function GpsModulePage() {
+  return (
+    <section class="content">
+      <GpsModulePanel />
+    </section>
+  );
+}

--- a/modules/memory/module.toml
+++ b/modules/memory/module.toml
@@ -3,6 +3,7 @@ apt = []
 pip = []
 launch = "modules/memory/launch_unit.sh"
 shutdown = "modules/memory/shutdown_unit.sh"
+pilot_control = "modules/memory/pilot/components/MemoryModulePanel.tsx"
 
 [unit.memory.ros]
 workspace = "."

--- a/modules/memory/pilot/components/MemoryModulePanel.tsx
+++ b/modules/memory/pilot/components/MemoryModulePanel.tsx
@@ -1,0 +1,16 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION =
+  "Semantic memory pipelines bridging vectors and graph stores.";
+
+/** Show lifecycle controls for the Memory knowledge store module. */
+export default function MemoryModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="memory"
+      title="Memory module"
+      description={DESCRIPTION}
+      accent="teal"
+    />
+  );
+}

--- a/modules/memory/pilot/islands/MemoryModulePanelIsland.tsx
+++ b/modules/memory/pilot/islands/MemoryModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/MemoryModulePanel.tsx";

--- a/modules/memory/pilot/routes/modules/memory.tsx
+++ b/modules/memory/pilot/routes/modules/memory.tsx
@@ -1,0 +1,9 @@
+import MemoryModulePanel from "../../islands/MemoryModulePanelIsland.tsx";
+
+export default function MemoryModulePage() {
+  return (
+    <section class="content">
+      <MemoryModulePanel />
+    </section>
+  );
+}

--- a/modules/nav/module.toml
+++ b/modules/nav/module.toml
@@ -8,6 +8,7 @@ patches = [
 ]
 launch = "modules/nav/launch_unit.sh"
 shutdown = "modules/nav/shutdown_unit.sh"
+pilot_control = "modules/nav/pilot/components/NavModulePanel.tsx"
 
 [unit.nav.ros]
 workspace = "."

--- a/modules/nav/pilot/components/NavModulePanel.tsx
+++ b/modules/nav/pilot/components/NavModulePanel.tsx
@@ -1,0 +1,16 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION =
+  "Navigation stack coordinating localization and path planning.";
+
+/** Lifecycle controls for the Nav autonomy module. */
+export default function NavModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="nav"
+      title="Nav module"
+      description={DESCRIPTION}
+      accent="violet"
+    />
+  );
+}

--- a/modules/nav/pilot/islands/NavModulePanelIsland.tsx
+++ b/modules/nav/pilot/islands/NavModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/NavModulePanel.tsx";

--- a/modules/nav/pilot/routes/modules/nav.tsx
+++ b/modules/nav/pilot/routes/modules/nav.tsx
@@ -1,0 +1,9 @@
+import NavModulePanel from "../../islands/NavModulePanelIsland.tsx";
+
+export default function NavModulePage() {
+  return (
+    <section class="content">
+      <NavModulePanel />
+    </section>
+  );
+}

--- a/modules/pilot/frontend/lib/dashboard/tiles.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.ts
@@ -3,9 +3,19 @@ import type { ComponentType } from "preact";
 import type { Accent } from "@pilot/components/dashboard.tsx";
 
 import PilotOverviewIsland from "../../../pilot/islands/PilotOverviewIsland.tsx";
+import ChatModulePanelIsland from "../../../../chat/pilot/islands/ChatModulePanelIsland.tsx";
+import EarModulePanelIsland from "../../../../ear/pilot/islands/EarModulePanelIsland.tsx";
 import ImuTelemetryIsland from "../../../../imu/pilot/islands/ImuTelemetryIsland.tsx";
+import FacesModulePanelIsland from "../../../../faces/pilot/islands/FacesModulePanelIsland.tsx";
 import FootControlPanelIsland from "../../../../foot/pilot/islands/FootControlPanelIsland.tsx";
+import GpsModulePanelIsland from "../../../../gps/pilot/islands/GpsModulePanelIsland.tsx";
 import KinectStreamPanelIsland from "../../../../eye/pilot/islands/KinectStreamPanelIsland.tsx";
+import MemoryModulePanelIsland from "../../../../memory/pilot/islands/MemoryModulePanelIsland.tsx";
+import NavModulePanelIsland from "../../../../nav/pilot/islands/NavModulePanelIsland.tsx";
+import VoiceModulePanelIsland from "../../../../voice/pilot/islands/VoiceModulePanelIsland.tsx";
+import VisceraModulePanelIsland from "../../../../viscera/pilot/islands/VisceraModulePanelIsland.tsx";
+import WifiModulePanelIsland from "../../../../wifi/pilot/islands/WifiModulePanelIsland.tsx";
+import WillModulePanelIsland from "../../../../will/pilot/islands/WillModulePanelIsland.tsx";
 import AsrServicePanelIsland from "../../../../../services/asr/pilot/islands/AsrServicePanelIsland.tsx";
 import GraphsServicePanelIsland from "../../../../../services/graphs/pilot/islands/GraphsServicePanelIsland.tsx";
 import LlmServicePanelIsland from "../../../../../services/llm/pilot/islands/LlmServicePanelIsland.tsx";
@@ -45,6 +55,24 @@ export const moduleTiles: ReadonlyArray<DashboardTileDefinition> = [
     },
   },
   {
+    name: "chat",
+    title: "Chat module",
+    description: "Conversational agent orchestrating Pete's dialogue skills.",
+    accent: "violet",
+    kind: "module",
+    href: "/modules/chat",
+    overlay: ChatModulePanelIsland,
+  },
+  {
+    name: "ear",
+    title: "Ear module",
+    description: "Microphone ingestion and speech recognition interface.",
+    accent: "cyan",
+    kind: "module",
+    href: "/modules/ear",
+    overlay: EarModulePanelIsland,
+  },
+  {
     name: "imu",
     title: "IMU module",
     description: "Orientation, acceleration, and angular velocity telemetry.",
@@ -52,6 +80,15 @@ export const moduleTiles: ReadonlyArray<DashboardTileDefinition> = [
     kind: "module",
     href: "/modules/imu",
     overlay: ImuTelemetryIsland,
+  },
+  {
+    name: "faces",
+    title: "Faces module",
+    description: "Face detection pipeline for presence and identity cues.",
+    accent: "magenta",
+    kind: "module",
+    href: "/modules/faces",
+    overlay: FacesModulePanelIsland,
   },
   {
     name: "foot",
@@ -64,6 +101,15 @@ export const moduleTiles: ReadonlyArray<DashboardTileDefinition> = [
     overlay: FootControlPanelIsland,
   },
   {
+    name: "gps",
+    title: "GPS module",
+    description: "GNSS receiver integration for Pete's localization stack.",
+    accent: "amber",
+    kind: "module",
+    href: "/modules/gps",
+    overlay: GpsModulePanelIsland,
+  },
+  {
     name: "eye",
     title: "Eye module",
     description: "Kinect RGB-D stream with payload diagnostics.",
@@ -71,6 +117,61 @@ export const moduleTiles: ReadonlyArray<DashboardTileDefinition> = [
     kind: "module",
     href: "/modules/eye",
     overlay: KinectStreamPanelIsland,
+  },
+  {
+    name: "memory",
+    title: "Memory module",
+    description: "Semantic memory pipelines bridging vectors and graph stores.",
+    accent: "teal",
+    kind: "module",
+    href: "/modules/memory",
+    overlay: MemoryModulePanelIsland,
+  },
+  {
+    name: "nav",
+    title: "Nav module",
+    description:
+      "Navigation stack coordinating localization and path planning.",
+    accent: "violet",
+    kind: "module",
+    href: "/modules/nav",
+    overlay: NavModulePanelIsland,
+  },
+  {
+    name: "voice",
+    title: "Voice module",
+    description: "Speech synthesis bridge coordinating the TTS service.",
+    accent: "cyan",
+    kind: "module",
+    href: "/modules/voice",
+    overlay: VoiceModulePanelIsland,
+  },
+  {
+    name: "viscera",
+    title: "Viscera module",
+    description: "System health monitors and feelers for onboard diagnostics.",
+    accent: "amber",
+    kind: "module",
+    href: "/modules/viscera",
+    overlay: VisceraModulePanelIsland,
+  },
+  {
+    name: "wifi",
+    title: "Wi-Fi module",
+    description: "Wireless connectivity tooling and diagnostics for Pete.",
+    accent: "teal",
+    kind: "module",
+    href: "/modules/wifi",
+    overlay: WifiModulePanelIsland,
+  },
+  {
+    name: "will",
+    title: "Will module",
+    description: "High-level intent planner orchestrating Pete's behaviours.",
+    accent: "magenta",
+    kind: "module",
+    href: "/modules/will",
+    overlay: WillModulePanelIsland,
   },
 ] as const;
 

--- a/modules/pilot/pilot/components/ModuleOverview.tsx
+++ b/modules/pilot/pilot/components/ModuleOverview.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useMemo, useState } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+import { type Accent, Card, Panel } from "./dashboard.tsx";
+import {
+  MODULE_ACTIONS,
+  type ModuleAction,
+  moduleActionEndpoint,
+  moduleActionLabel,
+} from "./module_actions.ts";
+import { usePshStatus } from "@pilot/lib/psh_status.ts";
+import { formatRelativeTime } from "../../frontend/lib/format.ts";
+
+interface ModuleOverviewProps {
+  /** Identifier used by `psh` to reference the module. */
+  moduleName: string;
+  /** Heading displayed at the top of the panel. */
+  title: string;
+  /** Optional supporting copy rendered under the title. */
+  description?: string;
+  /** Accent applied to the panel and action buttons. */
+  accent?: Accent;
+  /** Link to module documentation surfaced beside the quick actions. */
+  docUrl?: string;
+  /** Additional cards rendered alongside the default lifecycle controls. */
+  children?: ComponentChildren;
+}
+
+type ActionMessage =
+  | { kind: "success"; text: string }
+  | { kind: "error"; text: string };
+
+const SUCCESS_MESSAGE = "Lifecycle command dispatched successfully.";
+const ERROR_PREFIX = "Lifecycle command failed:";
+
+/**
+ * Present lifecycle telemetry and quick controls for a ROS module.
+ *
+ * @example
+ * ```tsx
+ * <ModuleOverview
+ *   moduleName="chat"
+ *   title="Chat module"
+ *   description="Conversational agent backed by the LLM service."
+ * />
+ * ```
+ */
+export default function ModuleOverview({
+  moduleName,
+  title,
+  description,
+  accent = "teal",
+  docUrl,
+  children,
+}: ModuleOverviewProps) {
+  const status = usePshStatus("module", moduleName);
+  const [pendingAction, setPendingAction] = useState<ModuleAction | null>(
+    null,
+  );
+  const [message, setMessage] = useState<ActionMessage | null>(null);
+
+  const lastUpdatedLabel = useMemo(
+    () => formatRelativeTime(status.lastUpdated),
+    [status.lastUpdated],
+  );
+
+  const handleAction = useCallback(
+    async (action: ModuleAction) => {
+      if (typeof fetch !== "function") {
+        return;
+      }
+
+      setPendingAction(action);
+      setMessage(null);
+      try {
+        const response = await fetch(moduleActionEndpoint(action), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ modules: [moduleName] }),
+        });
+        const payload = await response.json() as {
+          ok: boolean;
+          error?: string;
+        };
+        if (!payload.ok) {
+          throw new Error(payload.error ?? "Unknown lifecycle error");
+        }
+        setMessage({ kind: "success", text: SUCCESS_MESSAGE });
+        status.refresh();
+      } catch (error) {
+        const text = error instanceof Error ? error.message : String(error);
+        setMessage({ kind: "error", text: `${ERROR_PREFIX} ${text}` });
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [moduleName, status.refresh],
+  );
+
+  return (
+    <Panel
+      title={title}
+      subtitle={description}
+      accent={accent}
+      badges={[
+        {
+          label: status.label,
+          tone: status.tone,
+          pulse: status.loading,
+        },
+        {
+          label: `Updated ${lastUpdatedLabel}`,
+          tone: "neutral",
+        },
+      ]}
+      actions={
+        <a class="button button--ghost" href="/psh/mod">
+          Open module console
+        </a>
+      }
+    >
+      <div class="panel-grid panel-grid--stretch">
+        <Card title="Lifecycle" subtitle="psh mod status" tone={accent}>
+          <dl class="stat-list">
+            <div class="stat-list__item">
+              <dt>Status</dt>
+              <dd>{status.label}</dd>
+            </div>
+            <div class="stat-list__item">
+              <dt>Last updated</dt>
+              <dd>{lastUpdatedLabel}</dd>
+            </div>
+            <div class="stat-list__item">
+              <dt>Details</dt>
+              <dd>{status.description ?? "—"}</dd>
+            </div>
+            {status.error && (
+              <div class="stat-list__item">
+                <dt>Last error</dt>
+                <dd>{status.error}</dd>
+              </div>
+            )}
+          </dl>
+          <div class="button-group button-group--wrap">
+            <button
+              class="button button--primary"
+              type="button"
+              onClick={() => status.refresh()}
+              disabled={status.loading}
+            >
+              Refresh status
+            </button>
+            {docUrl && (
+              <a
+                class="button button--ghost"
+                href={docUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Documentation
+              </a>
+            )}
+          </div>
+        </Card>
+
+        <Card title="Controls" subtitle="psh mod lifecycle" tone="neutral">
+          {message && (
+            <p
+              class={`note ${
+                message.kind === "success" ? "note--success" : "note--alert"
+              }`}
+            >
+              {message.text}
+            </p>
+          )}
+          <div class="button-group button-group--wrap">
+            {MODULE_ACTIONS.map((action) => (
+              <button
+                key={action}
+                class={`button ${
+                  action === "teardown"
+                    ? "button--danger"
+                    : action === "down"
+                    ? "button--ghost"
+                    : "button--primary"
+                }`}
+                type="button"
+                disabled={pendingAction !== null}
+                onClick={() => handleAction(action)}
+              >
+                {moduleActionLabel(action)}
+              </button>
+            ))}
+          </div>
+        </Card>
+
+        {children}
+      </div>
+    </Panel>
+  );
+}

--- a/modules/pilot/pilot/components/ModuleOverview_test.ts
+++ b/modules/pilot/pilot/components/ModuleOverview_test.ts
@@ -1,0 +1,35 @@
+import {
+  MODULE_ACTIONS,
+  moduleActionEndpoint,
+  moduleActionLabel,
+} from "./module_actions.ts";
+
+Deno.test("module action endpoints map to psh mod APIs", () => {
+  for (const action of MODULE_ACTIONS) {
+    const endpoint = moduleActionEndpoint(action);
+    if (!endpoint.startsWith("/api/psh/mod/")) {
+      throw new Error(`Unexpected endpoint prefix for ${action}: ${endpoint}`);
+    }
+    const suffix = endpoint.replace("/api/psh/mod/", "");
+    if (suffix !== action) {
+      throw new Error(`Endpoint suffix mismatch for ${action}: ${suffix}`);
+    }
+  }
+});
+
+Deno.test("module action labels are human friendly", () => {
+  const expected = new Map(
+    [
+      ["setup", "Setup"],
+      ["up", "Start"],
+      ["down", "Stop"],
+      ["teardown", "Teardown"],
+    ] as const,
+  );
+  for (const action of MODULE_ACTIONS) {
+    const label = moduleActionLabel(action);
+    if (label !== expected.get(action)) {
+      throw new Error(`Unexpected label for ${action}: ${label}`);
+    }
+  }
+});

--- a/modules/pilot/pilot/components/PilotOverview.tsx
+++ b/modules/pilot/pilot/components/PilotOverview.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useMemo } from "preact/hooks";
-import {
-  type ConnectionStatus,
-  useCockpitTopic,
-} from "@pilot/lib/cockpit.ts";
+import { type ConnectionStatus, useCockpitTopic } from "@pilot/lib/cockpit.ts";
 
 import {
   Card,
@@ -50,8 +47,8 @@ export default function PilotOverview({
   );
 
   const connectionStatus = status as ConnectionStatus;
-  const connectionLabel =
-    CONNECTION_STATUS_LABELS[connectionStatus] ?? "Unknown";
+  const connectionLabel = CONNECTION_STATUS_LABELS[connectionStatus] ??
+    "Unknown";
   const formattedTimestamp = useMemo(
     () => formatTimestamp(data?.timestamp),
     [data?.timestamp],
@@ -69,10 +66,9 @@ export default function PilotOverview({
   }, [publish]);
 
   const activeModules = data?.activeModules;
-  const activeModulesLabel =
-    typeof activeModules === "number"
-      ? `${activeModules} active`
-      : "Active modules —";
+  const activeModulesLabel = typeof activeModules === "number"
+    ? `${activeModules} active`
+    : "Active modules —";
 
   return (
     <Panel

--- a/modules/pilot/pilot/components/dashboard.tsx
+++ b/modules/pilot/pilot/components/dashboard.tsx
@@ -149,8 +149,7 @@ export function Card({
   return (
     <section class="card" data-tone={tone}>
       <header class="card__header">
-        {icon && <span class="card__icon" aria-hidden="true">{icon}
-        </span>}
+        {icon && <span class="card__icon" aria-hidden="true">{icon}</span>}
         <div>
           <h2 class="card__title">{title}</h2>
           {subtitle && <p class="card__subtitle">{subtitle}</p>}

--- a/modules/pilot/pilot/components/module_actions.ts
+++ b/modules/pilot/pilot/components/module_actions.ts
@@ -1,0 +1,35 @@
+/**
+ * Lifecycle actions available for ROS modules managed through `psh mod`.
+ */
+export const MODULE_ACTIONS = [
+  "setup",
+  "up",
+  "down",
+  "teardown",
+] as const;
+
+export type ModuleAction = (typeof MODULE_ACTIONS)[number];
+
+const MODULE_ACTION_LABELS: Readonly<Record<ModuleAction, string>> = {
+  setup: "Setup",
+  up: "Start",
+  down: "Stop",
+  teardown: "Teardown",
+} as const;
+
+/**
+ * Resolve the cockpit API endpoint responsible for executing a module action.
+ *
+ * @example
+ * ```ts
+ * moduleActionEndpoint("up"); // "/api/psh/mod/up"
+ * ```
+ */
+export function moduleActionEndpoint(action: ModuleAction): string {
+  return `/api/psh/mod/${action}`;
+}
+
+/** Human friendly label for a module lifecycle action. */
+export function moduleActionLabel(action: ModuleAction): string {
+  return MODULE_ACTION_LABELS[action] ?? action;
+}

--- a/modules/pilot/pilot/deno.test.json
+++ b/modules/pilot/pilot/deno.test.json
@@ -1,0 +1,16 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "@pilot/lib/": "../frontend/lib/",
+    "@pilot/components/": "./components/",
+    "@pilot/lib/cockpit.ts": "../lib/cockpit.ts",
+    "@pilot/components/dashboard.tsx": "./components/dashboard.tsx",
+    "preact": "npm:preact@^10.27.2",
+    "preact/hooks": "npm:preact@^10.27.2/hooks"
+  },
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "lib": ["dom", "dom.iterable", "deno.ns"]
+  }
+}

--- a/modules/viscera/module.toml
+++ b/modules/viscera/module.toml
@@ -3,6 +3,7 @@ apt = []
 pip = []
 launch = "modules/viscera/launch_unit.sh"
 shutdown = "modules/viscera/shutdown_unit.sh"
+pilot_control = "modules/viscera/pilot/components/VisceraModulePanel.tsx"
 
 [unit.viscera.ros]
 workspace = "."

--- a/modules/viscera/pilot/components/VisceraModulePanel.tsx
+++ b/modules/viscera/pilot/components/VisceraModulePanel.tsx
@@ -1,0 +1,16 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION =
+  "System health monitors and feelers for onboard diagnostics.";
+
+/** Provide lifecycle controls for the Viscera health monitoring module. */
+export default function VisceraModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="viscera"
+      title="Viscera module"
+      description={DESCRIPTION}
+      accent="amber"
+    />
+  );
+}

--- a/modules/viscera/pilot/islands/VisceraModulePanelIsland.tsx
+++ b/modules/viscera/pilot/islands/VisceraModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/VisceraModulePanel.tsx";

--- a/modules/viscera/pilot/routes/modules/viscera.tsx
+++ b/modules/viscera/pilot/routes/modules/viscera.tsx
@@ -1,0 +1,9 @@
+import VisceraModulePanel from "../../islands/VisceraModulePanelIsland.tsx";
+
+export default function VisceraModulePage() {
+  return (
+    <section class="content">
+      <VisceraModulePanel />
+    </section>
+  );
+}

--- a/modules/voice/module.toml
+++ b/modules/voice/module.toml
@@ -5,6 +5,7 @@ apt = [
 pip = []
 launch = "modules/voice/launch_unit.sh"
 shutdown = "modules/voice/shutdown_unit.sh"
+pilot_control = "modules/voice/pilot/components/VoiceModulePanel.tsx"
 
 [unit.voice.ros]
 workspace = "."

--- a/modules/voice/pilot/components/VoiceModulePanel.tsx
+++ b/modules/voice/pilot/components/VoiceModulePanel.tsx
@@ -1,0 +1,15 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION = "Speech synthesis bridge coordinating the TTS service.";
+
+/** Lifecycle controls for the Voice output module. */
+export default function VoiceModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="voice"
+      title="Voice module"
+      description={DESCRIPTION}
+      accent="cyan"
+    />
+  );
+}

--- a/modules/voice/pilot/islands/VoiceModulePanelIsland.tsx
+++ b/modules/voice/pilot/islands/VoiceModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/VoiceModulePanel.tsx";

--- a/modules/voice/pilot/routes/modules/voice.tsx
+++ b/modules/voice/pilot/routes/modules/voice.tsx
@@ -1,0 +1,9 @@
+import VoiceModulePanel from "../../islands/VoiceModulePanelIsland.tsx";
+
+export default function VoiceModulePage() {
+  return (
+    <section class="content">
+      <VoiceModulePanel />
+    </section>
+  );
+}

--- a/modules/wifi/module.toml
+++ b/modules/wifi/module.toml
@@ -10,6 +10,7 @@ pip = ["zeroconf"]
 patches = []
 launch = "modules/wifi/launch_unit.sh"
 shutdown = "modules/wifi/shutdown_unit.sh"
+pilot_control = "modules/wifi/pilot/components/WifiModulePanel.tsx"
 
 [unit.wifi.ros]
 workspace = "."

--- a/modules/wifi/pilot/components/WifiModulePanel.tsx
+++ b/modules/wifi/pilot/components/WifiModulePanel.tsx
@@ -1,0 +1,15 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION = "Wireless connectivity tooling and diagnostics for Pete.";
+
+/** Lifecycle controls for the Wi-Fi connectivity module. */
+export default function WifiModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="wifi"
+      title="Wi-Fi module"
+      description={DESCRIPTION}
+      accent="teal"
+    />
+  );
+}

--- a/modules/wifi/pilot/islands/WifiModulePanelIsland.tsx
+++ b/modules/wifi/pilot/islands/WifiModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/WifiModulePanel.tsx";

--- a/modules/wifi/pilot/routes/modules/wifi.tsx
+++ b/modules/wifi/pilot/routes/modules/wifi.tsx
@@ -1,0 +1,9 @@
+import WifiModulePanel from "../../islands/WifiModulePanelIsland.tsx";
+
+export default function WifiModulePage() {
+  return (
+    <section class="content">
+      <WifiModulePanel />
+    </section>
+  );
+}

--- a/modules/will/module.toml
+++ b/modules/will/module.toml
@@ -7,6 +7,7 @@ pip = ["py_trees"]
 patches = ["modules/will/scripts/install_py_trees_ros.sh"]
 launch = "modules/will/launch_unit.sh"
 shutdown = "modules/will/shutdown_unit.sh"
+pilot_control = "modules/will/pilot/components/WillModulePanel.tsx"
 
 [unit.will.ros]
 workspace = "."

--- a/modules/will/pilot/components/WillModulePanel.tsx
+++ b/modules/will/pilot/components/WillModulePanel.tsx
@@ -1,0 +1,16 @@
+import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+
+const DESCRIPTION =
+  "High-level intent planner orchestrating Pete's behaviours.";
+
+/** Lifecycle controls for the Will behaviour coordination module. */
+export default function WillModulePanel() {
+  return (
+    <ModuleOverview
+      moduleName="will"
+      title="Will module"
+      description={DESCRIPTION}
+      accent="magenta"
+    />
+  );
+}

--- a/modules/will/pilot/islands/WillModulePanelIsland.tsx
+++ b/modules/will/pilot/islands/WillModulePanelIsland.tsx
@@ -1,0 +1,1 @@
+export { default } from "../components/WillModulePanel.tsx";

--- a/modules/will/pilot/routes/modules/will.tsx
+++ b/modules/will/pilot/routes/modules/will.tsx
@@ -1,0 +1,9 @@
+import WillModulePanel from "../../islands/WillModulePanelIsland.tsx";
+
+export default function WillModulePage() {
+  return (
+    <section class="content">
+      <WillModulePanel />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable `ModuleOverview` lifecycle panel with shared action helpers, dedicated config, and unit coverage
- add pilot overlay panels for each module and register them across the cockpit dashboard tiles
- wire `pilot_control` entries into every module manifest and document the new overlay workflow in `AGENTS.md`

## Testing
- `DENO_TLS_CA_STORE=system deno test --config modules/pilot/pilot/deno.test.json modules/pilot/pilot/components/ModuleOverview_test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e64b149128832098bb65ae43efb6dc