### PR TITLE
Refine cockpit layout styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Always prefer running the smallest relevant command set.
 - **Deno TLS certificates:** When fetching dependencies during `deno task test`, set `DENO_TLS_CA_STORE=system` if you encounter TLS certificate errors in restricted environments.
 - **Deno permissions:** Prefer `deno task test` (which wraps `deno test --allow-all`) so permission-gated tests can read env vars and temp directories without manual flags.
 - **Deno test harness:** Use `Deno.test(...)` when authoring unit tests—`deno test` is the CLI command and will not compile inside source files.
+- **Deno availability in containers:** Some automation containers omit the `deno` binary; if commands such as `deno fmt` fail with "command not found," document the limitation instead of repeatedly retrying.
 - **APT CLI stability:** Provisioning scripts must use `apt-get` (not `apt`) to avoid behaviour changes and interactive warnings during automation.
 - **ROS tooling packages:** Avoid installing `python3-colcon-*` or other catkin/colcon Debian packages; rely on ros-base and rosdep instead to prevent dpkg conflicts on Pete's hosts.
 - **Colcon virtualenv:** The ROS installers create `/opt/ros/<distro>/colcon-venv` and symlink `/usr/local/bin/colcon` into it. Reuse that environment instead of layering additional pip/apt colcon installs.

--- a/modules/pilot/frontend/routes/_app.tsx
+++ b/modules/pilot/frontend/routes/_app.tsx
@@ -8,12 +8,6 @@ export default define.page(function App({ Component, state }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Psyched Pilot</title>
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.0.6/css/pico.min.css"
-          integrity="sha256-3V/VWRr9ge4h3MEXrYXAFNw/HxncLXt9EB6grMKSdMI="
-          crossOrigin="anonymous"
-        />
         <link rel="stylesheet" href="/styles.css" />
       </head>
       <body

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -1,25 +1,26 @@
 :root {
   color-scheme: dark;
-  --brand-font-sans: var(--pico-font-family, "Inter", "Segoe UI", system-ui, sans-serif);
-  --brand-bg: #050a16;
-  --brand-surface: #0c1424;
-  --brand-surface-elevated: #101c30;
-  --brand-surface-muted: #111a2c;
-  --brand-surface-overlay: rgba(9, 16, 30, 0.85);
-  --brand-border: rgba(148, 163, 184, 0.18);
-  --brand-border-strong: rgba(148, 163, 184, 0.3);
-  --brand-text: #f4f7ff;
-  --brand-text-muted: rgba(224, 231, 255, 0.72);
-  --brand-shadow-lg: 0 30px 60px rgba(8, 15, 34, 0.45);
-  --brand-shadow-sm: 0 15px 30px rgba(8, 15, 34, 0.3);
-  --brand-radius-lg: 1.2rem;
-  --brand-radius-md: 0.9rem;
-  --brand-radius-sm: 0.6rem;
-  --brand-spacing-xs: 0.4rem;
-  --brand-spacing-sm: 0.7rem;
-  --brand-spacing-md: 1.1rem;
-  --brand-spacing-lg: 1.65rem;
-  --brand-spacing-xl: 2.5rem;
+  --brand-font-sans: "Inter", "Segoe UI", system-ui, sans-serif;
+  --brand-bg: #04070f;
+  --brand-surface: #0a111d;
+  --brand-surface-elevated: #0e1829;
+  --brand-surface-muted: #101b2c;
+  --brand-surface-overlay: rgba(7, 13, 24, 0.85);
+  --brand-border: rgba(148, 163, 184, 0.16);
+  --brand-border-strong: rgba(148, 163, 184, 0.28);
+  --brand-text: #f1f5ff;
+  --brand-text-muted: rgba(224, 231, 255, 0.68);
+  --brand-shadow-lg: 0 18px 36px rgba(6, 12, 24, 0.28);
+  --brand-shadow-sm: 0 10px 20px rgba(6, 12, 24, 0.22);
+  --brand-radius-lg: 1rem;
+  --brand-radius-md: 0.75rem;
+  --brand-radius-sm: 0.5rem;
+  --brand-spacing-xs: 0.3rem;
+  --brand-spacing-sm: 0.6rem;
+  --brand-spacing-md: 0.9rem;
+  --brand-spacing-lg: 1.35rem;
+  --brand-spacing-xl: 2rem;
+  --brand-max-width: min(1600px, calc(100% - clamp(2rem, 6vw, 4rem)));
   --focus-ring: 0 0 0 3px rgba(56, 189, 248, 0.35);
   --accent-amber: #f4a261;
   --accent-teal: #2dd4bf;
@@ -29,51 +30,94 @@
   --accent-neutral: #93a5c5;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   font-family: var(--brand-font-sans);
-  line-height: 1.65;
-  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 55%),
-    linear-gradient(180deg, #050a16 0%, #081124 40%, #0b1429 100%);
+  font-size: 16px;
+  line-height: 1.6;
+  background: linear-gradient(180deg, #04070f 0%, #070e1c 40%, #0a1426 100%);
   color: var(--brand-text);
+}
+
+a,
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
 }
 
 a {
   color: var(--accent-cyan);
+  text-decoration: none;
 }
 
 a:hover {
   color: var(--accent-magenta);
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 0.6rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--brand-text);
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+ul,
+ol {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .site-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(6, 13, 27, 0.92);
+  background: rgba(6, 13, 27, 0.95);
   border-bottom: 1px solid var(--brand-border);
-  backdrop-filter: blur(16px);
+  backdrop-filter: blur(14px);
 }
 
 .site-header__inner {
-  width: min(1200px, 100%);
+  width: var(--brand-max-width);
   margin: 0 auto;
-  padding: 1rem clamp(1.25rem, 3vw, 2.75rem);
+  padding: 0.75rem clamp(1rem, 3vw, 2.25rem);
   display: flex;
   align-items: center;
   gap: var(--brand-spacing-lg);
 }
 
 .site-brand {
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
   color: var(--brand-text);
-  text-decoration: none;
 }
 
 .site-nav {
@@ -84,7 +128,7 @@ a:hover {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4rem;
   margin: 0;
   padding: 0;
 }
@@ -92,41 +136,39 @@ a:hover {
 .site-nav__list a {
   display: inline-flex;
   align-items: center;
-  padding: 0.4rem 0.75rem;
+  padding: 0.45rem 0.75rem;
   border-radius: 999px;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--brand-text-muted);
-  text-decoration: none;
-  background: rgba(148, 163, 184, 0.1);
   border: 1px solid transparent;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 .site-nav__list a:hover,
 .site-nav__list a:focus-visible {
   color: var(--brand-text);
-  background: rgba(56, 189, 248, 0.2);
-  border-color: rgba(56, 189, 248, 0.35);
-  transform: translateY(-1px);
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.28);
   outline: none;
 }
 
 .site-main {
-  flex: 1;
-  padding: var(--brand-spacing-xl) clamp(1rem, 3vw, 2rem);
+  padding: var(--brand-spacing-xl) clamp(0.75rem, 2.5vw, 1.75rem);
+  gap: var(--brand-spacing-xl);
+  display: flex;
+  flex-direction: column;
 }
 
 .site-main > * {
-  width: min(1200px, 100%);
+  width: var(--brand-max-width);
   margin: 0 auto;
 }
 
 .content {
   display: grid;
   gap: var(--brand-spacing-xl);
-  padding-inline: clamp(0.5rem, 3vw, 2rem);
 }
 
 .dashboard-panel {
@@ -134,7 +176,7 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: var(--brand-spacing-lg);
-  padding: var(--brand-spacing-xl);
+  padding: clamp(1.5rem, 2vw + 0.75rem, 2.1rem);
   border-radius: var(--brand-radius-lg);
   border: 1px solid var(--brand-border);
   background: var(--brand-surface-elevated);
@@ -142,15 +184,16 @@ a:hover {
   isolation: isolate;
   overflow: hidden;
   --panel-accent: var(--accent-violet);
-  --panel-accent-soft: rgba(168, 85, 247, 0.16);
+  --panel-accent-soft: rgba(168, 85, 247, 0.14);
 }
 
 .dashboard-panel::before {
   content: "";
   position: absolute;
-  inset: -40% -40% 50% -40%;
-  background: radial-gradient(circle at top left, var(--panel-accent-soft), transparent 70%);
-  opacity: 0.85;
+  inset: 0;
+  background: linear-gradient(135deg, transparent, var(--panel-accent-soft));
+  opacity: 0.65;
+  pointer-events: none;
   z-index: -1;
 }
 
@@ -195,24 +238,26 @@ a:hover {
 }
 
 .dashboard-panel__accent {
-  width: 0.55rem;
+  width: 0.4rem;
   align-self: stretch;
   border-radius: 999px;
-  background: linear-gradient(180deg, var(--panel-accent), rgba(255, 255, 255, 0.16));
-  box-shadow: 0 0 24px var(--panel-accent-soft);
+  background: linear-gradient(180deg, var(--panel-accent), rgba(255, 255, 255, 0.08));
+  box-shadow: 0 0 18px var(--panel-accent-soft);
 }
 
 .dashboard-panel__title {
   margin: 0;
-  font-size: 1.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: clamp(1.25rem, 2vw, 1.6rem);
+  letter-spacing: 0.01em;
+  text-transform: none;
+  font-weight: 600;
 }
 
 .dashboard-panel__subtitle {
   margin: 0.35rem 0 0;
   color: var(--brand-text-muted);
-  max-width: 60ch;
+  max-width: 65ch;
+  font-size: 0.95rem;
 }
 
 .dashboard-panel__meta {
@@ -244,15 +289,15 @@ a:hover {
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.85rem;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
   border: 1px solid var(--badge-border, rgba(148, 163, 184, 0.28));
   background: var(--badge-bg, rgba(148, 163, 184, 0.12));
   color: var(--badge-color, var(--brand-text));
-  font-size: 0.72rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: none;
   font-weight: 600;
 }
 
@@ -337,9 +382,9 @@ a:hover {
   padding: 0.9rem 1.1rem;
   cursor: pointer;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  font-size: 0.85rem;
   color: var(--brand-text);
   background: rgba(255, 255, 255, 0.02);
 }
@@ -396,12 +441,12 @@ a:hover {
   position: relative;
   display: grid;
   gap: var(--brand-spacing-md);
-  padding: var(--brand-spacing-lg);
+  padding: clamp(1.1rem, 2vw + 0.4rem, 1.5rem);
   border-radius: var(--brand-radius-md);
   border: 1px solid var(--brand-border);
   background: var(--brand-surface-muted);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  border-left: 5px solid var(--card-accent, var(--panel-accent));
+  border-left: 4px solid var(--card-accent, var(--panel-accent));
   --panel-accent: var(--card-accent, var(--panel-accent));
 }
 
@@ -446,16 +491,17 @@ a:hover {
 
 .card__title {
   margin: 0;
-  font-size: 1.1rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 1.05rem;
+  letter-spacing: 0.015em;
+  text-transform: none;
+  font-weight: 600;
 }
 
 .card__subtitle {
   margin: 0.1rem 0 0;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  font-size: 0.82rem;
+  text-transform: none;
+  letter-spacing: 0.03em;
   color: var(--brand-text-muted);
 }
 
@@ -489,9 +535,10 @@ a:hover {
 }
 
 .form-label {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 0.82rem;
+  font-weight: 600;
   color: var(--brand-text-muted);
 }
 
@@ -523,9 +570,9 @@ a:hover {
   background: rgba(148, 163, 184, 0.08);
   color: var(--brand-text);
   font-weight: 600;
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: none;
   text-decoration: none;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
@@ -582,7 +629,7 @@ a:hover {
 
 .button--small {
   padding: 0.35rem 0.7rem;
-  font-size: 0.72rem;
+  font-size: 0.75rem;
 }
 
 .button-group {
@@ -611,9 +658,9 @@ a:hover {
 
 .data-table thead {
   background: rgba(255, 255, 255, 0.04);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.72rem;
+  text-transform: none;
+  letter-spacing: 0.03em;
+  font-size: 0.75rem;
 }
 
 .data-table th,
@@ -650,15 +697,15 @@ a:hover {
 }
 
 .stat-metric__value {
-  font-size: 2.4rem;
+  font-size: clamp(1.8rem, 4vw, 2.3rem);
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.01em;
 }
 
 .stat-metric__caption {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
+  text-transform: none;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
   color: var(--brand-text-muted);
 }
 
@@ -705,9 +752,9 @@ a:hover {
 
 .stat-list dt {
   margin: 0;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  text-transform: none;
+  letter-spacing: 0.03em;
   color: var(--brand-text-muted);
 }
 
@@ -735,9 +782,9 @@ a:hover {
   padding: 0.28rem 0.65rem;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.12);
-  text-transform: uppercase;
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  text-transform: none;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
   font-weight: 600;
 }
 
@@ -749,9 +796,9 @@ a:hover {
 
 .hazard-grid__title {
   margin: 0 0 0.5rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.8rem;
+  text-transform: none;
+  letter-spacing: 0.03em;
+  font-size: 0.82rem;
   color: var(--brand-text-muted);
 }
 
@@ -786,8 +833,8 @@ a:hover {
   justify-content: center;
   padding: 0.5rem 0.85rem;
   border-radius: var(--brand-radius-sm);
-  border: 1px solid rgba(56, 189, 248, 0.35);
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(168, 85, 247, 0.25));
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(168, 85, 247, 0.18));
   color: var(--brand-text);
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
@@ -795,7 +842,7 @@ a:hover {
 
 .control-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.2);
 }
 
 .video-frame {


### PR DESCRIPTION
## Summary
- remove the Pico CSS dependency and lean on bespoke cockpit styling for a full-bleed layout
- soften typography, spacing, and badges/cards so the dashboard uses space efficiently without feeling garish
- document the missing Deno binary caveat in the agent handbook for future contributors

## Testing
- deno fmt routes/_app.tsx *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f8ec7248320bd28f8b82cb2548e