### PR TITLE
Fix cockpit websocket fallback for Vite dev server

### DIFF
--- a/modules/pilot/frontend/lib/cockpit_test.ts
+++ b/modules/pilot/frontend/lib/cockpit_test.ts
@@ -69,6 +69,17 @@ Deno.test("defaults to bridge port 8088 when dev server runs on 8000", async () 
   });
 });
 
+Deno.test(
+  "defaults to bridge port 8088 when served from Vite's dev server",
+  async () => {
+    await withBrowserEnv({ port: "5173" }, async () => {
+      const { __test__ } = await importCockpitModule();
+      const url = __test__.defaultCockpitUrl();
+      assertEquals(url, "ws://localhost:8088/ws");
+    });
+  },
+);
+
 Deno.test("uses bootstrapped cockpit port when provided", async () => {
   await withBrowserEnv({
     port: "8000",


### PR DESCRIPTION
## Summary
- adjust cockpit websocket URL derivation to treat Vite's dev port like other local dev servers
- keep default fallback targeting the cockpit bridge even when the pilot UI runs on port 5173
- add a regression test covering the Vite dev server scenario

## Testing
- deno test lib/cockpit_test.ts *(fails: deno is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e652373a588320aced7a84b3e6eb50