### PR TITLE
Handle duplicate launch argument tables

### DIFF
--- a/hosts/AGENTS.md
+++ b/hosts/AGENTS.md
@@ -5,4 +5,5 @@
 - Describe services with `[[services.<name>]]` entries; include `intent`, `summary`, `runtime`, and a quick `ports = [...]` list so orchestration tooling can render useful dashboards.
 - Declare externally reachable sockets under `[[services.<name>.ports]]` and capture `bind`, `port`, `target`, and `advertise` values so consumers know how to connect.
 - Declare modules with `[modules.<name>]`, add runtime configuration in `[modules.<name>.env]`, and capture cross-host wiring with `[[modules.<name>.dependencies]]` (reference dependencies as `<host>.<service>` and bind env vars with `bind_env`).
+- Keep module launch argument blocks unique; if you need to override values, update the existing table instead of duplicating it so configuration remains easy to diff.
 - Draft updates in an editor before overwriting files—redirects (`cat <<'EOF'`) won’t forgive stray placeholders.


### PR DESCRIPTION
## Summary
- tolerate duplicate module launch argument tables when rendering ROS launch flags
- add regression coverage for duplicate tables and document host manifest expectations

## Testing
- pytest tests/test_launch_args.py

------
https://chatgpt.com/codex/tasks/task_e_68e684043de08320a48cf20cf477f99e