### PR TITLE
Improve faces dependency handling and launch args dedupe

### DIFF
--- a/modules/faces/packages/faces/faces/__init__.py
+++ b/modules/faces/packages/faces/faces/__init__.py
@@ -1,13 +1,20 @@
 """Face detection utilities for the Psyched faces module."""
-from .processing import (  # noqa: F401
-    BasicEmbeddingExtractor,
-    BoundingBox,
-    Detection,
-    FaceProcessor,
-    HaarCascadeDetector,
-    ProcessedFace,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, TYPE_CHECKING
+
 from .message_builder import build_face_detections_msg  # noqa: F401
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .processing import (  # type: ignore[attr-defined]
+        BasicEmbeddingExtractor,
+        BoundingBox,
+        Detection,
+        FaceProcessor,
+        HaarCascadeDetector,
+        ProcessedFace,
+    )
 
 __all__ = [
     "BasicEmbeddingExtractor",
@@ -18,3 +25,52 @@ __all__ = [
     "ProcessedFace",
     "build_face_detections_msg",
 ]
+
+_PROCESSING_EXPORTS = {
+    "BasicEmbeddingExtractor",
+    "BoundingBox",
+    "Detection",
+    "FaceProcessor",
+    "HaarCascadeDetector",
+    "ProcessedFace",
+}
+
+_PROCESSING_MODULE: Any | None = None
+_PROCESSING_IMPORT_ERROR: ModuleNotFoundError | None = None
+
+
+def _missing_dependency_message(missing: str) -> str:
+    human_readable = "OpenCV (cv2)" if missing == "cv2" else missing
+    return (
+        "faces module is missing the '{}' dependency. "
+        "Run `psh mod setup faces` or install the required packages.".format(human_readable)
+    )
+
+
+def _load_processing_module() -> Any:
+    """Lazily import ``faces.processing`` and surface helpful errors."""
+
+    global _PROCESSING_MODULE, _PROCESSING_IMPORT_ERROR
+
+    if _PROCESSING_MODULE is not None:
+        return _PROCESSING_MODULE
+    if _PROCESSING_IMPORT_ERROR is not None:
+        missing = getattr(_PROCESSING_IMPORT_ERROR, "name", "dependency")
+        raise ModuleNotFoundError(_missing_dependency_message(missing)) from _PROCESSING_IMPORT_ERROR
+    try:
+        module = import_module(".processing", __name__)
+    except ModuleNotFoundError as exc:
+        _PROCESSING_IMPORT_ERROR = exc
+        missing = getattr(exc, "name", "dependency")
+        raise ModuleNotFoundError(_missing_dependency_message(missing)) from exc
+    _PROCESSING_MODULE = module
+    return module
+
+
+def __getattr__(name: str) -> Any:
+    if name in _PROCESSING_EXPORTS:
+        module = _load_processing_module()
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/modules/faces/packages/faces/faces/message_builder.py
+++ b/modules/faces/packages/faces/faces/message_builder.py
@@ -1,19 +1,20 @@
 """Helpers for constructing ROS messages from processed faces."""
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, TYPE_CHECKING
 
 import numpy as np
 from cv_bridge import CvBridge
 from faces_msgs.msg import FaceDetection, FaceDetections
 from std_msgs.msg import Header
 
-from .processing import ProcessedFace
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .processing import ProcessedFace
 
 
 def build_face_detections_msg(
     header: Header,
-    faces: Iterable[ProcessedFace],
+    faces: Iterable["ProcessedFace"],
     *,
     bridge: Optional[CvBridge] = None,
 ) -> FaceDetections:

--- a/tests/test_face_detector_dependencies.py
+++ b/tests/test_face_detector_dependencies.py
@@ -1,0 +1,215 @@
+"""Tests covering dependency validation for the faces module."""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections import deque
+from pathlib import Path
+
+import pytest
+
+
+def _install_module(name: str, module: types.ModuleType) -> None:
+    """Register ``module`` under ``name`` in ``sys.modules``."""
+
+    parts = name.split(".")
+    for index in range(1, len(parts)):
+        parent_name = ".".join(parts[:index])
+        sys.modules.setdefault(parent_name, types.ModuleType(parent_name))
+    sys.modules[name] = module
+
+
+def _stub_ros_graph() -> None:
+    """Create lightweight stubs for ROS-related modules used by the node."""
+
+    # rclpy core entry points
+    rclpy = types.ModuleType("rclpy")
+
+    def _noop(*_args: object, **_kwargs: object) -> None:  # pragma: no cover - trivial stub
+        return None
+
+    rclpy.init = _noop  # type: ignore[attr-defined]
+    rclpy.spin = _noop  # type: ignore[attr-defined]
+    rclpy.shutdown = _noop  # type: ignore[attr-defined]
+    _install_module("rclpy", rclpy)
+
+    # rclpy.node
+    rclpy_node = types.ModuleType("rclpy.node")
+
+    class _StubLogger:
+        def info(self, *_args: object, **_kwargs: object) -> None:  # pragma: no cover - debug stub
+            return None
+
+        def error(self, *_args: object, **_kwargs: object) -> None:  # pragma: no cover - debug stub
+            return None
+
+    class _StubParameter:
+        def __init__(self) -> None:
+            self.value = None
+
+    class _StubNode:
+        """Minimal stand-in for :class:`rclpy.node.Node`."""
+
+        def __init__(self, _name: str) -> None:
+            self._logger = _StubLogger()
+
+        def declare_parameter(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def get_parameter(self, _name: str) -> _StubParameter:
+            return _StubParameter()
+
+        def create_publisher(self, *_args: object, **_kwargs: object) -> object:
+            return object()
+
+        def create_subscription(self, *_args: object, **_kwargs: object) -> object:
+            return object()
+
+        def add_on_set_parameters_callback(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def get_logger(self) -> _StubLogger:
+            return self._logger
+
+        def destroy_subscription(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def destroy_node(self) -> None:
+            return None
+
+    rclpy_node.Node = _StubNode  # type: ignore[attr-defined]
+    _install_module("rclpy.node", rclpy_node)
+
+    # rclpy.qos helpers referenced in the node
+    rclpy_qos = types.ModuleType("rclpy.qos")
+
+    class _QoSProfile:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    class _Enum:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    rclpy_qos.QoSProfile = _QoSProfile  # type: ignore[attr-defined]
+    rclpy_qos.QoSDurabilityPolicy = types.SimpleNamespace(VOLATILE=_Enum(0))
+    rclpy_qos.QoSHistoryPolicy = types.SimpleNamespace(KEEP_LAST=_Enum(0))
+    rclpy_qos.QoSReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=_Enum(0))
+
+    def _sensor_data_qos() -> int:  # pragma: no cover - simple stub
+        return 10
+
+    rclpy_qos.SensorDataQoS = _sensor_data_qos  # type: ignore[attr-defined]
+    _install_module("rclpy.qos", rclpy_qos)
+
+    # rclpy.logging
+    rclpy_logging = types.ModuleType("rclpy.logging")
+
+    def _get_logger(_name: str) -> _StubLogger:  # pragma: no cover - trivial stub
+        return _StubLogger()
+
+    rclpy_logging.get_logger = _get_logger  # type: ignore[attr-defined]
+    _install_module("rclpy.logging", rclpy_logging)
+
+    # rcl_interfaces.msg
+    rcl_interfaces_msg = types.ModuleType("rcl_interfaces.msg")
+
+    class _SetParametersResult:
+        def __init__(self, successful: bool = True) -> None:
+            self.successful = successful
+
+    rcl_interfaces_msg.SetParametersResult = _SetParametersResult  # type: ignore[attr-defined]
+    _install_module("rcl_interfaces.msg", rcl_interfaces_msg)
+
+    # sensor_msgs.msg
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+
+    class _Image:  # pragma: no cover - minimal stub
+        def __init__(self) -> None:
+            self.header = types.SimpleNamespace(stamp=types.SimpleNamespace(sec=0, nanosec=0))
+            self.width = 0
+            self.height = 0
+
+    sensor_msgs_msg.Image = _Image  # type: ignore[attr-defined]
+    _install_module("sensor_msgs.msg", sensor_msgs_msg)
+
+    # std_msgs.msg
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+
+    class _String:  # pragma: no cover - minimal stub
+        def __init__(self) -> None:
+            self.data = ""
+
+    class _Header:  # pragma: no cover - minimal stub
+        def __init__(self) -> None:
+            self.frame_id = ""
+            self.stamp = types.SimpleNamespace(sec=0, nanosec=0)
+
+    std_msgs_msg.String = _String  # type: ignore[attr-defined]
+    std_msgs_msg.Header = _Header  # type: ignore[attr-defined]
+    _install_module("std_msgs.msg", std_msgs_msg)
+
+    # faces_msgs.msg
+    faces_msgs_msg = types.ModuleType("faces_msgs.msg")
+
+    class _FaceDetection:  # pragma: no cover - minimal stub
+        def __init__(self) -> None:
+            self.header = None
+            self.x = 0
+            self.y = 0
+            self.width = 0
+            self.height = 0
+            self.confidence = 0.0
+            self.embedding = []
+            self.crop = None
+
+    class _FaceDetections:  # pragma: no cover - minimal stub
+        def __init__(self) -> None:
+            self.header = None
+            self.faces: deque = deque()
+
+    faces_msgs_msg.FaceDetection = _FaceDetection  # type: ignore[attr-defined]
+    faces_msgs_msg.FaceDetections = _FaceDetections  # type: ignore[attr-defined]
+    _install_module("faces_msgs.msg", faces_msgs_msg)
+
+    # cv_bridge
+    cv_bridge = types.ModuleType("cv_bridge")
+
+    class _CvBridge:  # pragma: no cover - minimal stub
+        def imgmsg_to_cv2(self, msg: object, desired_encoding: str = "bgr8") -> object:
+            return object()
+
+    cv_bridge.CvBridge = _CvBridge  # type: ignore[attr-defined]
+    _install_module("cv_bridge", cv_bridge)
+
+    # numpy placeholder (sufficient for imports without heavy dependency)
+    numpy_module = types.ModuleType("numpy")
+    numpy_module.ndarray = object  # type: ignore[attr-defined]
+    numpy_module.asarray = lambda array, dtype=None: array  # type: ignore[attr-defined]
+    _install_module("numpy", numpy_module)
+
+
+def test_face_detector_reports_missing_cv2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the faces node surfaces a helpful error when OpenCV is absent."""
+
+    _stub_ros_graph()
+
+    # Ensure cv2 is absent so the processing import fails similarly to runtime logs.
+    monkeypatch.delitem(sys.modules, "cv2", raising=False)
+
+    module_name = "modules.faces.packages.faces.faces.face_detector_node"
+    if module_name in sys.modules:
+        sys.modules.pop(module_name)
+
+    module = importlib.import_module(module_name)
+
+    with pytest.raises(getattr(module, "MissingDependencyError")) as exc_info:
+        module._get_processing_module()
+
+    message = str(exc_info.value)
+    assert "OpenCV" in message or "cv2" in message
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))


### PR DESCRIPTION
## Summary
- sanitize module-specific TOML before parsing so duplicate tables in other modules no longer break launch argument rendering
- lazily import faces processing utilities and surface actionable OpenCV installation guidance when dependencies are missing
- add regression coverage that stubs ROS dependencies to assert the new faces dependency guard

## Testing
- pytest tests/test_launch_args.py -q
- pytest tests/test_face_detector_dependencies.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e6867a8b1c832094ae1cb1642e08eb