### PR TITLE
Align IMU telemetry tables and add dual-scale temperatures

### DIFF
--- a/modules/imu/AGENTS.md
+++ b/modules/imu/AGENTS.md
@@ -1,0 +1,3 @@
+# IMU module notes
+
+- Mirror Celsius telemetry with Fahrenheit readouts in cockpit components so operators can scan both units at a glance.

--- a/modules/imu/pilot/components/ImuReadout.tsx
+++ b/modules/imu/pilot/components/ImuReadout.tsx
@@ -7,8 +7,8 @@ import {
   toneFromConnection,
 } from "@pilot/components/dashboard.tsx";
 import {
-  formatNullableNumber,
   formatRelativeTime,
+  formatTemperaturePair,
 } from "../../../pilot/frontend/lib/format.ts";
 import type { ConnectionStatus } from "@pilot/lib/cockpit.ts";
 
@@ -68,6 +68,11 @@ export function ImuReadout({
 }: ImuReadoutProps) {
   const euler = sensor.orientation?.euler;
   const quaternion = sensor.orientation?.quaternion;
+  const temperatureC = sensor.temperatureC;
+  const hasTemperature =
+    temperatureC !== undefined &&
+    temperatureC !== null &&
+    Number.isFinite(temperatureC);
 
   const connectionLabel =
     CONNECTION_STATUS_LABELS[connectionStatus ?? "idle"] ??
@@ -147,15 +152,10 @@ export function ImuReadout({
               <dt>Updated</dt>
               <dd>{formatRelativeTime(lastUpdate)}</dd>
             </div>
-            {sensor.temperatureC !== undefined &&
-              sensor.temperatureC !== null && (
+            {hasTemperature && (
               <div class="stat-list__item">
                 <dt>Temperature</dt>
-                <dd>
-                  {formatNullableNumber(sensor.temperatureC, {
-                    fractionDigits: 1,
-                  })} °C
-                </dd>
+                <dd>{formatTemperaturePair(temperatureC)}</dd>
               </div>
             )}
           </dl>

--- a/modules/pilot/frontend/assets/styles.css
+++ b/modules/pilot/frontend/assets/styles.css
@@ -648,6 +648,9 @@ body {
     "Liberation Mono",
     "Courier New",
     monospace;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
 }
 
 .command-matrix {

--- a/modules/pilot/frontend/lib/format.ts
+++ b/modules/pilot/frontend/lib/format.ts
@@ -11,6 +11,15 @@ export interface FormatNumberOptions {
   fallback?: string;
 }
 
+export interface FormatTemperaturePairOptions {
+  /** Number of fractional digits to display for the Celsius value. */
+  celsiusDigits?: number;
+  /** Number of fractional digits to display for the Fahrenheit value. */
+  fahrenheitDigits?: number;
+  /** Placeholder used when the payload is nullish or not a finite number. */
+  fallback?: string;
+}
+
 const DEFAULT_NUMBER_OPTIONS: Required<
   Pick<FormatNumberOptions, "fractionDigits" | "fallback">
 > = {
@@ -41,6 +50,35 @@ export function formatNullableNumber(
     return fallback;
   }
   return value.toFixed(fractionDigits);
+}
+
+/**
+ * Formats a Celsius temperature so the readout also exposes the Fahrenheit
+ * equivalent. The cockpit dashboard frequently presents sensor data as
+ * side-by-side tables, so the helper keeps the output short and symmetrical.
+ *
+ * @example
+ * ```ts
+ * formatTemperaturePair(23.1); // "23.1 °C / 73.6 °F"
+ * formatTemperaturePair(undefined); // "—"
+ * ```
+ */
+export function formatTemperaturePair(
+  celsius: number | null | undefined,
+  options: FormatTemperaturePairOptions = {},
+): string {
+  const {
+    celsiusDigits = 1,
+    fahrenheitDigits = 1,
+    fallback = "—",
+  } = options;
+  if (celsius === undefined || celsius === null || !Number.isFinite(celsius)) {
+    return fallback;
+  }
+  const fahrenheit = (celsius * 9) / 5 + 32;
+  return `${celsius.toFixed(celsiusDigits)} °C / ${
+    fahrenheit.toFixed(fahrenheitDigits)
+  } °F`;
 }
 
 export interface FormatRelativeTimeOptions {

--- a/modules/pilot/frontend/lib/format_test.ts
+++ b/modules/pilot/frontend/lib/format_test.ts
@@ -5,6 +5,7 @@ import {
   formatBytes,
   formatNullableNumber,
   formatRelativeTime,
+  formatTemperaturePair,
 } from "./format.ts";
 
 describe("formatNullableNumber", () => {
@@ -54,5 +55,27 @@ describe("formatBytes", () => {
     assertEquals(formatBytes(512), "512 B");
     assertEquals(formatBytes(1_500), "1.5 KiB");
     assertEquals(formatBytes(2_620_000), "2.5 MiB");
+  });
+});
+
+describe("formatTemperaturePair", () => {
+  it("returns a fallback when the Celsius reading is unavailable", () => {
+    assertEquals(formatTemperaturePair(undefined), "—");
+    assertEquals(formatTemperaturePair(null), "—");
+    assertEquals(formatTemperaturePair(NaN), "—");
+  });
+
+  it("rounds both Celsius and Fahrenheit using the requested precision", () => {
+    assertEquals(
+      formatTemperaturePair(23.123, {
+        celsiusDigits: 2,
+        fahrenheitDigits: 0,
+      }),
+      "23.12 °C / 74 °F",
+    );
+  });
+
+  it("defaults to one decimal place for each scale", () => {
+    assertEquals(formatTemperaturePair(23.123), "23.1 °C / 73.6 °F");
   });
 });

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -762,6 +762,9 @@ main {
   margin: 0;
   font-family: "Fira Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
 }
 
 .command-matrix {


### PR DESCRIPTION
## Summary
- align IMU stat readouts with tabular numeric styling so decimals line up cleanly
- show Celsius telemetry with paired Fahrenheit output via a shared formatter and tests
- document the IMU module temperature convention for future contributors

## Testing
- `deno test modules/pilot/frontend/lib/format_test.ts` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f92fc9e08320a5da0e2c3425539d