### PR TITLE
Make pilot dashboard content full width

### DIFF
--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -162,8 +162,9 @@ main {
 }
 
 .site-main > * {
-  width: var(--brand-max-width);
-  margin: 0 auto;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- remove the main layout's max-width constraint so pilot panels can expand across the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6f9ede8708320830974ea262f5507