### PR TITLE
Scope cockpit modules to host config and refresh IMU

### DIFF
--- a/modules/imu/pilot/islands/ImuTelemetryIsland_test.ts
+++ b/modules/imu/pilot/islands/ImuTelemetryIsland_test.ts
@@ -1,0 +1,35 @@
+import { assertAlmostEquals } from "$std/assert/assert_almost_equals.ts";
+import { assertEquals } from "$std/assert/assert_equals.ts";
+import { assertExists } from "$std/assert/assert_exists.ts";
+
+import { __test__ } from "./ImuTelemetryIsland.tsx";
+
+Deno.test("mapMessageToSample computes quaternion and Euler angles", () => {
+  const result = __test__.mapMessageToSample({
+    header: { stamp: { sec: 12, nanosec: 340_000_000 } },
+    frame_id: "imu_frame",
+    orientation: { x: 0, y: 0, z: 0.70710678, w: 0.70710678 },
+    angular_velocity: { x: 0.1, y: -0.2, z: 0.3 },
+    linear_acceleration: { x: 1, y: 2, z: 3 },
+  });
+
+  assertEquals(result.frameId, "imu_frame");
+  assertExists(result.orientation);
+  assertEquals(result.orientation?.quaternion, [0, 0, 0.70710678, 0.70710678]);
+  assertExists(result.orientation?.euler);
+  assertAlmostEquals(result.orientation!.euler!.roll ?? 0, 0, 1e-6);
+  assertAlmostEquals(result.orientation!.euler!.pitch ?? 0, 0, 1e-6);
+  assertAlmostEquals(result.orientation!.euler!.yaw ?? 0, 90, 1e-2);
+  assertEquals(result.angularVelocity, { x: 0.1, y: -0.2, z: 0.3 });
+  assertEquals(result.linearAcceleration, { x: 1, y: 2, z: 3 });
+  assertEquals(result.lastUpdate, "1970-01-01T00:00:12.340Z");
+});
+
+Deno.test("mapMessageToSample omits undefined vectors", () => {
+  const result = __test__.mapMessageToSample({
+    header: { stamp: { sec: 1, nanosec: 0 } },
+  });
+
+  assertEquals(result.angularVelocity, undefined);
+  assertEquals(result.linearAcceleration, undefined);
+});

--- a/modules/pilot/frontend/lib/dashboard/tiles.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "preact";
 
 import type { Accent } from "@pilot/components/dashboard.tsx";
+import { listModules, type ListModulesOptions } from "../server/modules.ts";
 
 import PilotOverviewIsland from "../../../pilot/islands/PilotOverviewIsland.tsx";
 import ChatModulePanelIsland from "../../../../chat/pilot/islands/ChatModulePanelIsland.tsx";
@@ -243,3 +244,21 @@ export const dashboardTiles: ReadonlyArray<DashboardTileDefinition> = [
   ...moduleTiles,
   ...serviceTiles,
 ];
+
+export type ModuleTileFilterOptions = ListModulesOptions;
+
+export function moduleTilesForHost(
+  options: ModuleTileFilterOptions = {},
+): DashboardTileDefinition[] {
+  const enabled = new Set(listModules(options));
+  if (enabled.size === 0) {
+    return [];
+  }
+  return moduleTiles.filter((tile) => enabled.has(tile.name));
+}
+
+export function dashboardTilesForHost(
+  options: ModuleTileFilterOptions = {},
+): DashboardTileDefinition[] {
+  return [...moduleTilesForHost(options), ...serviceTiles];
+}

--- a/modules/pilot/frontend/lib/server/host_config.ts
+++ b/modules/pilot/frontend/lib/server/host_config.ts
@@ -1,0 +1,245 @@
+import { extname, join, resolve } from "$std/path/mod.ts";
+import { parse as parseJsonc } from "$std/jsonc/mod.ts";
+import { parse as parseToml } from "$std/toml/mod.ts";
+import { parse as parseYaml } from "$std/yaml/mod.ts";
+
+import { hostsRoot as defaultHostsRoot } from "./paths.ts";
+
+export interface HostConfigLocatorOptions {
+  hostname?: string;
+  hostsDir?: string;
+}
+
+export interface HostConfigDetails {
+  path: string;
+  raw: Record<string, unknown>;
+  mtimeMs: number;
+}
+
+export interface EnabledModuleOptions extends HostConfigLocatorOptions {
+  includePilot?: boolean;
+}
+
+const DEFAULT_HOSTS_DIR = resolve(defaultHostsRoot());
+
+const HOST_CONFIG_EXTENSIONS = [
+  ".json",
+  ".jsonc",
+  ".yaml",
+  ".yml",
+  ".toml",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function pathExists(path: string): boolean {
+  try {
+    Deno.statSync(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export function findHostConfig(
+  hostname: string,
+  hostsDir: string,
+): string | undefined {
+  for (const extension of HOST_CONFIG_EXTENSIONS) {
+    const candidate = join(hostsDir, `${hostname}${extension}`);
+    if (pathExists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function loadRawHostConfig(path: string): Record<string, unknown> {
+  const text = Deno.readTextFileSync(path);
+  const extension = extname(path).toLowerCase();
+  let parsed: unknown;
+  switch (extension) {
+    case ".json":
+    case ".jsonc":
+      parsed = parseJsonc(text);
+      break;
+    case ".yaml":
+    case ".yml":
+      parsed = parseYaml(text);
+      break;
+    case ".toml":
+    default:
+      parsed = parseToml(text);
+      break;
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `Expected host manifest at ${path} to parse to an object, received ${typeof parsed}`,
+    );
+  }
+  return parsed;
+}
+
+export function resolveHostConfig(
+  options: HostConfigLocatorOptions = {},
+): HostConfigDetails | undefined {
+  const hostname = options.hostname ?? Deno.hostname();
+  const hostsDir = options.hostsDir
+    ? resolve(options.hostsDir)
+    : DEFAULT_HOSTS_DIR;
+  const path = findHostConfig(hostname, hostsDir);
+  if (!path) return undefined;
+  const raw = loadRawHostConfig(path);
+  const stat = Deno.statSync(path);
+  const mtimeMs = stat.mtime?.getTime() ?? 0;
+  return { path, raw, mtimeMs };
+}
+
+function coerceBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return undefined;
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return undefined;
+    if (["true", "yes", "on", "1"].includes(normalized)) return true;
+    if (["false", "no", "off", "0"].includes(normalized)) return false;
+    return undefined;
+  }
+  return undefined;
+}
+
+function moduleLaunchEnabled(raw: unknown): boolean {
+  const direct = coerceBoolean(raw);
+  if (direct !== undefined) {
+    return direct;
+  }
+  if (isRecord(raw)) {
+    const enabled = coerceBoolean(raw.enabled);
+    if (enabled !== undefined) {
+      return enabled;
+    }
+    if (raw.arguments !== undefined) {
+      return true;
+    }
+    return Object.keys(raw).length > 0;
+  }
+  return false;
+}
+
+function gatherModuleEntries(
+  raw: Record<string, unknown>,
+): Map<string, unknown> {
+  const modules = new Map<string, unknown>();
+
+  const host = raw.host;
+  if (isRecord(host)) {
+    const declared = host.modules;
+    if (Array.isArray(declared)) {
+      for (const entry of declared) {
+        if (typeof entry !== "string") continue;
+        const name = entry.trim();
+        if (!name) continue;
+        if (!modules.has(name)) {
+          modules.set(name, undefined);
+        }
+      }
+    }
+  }
+
+  const moduleTable = raw.modules;
+  if (isRecord(moduleTable)) {
+    for (const [key, value] of Object.entries(moduleTable)) {
+      const name = key.trim();
+      if (!name) continue;
+      modules.set(name, value);
+    }
+  }
+
+  return modules;
+}
+
+function sortModules(modules: string[]): string[] {
+  if (modules.length <= 1) return modules;
+  const order = new Map<string, number>();
+  const displayOrder = [
+    "chat",
+    "ear",
+    "imu",
+    "faces",
+    "foot",
+    "gps",
+    "eye",
+    "memory",
+    "nav",
+    "voice",
+    "viscera",
+    "wifi",
+    "will",
+  ] as const;
+  displayOrder.forEach((name, index) => order.set(name, index));
+  return modules.sort((a, b) => {
+    const aIndex = order.get(a);
+    const bIndex = order.get(b);
+    if (aIndex !== undefined && bIndex !== undefined) return aIndex - bIndex;
+    if (aIndex !== undefined) return -1;
+    if (bIndex !== undefined) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+export function determineEnabledModules(
+  raw: Record<string, unknown>,
+  options: { includePilot?: boolean } = {},
+): string[] {
+  const modules = gatherModuleEntries(raw);
+  const enabled = new Set<string>();
+
+  for (const [name, value] of modules.entries()) {
+    if (!options.includePilot && name === "pilot") continue;
+
+    if (value === undefined) {
+      continue;
+    }
+
+    if (!isRecord(value)) {
+      if (coerceBoolean(value) === true) {
+        enabled.add(name);
+      }
+      continue;
+    }
+
+    const launch = value.launch ?? value.launchConfig;
+    if (moduleLaunchEnabled(launch)) {
+      enabled.add(name);
+    }
+  }
+
+  return sortModules(Array.from(enabled));
+}
+
+export function enabledModulesForHost(
+  options: EnabledModuleOptions = {},
+): { modules: string[]; path?: string; mtimeMs?: number } {
+  const includePilot = options.includePilot ?? false;
+  const resolved = resolveHostConfig(options);
+  if (!resolved) {
+    return { modules: [] };
+  }
+  const modules = determineEnabledModules(resolved.raw, { includePilot });
+  return { modules, path: resolved.path, mtimeMs: resolved.mtimeMs };
+}
+
+export const __test__ = {
+  coerceBoolean,
+  moduleLaunchEnabled,
+  gatherModuleEntries,
+  sortModules,
+};

--- a/modules/pilot/frontend/lib/server/modules_test.ts
+++ b/modules/pilot/frontend/lib/server/modules_test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "$std/assert/assert_equals.ts";
+import { join } from "$std/path/mod.ts";
+
+import { listModules } from "./modules.ts";
+
+Deno.test("listModules filters by host manifest", () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const modulesDir = join(tempDir, "modules");
+    const hostsDir = join(tempDir, "hosts");
+    Deno.mkdirSync(modulesDir, { recursive: true });
+    Deno.mkdirSync(hostsDir, { recursive: true });
+
+    for (const name of ["alpha", "bravo", "charlie", "pilot"]) {
+      Deno.mkdirSync(join(modulesDir, name));
+    }
+
+    const hostConfig = {
+      host: { modules: ["alpha", "pilot"] },
+      modules: {
+        alpha: { launch: { enabled: true } },
+        bravo: { launch: { enabled: false } },
+        charlie: { launch: { arguments: { enabled: true } } },
+      },
+    };
+    Deno.writeTextFileSync(
+      join(hostsDir, "test-host.json"),
+      JSON.stringify(hostConfig, null, 2),
+    );
+
+    const modules = listModules({
+      hostname: "test-host",
+      hostsDir,
+      modulesDir,
+    });
+
+    assertEquals(modules, ["alpha", "charlie"]);
+  } finally {
+    Deno.removeSync(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("listModules falls back to scanning module directories", () => {
+  const tempDir = Deno.makeTempDirSync();
+  try {
+    const modulesDir = join(tempDir, "modules");
+    const hostsDir = join(tempDir, "hosts");
+    Deno.mkdirSync(modulesDir, { recursive: true });
+    Deno.mkdirSync(hostsDir, { recursive: true });
+
+    for (const name of ["alpha", "bravo", "pilot"]) {
+      Deno.mkdirSync(join(modulesDir, name));
+    }
+
+    const modules = listModules({
+      hostname: "ghost", // no manifest written
+      hostsDir,
+      modulesDir,
+    });
+
+    assertEquals(modules, ["alpha", "bravo"]);
+  } finally {
+    Deno.removeSync(tempDir, { recursive: true });
+  }
+});

--- a/modules/pilot/frontend/lib/server/navigation.ts
+++ b/modules/pilot/frontend/lib/server/navigation.ts
@@ -1,10 +1,8 @@
-import { extname, join, resolve } from "$std/path/mod.ts";
-import { parse as parseJsonc } from "$std/jsonc/mod.ts";
-import { parse as parseToml } from "$std/toml/mod.ts";
-import { parse as parseYaml } from "$std/yaml/mod.ts";
+import { resolve } from "$std/path/mod.ts";
 
 import type { NavigationLink } from "../navigation_types.ts";
 import { hostsRoot as defaultHostsRoot } from "./paths.ts";
+import { determineEnabledModules, resolveHostConfig } from "./host_config.ts";
 
 export interface PrimaryNavigationOptions {
   hostname?: string;
@@ -27,14 +25,6 @@ interface CacheEntry {
 
 const DEFAULT_HOSTS_DIR = resolve(defaultHostsRoot());
 
-const HOST_CONFIG_EXTENSIONS = [
-  ".json",
-  ".jsonc",
-  ".yaml",
-  ".yml",
-  ".toml",
-] as const;
-
 const STATIC_PREFIX_LINKS: ReadonlyArray<NavigationLink> = [
   { href: "/", label: "Home" },
   { href: "/modules/pilot", label: "Pilot" },
@@ -46,22 +36,6 @@ const STATIC_SUFFIX_LINKS: ReadonlyArray<NavigationLink> = [
   { href: "/psh/srv", label: "Services" },
   { href: "/psh/sys", label: "Systemd" },
 ];
-
-const MODULE_DISPLAY_ORDER = [
-  "chat",
-  "ear",
-  "imu",
-  "faces",
-  "foot",
-  "gps",
-  "eye",
-  "memory",
-  "nav",
-  "voice",
-  "viscera",
-  "wifi",
-  "will",
-] as const;
 
 const MODULE_NAV_LINKS: Readonly<Record<string, NavigationLink>> = {
   pilot: { href: "/modules/pilot", label: "Pilot" },
@@ -81,168 +55,6 @@ const MODULE_NAV_LINKS: Readonly<Record<string, NavigationLink>> = {
 };
 
 let cache: CacheEntry | undefined;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function pathExists(path: string): boolean {
-  try {
-    Deno.statSync(path);
-    return true;
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      return false;
-    }
-    throw error;
-  }
-}
-
-function findHostConfig(
-  hostname: string,
-  hostsDir: string,
-): string | undefined {
-  for (const extension of HOST_CONFIG_EXTENSIONS) {
-    const candidate = join(hostsDir, `${hostname}${extension}`);
-    if (pathExists(candidate)) {
-      return candidate;
-    }
-  }
-  return undefined;
-}
-
-function loadRawHostConfig(path: string): Record<string, unknown> {
-  const text = Deno.readTextFileSync(path);
-  const extension = extname(path).toLowerCase();
-  let parsed: unknown;
-  switch (extension) {
-    case ".json":
-    case ".jsonc":
-      parsed = parseJsonc(text);
-      break;
-    case ".yaml":
-    case ".yml":
-      parsed = parseYaml(text);
-      break;
-    case ".toml":
-    default:
-      parsed = parseToml(text);
-      break;
-  }
-  if (!isRecord(parsed)) {
-    throw new Error(
-      `Expected host manifest at ${path} to parse to an object, received ${typeof parsed}`,
-    );
-  }
-  return parsed;
-}
-
-function coerceBoolean(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") {
-    if (Number.isNaN(value)) return undefined;
-    return value !== 0;
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (!normalized) return undefined;
-    if (["true", "yes", "on", "1"].includes(normalized)) return true;
-    if (["false", "no", "off", "0"].includes(normalized)) return false;
-    return undefined;
-  }
-  return undefined;
-}
-
-function moduleLaunchEnabled(raw: unknown): boolean {
-  const direct = coerceBoolean(raw);
-  if (direct !== undefined) {
-    return direct;
-  }
-  if (isRecord(raw)) {
-    const enabled = coerceBoolean(raw.enabled);
-    if (enabled !== undefined) {
-      return enabled;
-    }
-    if (raw.arguments !== undefined) {
-      return true;
-    }
-    return Object.keys(raw).length > 0;
-  }
-  return false;
-}
-
-function gatherModuleEntries(
-  raw: Record<string, unknown>,
-): Map<string, unknown> {
-  const modules = new Map<string, unknown>();
-
-  const host = raw.host;
-  if (isRecord(host)) {
-    const declared = host.modules;
-    if (Array.isArray(declared)) {
-      for (const entry of declared) {
-        if (typeof entry !== "string") continue;
-        const name = entry.trim();
-        if (!name) continue;
-        if (!modules.has(name)) {
-          modules.set(name, undefined);
-        }
-      }
-    }
-  }
-
-  const moduleTable = raw.modules;
-  if (isRecord(moduleTable)) {
-    for (const [key, value] of Object.entries(moduleTable)) {
-      const name = key.trim();
-      if (!name) continue;
-      modules.set(name, value);
-    }
-  }
-
-  return modules;
-}
-
-function determineEnabledModules(raw: Record<string, unknown>): string[] {
-  const modules = gatherModuleEntries(raw);
-  const enabled = new Set<string>();
-
-  for (const [name, value] of modules.entries()) {
-    if (name === "pilot") continue;
-
-    if (value === undefined) {
-      continue;
-    }
-
-    if (!isRecord(value)) {
-      if (coerceBoolean(value) === true) {
-        enabled.add(name);
-      }
-      continue;
-    }
-
-    const launch = value.launch ?? value.launchConfig;
-    if (moduleLaunchEnabled(launch)) {
-      enabled.add(name);
-    }
-  }
-
-  return sortModules(Array.from(enabled));
-}
-
-function sortModules(modules: string[]): string[] {
-  if (modules.length <= 1) return modules;
-  const order = new Map<string, number>();
-  MODULE_DISPLAY_ORDER.forEach((name, index) => order.set(name, index));
-  return modules.sort((a, b) => {
-    const aIndex = order.get(a);
-    const bIndex = order.get(b);
-    if (aIndex !== undefined && bIndex !== undefined) return aIndex - bIndex;
-    if (aIndex !== undefined) return -1;
-    if (bIndex !== undefined) return 1;
-    return a.localeCompare(b);
-  });
-}
 
 function defaultLabel(name: string): string {
   if (!name) return "";
@@ -283,24 +95,21 @@ function computeNavigation(
   hostname: string,
   hostsDir: string,
 ): NavigationComputation {
-  const path = findHostConfig(hostname, hostsDir);
-  if (!path) {
+  const resolved = resolveHostConfig({ hostname, hostsDir });
+  if (!resolved) {
     return { links: buildNavigation([]) };
   }
 
   try {
-    const raw = loadRawHostConfig(path);
-    const modules = determineEnabledModules(raw);
+    const modules = determineEnabledModules(resolved.raw);
     const moduleLinks = modules.map(moduleLinkFor);
-    const stat = Deno.statSync(path);
-    const mtimeMs = stat.mtime?.getTime() ?? 0;
     return {
       links: buildNavigation(moduleLinks),
-      path,
-      mtimeMs,
+      path: resolved.path,
+      mtimeMs: resolved.mtimeMs,
     };
   } catch (error) {
-    console.warn(`Failed to read navigation from ${path}`, error);
+    console.warn(`Failed to read navigation from ${resolved.path}`, error);
     return { links: buildNavigation([]) };
   }
 }

--- a/modules/pilot/frontend/routes/index.tsx
+++ b/modules/pilot/frontend/routes/index.tsx
@@ -1,10 +1,11 @@
 import { Card, Panel } from "@pilot/components/dashboard.tsx";
 
 import DashboardTile from "../components/DashboardTile.tsx";
-import { moduleTiles, serviceTiles } from "../lib/dashboard/tiles.ts";
+import { moduleTilesForHost, serviceTiles } from "../lib/dashboard/tiles.ts";
 import { define } from "../utils.ts";
 
 export default define.page(() => {
+  const moduleTiles = moduleTilesForHost();
   const moduleCount = moduleTiles.length;
   const serviceCount = serviceTiles.length;
 


### PR DESCRIPTION
## Summary
- add host-config helpers so the pilot UI filters modules to the current host
- update navigation, module lifecycle APIs, and dashboard tiles to honour the host manifest
- refresh the IMU telemetry island to stream live samples with derived Euler angles and new tests

## Testing
- deno test lib/server/modules_test.ts *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f87b4e1c8320ab9d47b2a123818b