### PR TITLE
Improve pilot dashboard responsiveness

### DIFF
--- a/modules/pilot/frontend/assets/styles.css
+++ b/modules/pilot/frontend/assets/styles.css
@@ -113,10 +113,9 @@ body {
 }
 
 .dashboard-panel__header {
-  display: flex;
   justify-content: space-between;
-  align-items: flex-start;
   gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .dashboard-panel__heading {
@@ -238,8 +237,14 @@ body {
 
 .dashboard-grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 64rem) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .dashboard-tile__details {

--- a/modules/pilot/frontend/components/DashboardTile.tsx
+++ b/modules/pilot/frontend/components/DashboardTile.tsx
@@ -18,7 +18,23 @@ export interface DashboardTileProps {
 }
 
 /**
- * Compact card that pairs lifecycle telemetry with a collapsible overlay.
+ * Compact card that pairs lifecycle telemetry with a live overlay.
+ *
+ * Tiles keep their `<details>` element open by default so websocket-backed
+ * widgets can subscribe as soon as the page renders.
+ *
+ * @example
+ * ```tsx
+ * <DashboardTile
+ *   name="pilot"
+ *   title="Pilot module"
+ *   description="Bridge health and cockpit version"
+ *   kind="module"
+ *   accent="amber"
+ *   href="/modules/pilot"
+ *   overlay={() => <span>Overlay</span>}
+ * />
+ * ```
  */
 export default function DashboardTile({
   name,
@@ -43,7 +59,7 @@ export default function DashboardTile({
       actions={<DashboardStatusBadge kind={kind} name={name} />}
     >
       {helper && <div class="dashboard-tile__helper">{helper}</div>}
-      <details class="dashboard-tile__details">
+      <details open class="dashboard-tile__details">
         <summary class="dashboard-tile__summary">Show live overlay</summary>
         <div class="dashboard-tile__overlay">
           <Overlay {...overlayProps} />

--- a/modules/pilot/frontend/components/DashboardTile_test.tsx
+++ b/modules/pilot/frontend/components/DashboardTile_test.tsx
@@ -1,0 +1,27 @@
+import { assertStringIncludes } from "$std/assert/assert_string_includes.ts";
+import render from "preact-render-to-string";
+
+import DashboardTile from "./DashboardTile.tsx";
+
+function OverlayStub() {
+  return <div data-testid="overlay">ready</div>;
+}
+
+Deno.test("dashboard tiles render their overlays open by default", () => {
+  const markup = render(
+    <DashboardTile
+      name="example"
+      title="Example"
+      description="Demo tile"
+      kind="module"
+      accent="teal"
+      href="/modules/example"
+      overlay={OverlayStub}
+    />,
+  );
+
+  assertStringIncludes(
+    markup,
+    "<details open class=\"dashboard-tile__details\"",
+  );
+});

--- a/modules/pilot/frontend/islands/DashboardStatusBadge.tsx
+++ b/modules/pilot/frontend/islands/DashboardStatusBadge.tsx
@@ -3,6 +3,16 @@ import { useMemo } from "preact/hooks";
 import { Badge } from "@pilot/components/dashboard.tsx";
 import { usePshStatus } from "@pilot/lib/psh_status.ts";
 
+/**
+ * Polling interval used by the pilot dashboard to keep lifecycle badges live.
+ *
+ * @example
+ * ```ts
+ * const interval = DASHBOARD_STATUS_REFRESH_INTERVAL_MS; // 5000
+ * ```
+ */
+export const DASHBOARD_STATUS_REFRESH_INTERVAL_MS = 5_000;
+
 export interface DashboardStatusBadgeProps {
   kind: "module" | "service";
   name: string;
@@ -14,12 +24,14 @@ export interface DashboardStatusBadgeProps {
  *
  * The badge polls the relevant `/api/psh` endpoint and surfaces the status as a
  * colour-coded pill. When a fetch error occurs the badge switches to the
- * "danger" palette and surfaces the error text below the badge.
+ * "danger" palette and surfaces the error text below the badge. Polling
+ * defaults to {@link DASHBOARD_STATUS_REFRESH_INTERVAL_MS} so cockpit updates
+ * feel live without overwhelming the backend.
  */
 export default function DashboardStatusBadge({
   kind,
   name,
-  refreshIntervalMs,
+  refreshIntervalMs = DASHBOARD_STATUS_REFRESH_INTERVAL_MS,
 }: DashboardStatusBadgeProps) {
   const status = usePshStatus(kind, name, { refreshIntervalMs });
   const message = useMemo(() => {

--- a/modules/pilot/frontend/islands/DashboardStatusBadge_test.tsx
+++ b/modules/pilot/frontend/islands/DashboardStatusBadge_test.tsx
@@ -1,0 +1,39 @@
+import { assertEquals } from "$std/assert/assert_equals.ts";
+import render from "preact-render-to-string";
+import { stub } from "$std/testing/mock.ts";
+
+import * as statusModule from "@pilot/lib/psh_status.ts";
+import DashboardStatusBadge, {
+  DASHBOARD_STATUS_REFRESH_INTERVAL_MS,
+} from "./DashboardStatusBadge.tsx";
+
+Deno.test("dashboard status badge subscribes with live refresh interval", () => {
+  const fakeStatus = {
+    status: "running",
+    label: "Running",
+    tone: "ok" as const,
+    loading: false,
+    refresh: () => {},
+  };
+
+  let receivedInterval: number | undefined;
+  const statusStub = stub(
+    statusModule,
+    "usePshStatus",
+    (_kind, _name, options) => {
+      receivedInterval = options?.refreshIntervalMs;
+      return fakeStatus;
+    },
+  );
+
+  try {
+    render(<DashboardStatusBadge kind="module" name="pilot" />);
+  } finally {
+    statusStub.restore();
+  }
+
+  assertEquals(
+    receivedInterval,
+    DASHBOARD_STATUS_REFRESH_INTERVAL_MS,
+  );
+});

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -224,9 +224,7 @@ main {
 }
 
 .dashboard-panel__header {
-  display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
   justify-content: space-between;
   gap: var(--brand-spacing-lg);
 }
@@ -358,8 +356,14 @@ main {
 
 .dashboard-grid {
   display: grid;
-  gap: var(--brand-spacing-lg);
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--brand-spacing-xl);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 64rem) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .dashboard-tile__helper {

--- a/modules/pilot/pilot/components/dashboard.tsx
+++ b/modules/pilot/pilot/components/dashboard.tsx
@@ -94,7 +94,7 @@ export function Panel({
 }: PanelProps) {
   return (
     <article class="dashboard-panel" data-tone={accent}>
-      <header class="dashboard-panel__header">
+      <header class="card__header dashboard-panel__header">
         <div class="dashboard-panel__heading">
           <span class="dashboard-panel__accent" aria-hidden="true" />
           <div>


### PR DESCRIPTION
## Summary
- reuse the shared card header styling for pilot panels and widen the dashboard grid to at most two columns
- expand dashboard tiles by default so overlays stay live and poll psh status more frequently
- add regression tests covering the open overlays and the badge polling interval

## Testing
- `deno test components/DashboardTile_test.tsx islands/DashboardStatusBadge_test.tsx` *(fails: deno: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e6fbae0c4083208163d380efeaae84