### PR TITLE
Keep IMU telemetry page subscribed and fresh

### DIFF
--- a/modules/imu/pilot/islands/ImuTelemetryIsland_test.ts
+++ b/modules/imu/pilot/islands/ImuTelemetryIsland_test.ts
@@ -1,6 +1,7 @@
 import { assertAlmostEquals } from "$std/assert/assert_almost_equals.ts";
 import { assertEquals } from "$std/assert/assert_equals.ts";
 import { assertExists } from "$std/assert/assert_exists.ts";
+import { assertStringIncludes } from "$std/assert/assert_string_includes.ts";
 
 import { __test__ } from "./ImuTelemetryIsland.tsx";
 
@@ -11,6 +12,8 @@ Deno.test("mapMessageToSample computes quaternion and Euler angles", () => {
     orientation: { x: 0, y: 0, z: 0.70710678, w: 0.70710678 },
     angular_velocity: { x: 0.1, y: -0.2, z: 0.3 },
     linear_acceleration: { x: 1, y: 2, z: 3 },
+    temperature: 22.4,
+    status: "Streaming",
   });
 
   assertEquals(result.frameId, "imu_frame");
@@ -23,6 +26,8 @@ Deno.test("mapMessageToSample computes quaternion and Euler angles", () => {
   assertEquals(result.angularVelocity, { x: 0.1, y: -0.2, z: 0.3 });
   assertEquals(result.linearAcceleration, { x: 1, y: 2, z: 3 });
   assertEquals(result.lastUpdate, "1970-01-01T00:00:12.340Z");
+  assertEquals(result.temperatureC, 22.4);
+  assertEquals(result.status, "Streaming");
 });
 
 Deno.test("mapMessageToSample omits undefined vectors", () => {
@@ -32,4 +37,20 @@ Deno.test("mapMessageToSample omits undefined vectors", () => {
 
   assertEquals(result.angularVelocity, undefined);
   assertEquals(result.linearAcceleration, undefined);
+});
+
+Deno.test("composeStatus favours cockpit errors", () => {
+  const result = __test__.composeStatus("Ready", "Open", "uh oh");
+  assertEquals(result, "Error: uh oh");
+});
+
+Deno.test("composeStatus merges sensor status with connection state", () => {
+  const result = __test__.composeStatus("Streaming", "Open", null);
+  assertEquals(result, "Streaming (Open)");
+});
+
+Deno.test("composeStatus avoids duplicating connection label", () => {
+  const result = __test__.composeStatus("open", "Open", null);
+  assertStringIncludes(result, "Open");
+  assertEquals(result, "Open");
 });


### PR DESCRIPTION
## Summary
- ensure the IMU cockpit island auto-connects to /imu/data and keeps rendering even during quiet periods
- document the refresh cadence and expose composeStatus for testing
- expand IMU telemetry tests to cover status/temperature mapping and composeStatus behaviour

## Testing
- deno test ../imu/pilot/islands/ImuTelemetryIsland_test.ts *(fails: `deno` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6fdf93cf48320b37188476c55e487