### PR TITLE
Align pilot navigation with host manifest

### DIFF
--- a/modules/pilot/frontend/lib/dashboard/tiles.test.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.test.ts
@@ -8,6 +8,7 @@ import {
   moduleTiles,
   moduleTilesForHost,
   serviceTiles,
+  serviceTilesForHost,
 } from "./tiles.ts";
 
 Deno.test("module tiles have unique names", () => {
@@ -45,10 +46,13 @@ Deno.test("moduleTilesForHost returns tiles for enabled modules", () => {
     }
 
     const manifest = {
-      host: { modules: ["imu"] },
+      host: { modules: ["imu", "chat"], services: ["asr"] },
       modules: {
         chat: { launch: true },
         imu: { launch: { enabled: true } },
+      },
+      services: {
+        asr: {},
       },
     };
     Deno.writeTextFileSync(
@@ -63,6 +67,12 @@ Deno.test("moduleTilesForHost returns tiles for enabled modules", () => {
     });
 
     assertEquals(tiles.map((tile) => tile.name).sort(), ["chat", "imu"]);
+
+    const serviceTilesForHostResult = serviceTilesForHost({
+      hostname: "dash",
+      hostsDir,
+    });
+    assertEquals(serviceTilesForHostResult.map((tile) => tile.name), ["asr"]);
   } finally {
     Deno.removeSync(tempDir, { recursive: true });
   }

--- a/modules/pilot/frontend/lib/dashboard/tiles.ts
+++ b/modules/pilot/frontend/lib/dashboard/tiles.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "preact";
 
 import type { Accent } from "@pilot/components/dashboard.tsx";
 import { listModules, type ListModulesOptions } from "../server/modules.ts";
+import { enabledServicesForHost } from "../server/host_config.ts";
 
 import PilotOverviewIsland from "../../../pilot/islands/PilotOverviewIsland.tsx";
 import ChatModulePanelIsland from "../../../../chat/pilot/islands/ChatModulePanelIsland.tsx";
@@ -247,6 +248,11 @@ export const dashboardTiles: ReadonlyArray<DashboardTileDefinition> = [
 
 export type ModuleTileFilterOptions = ListModulesOptions;
 
+export interface ServiceTileFilterOptions {
+  hostname?: string;
+  hostsDir?: string;
+}
+
 export function moduleTilesForHost(
   options: ModuleTileFilterOptions = {},
 ): DashboardTileDefinition[] {
@@ -257,8 +263,29 @@ export function moduleTilesForHost(
   return moduleTiles.filter((tile) => enabled.has(tile.name));
 }
 
+export function serviceTilesForHost(
+  options: ServiceTileFilterOptions = {},
+): DashboardTileDefinition[] {
+  const { services } = enabledServicesForHost({
+    hostname: options.hostname,
+    hostsDir: options.hostsDir,
+  });
+  if (services.length === 0) {
+    return [];
+  }
+  const enabled = new Set(services);
+  return serviceTiles.filter((tile) => enabled.has(tile.name));
+}
+
 export function dashboardTilesForHost(
   options: ModuleTileFilterOptions = {},
 ): DashboardTileDefinition[] {
-  return [...moduleTilesForHost(options), ...serviceTiles];
+  const serviceOptions: ServiceTileFilterOptions = {
+    hostname: options.hostname,
+    hostsDir: options.hostsDir,
+  };
+  return [
+    ...moduleTilesForHost(options),
+    ...serviceTilesForHost(serviceOptions),
+  ];
 }

--- a/modules/pilot/frontend/lib/server/host_config_test.ts
+++ b/modules/pilot/frontend/lib/server/host_config_test.ts
@@ -1,0 +1,104 @@
+import { assertEquals } from "$std/assert/mod.ts";
+
+import {
+  determineEnabledModules,
+  determineEnabledServices,
+} from "./host_config.ts";
+
+Deno.test("determineEnabledModules only includes host declared modules", () => {
+  const raw = {
+    host: { modules: ["pilot", "imu"] },
+    modules: {
+      imu: { launch: true },
+      foot: { launch: true },
+      nav: { launch: { enabled: false } },
+      eye: { launch: { arguments: { enabled: true } } },
+    },
+  } as Record<string, unknown>;
+
+  assertEquals(
+    determineEnabledModules(raw),
+    ["imu"],
+  );
+
+  assertEquals(
+    determineEnabledModules(raw, { includePilot: true }),
+    ["imu", "pilot"],
+  );
+});
+
+Deno.test(
+  "determineEnabledModules falls back to configured launches when host is silent",
+  () => {
+    const raw = {
+      modules: {
+        ear: { launch: true },
+        foot: { launch: false },
+        memory: { launch: { enabled: true } },
+      },
+    } as Record<string, unknown>;
+
+    assertEquals(
+      determineEnabledModules(raw),
+      ["ear", "memory"],
+    );
+  },
+);
+
+Deno.test(
+  "determineEnabledModules treats declared modules without overrides as enabled",
+  () => {
+    const raw = {
+      host: { modules: ["pilot", "nav"] },
+      modules: {
+        pilot: {},
+        nav: {},
+        ear: { launch: true },
+      },
+    } as Record<string, unknown>;
+
+    assertEquals(
+      determineEnabledModules(raw),
+      ["nav"],
+    );
+
+    assertEquals(
+      determineEnabledModules(raw, { includePilot: true }),
+      ["nav", "pilot"],
+    );
+  },
+);
+
+Deno.test("determineEnabledServices reflects host declarations", () => {
+  const raw = {
+    host: { services: ["asr", "tts"] },
+    services: {
+      asr: {},
+      graphs: { enabled: true },
+      vectors: { enabled: false },
+    },
+  } as Record<string, unknown>;
+
+  assertEquals(
+    determineEnabledServices(raw),
+    ["asr", "tts"],
+  );
+});
+
+Deno.test(
+  "determineEnabledServices falls back to configured services when host is silent",
+  () => {
+    const raw = {
+      services: {
+        asr: { enabled: true },
+        graphs: { enabled: false },
+        vectors: { enabled: "yes" },
+      },
+    } as Record<string, unknown>;
+
+    assertEquals(
+      determineEnabledServices(raw),
+      ["asr", "vectors"],
+    );
+  },
+);

--- a/modules/pilot/frontend/routes/index.tsx
+++ b/modules/pilot/frontend/routes/index.tsx
@@ -1,12 +1,16 @@
 import { Card, Panel } from "@pilot/components/dashboard.tsx";
 
 import DashboardTile from "../components/DashboardTile.tsx";
-import { moduleTilesForHost, serviceTiles } from "../lib/dashboard/tiles.ts";
+import {
+  moduleTilesForHost,
+  serviceTilesForHost,
+} from "../lib/dashboard/tiles.ts";
 import { define } from "../utils.ts";
 
 export default define.page(() => {
   const moduleTiles = moduleTilesForHost();
   const moduleCount = moduleTiles.length;
+  const serviceTiles = serviceTilesForHost();
   const serviceCount = serviceTiles.length;
 
   return (


### PR DESCRIPTION
## Summary
- restrict cockpit navigation entries to modules declared for the active host and surface service availability
- add service-aware dashboard filtering and regression coverage for module/service selection helpers
- extend host config utilities to detect enabled services alongside tightened module detection rules

## Testing
- `deno test lib/server/navigation_test.ts lib/server/host_config_test.ts lib/dashboard/tiles.test.ts` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68e6fd415a488320972625da35dcb2c3