### PR TITLE
Fix IMU island wiring

### DIFF
--- a/modules/pilot/frontend/AGENTS.md
+++ b/modules/pilot/frontend/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Keep websocket bootstrap logic (`lib/cockpit_url.ts`) and its regression tests (`lib/cockpit_test.ts`) in sync whenever adjusting connection defaults or overrides.
 - Run `deno fmt` and the focused test suite (`deno test lib/cockpit_test.ts`) after touching cockpit client utilities whenever Deno is available in the environment.
+- Prefer relative imports or re-export shims for module-provided islands so cockpit builds remain portable across different checkout paths.

--- a/modules/pilot/frontend/islands/ImuTelemetryIsland.tsx
+++ b/modules/pilot/frontend/islands/ImuTelemetryIsland.tsx
@@ -1,1 +1,2 @@
-/home/pete/psyched/modules/imu/pilot/islands/ImuTelemetryIsland.tsx
+export { default } from "../../../../imu/pilot/islands/ImuTelemetryIsland.tsx";
+export * from "../../../../imu/pilot/islands/ImuTelemetryIsland.tsx";

--- a/modules/pilot/frontend/islands/ImuTelemetryIsland_test.ts
+++ b/modules/pilot/frontend/islands/ImuTelemetryIsland_test.ts
@@ -1,1 +1,1 @@
-/home/pete/psyched/modules/imu/pilot/islands/ImuTelemetryIsland_test.ts
+export * from "../../../../imu/pilot/islands/ImuTelemetryIsland_test.ts";


### PR DESCRIPTION
## Summary
- replace the cockpit IMU island symlinks with portable re-export shims
- document the need for relative module island wiring in the pilot frontend agent notes

## Testing
- not run (deno is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e700d93e3083208324c087339bae59