### PR TITLE
Streamline pilot overlays layout

### DIFF
--- a/modules/pilot/frontend/assets/styles.css
+++ b/modules/pilot/frontend/assets/styles.css
@@ -247,6 +247,31 @@ body {
   }
 }
 
+.overlay-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 70rem) {
+  .overlay-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.overlay-grid__item {
+  min-width: 0;
+}
+
+.overlay-grid__empty {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
+}
+
 .dashboard-tile__details {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 1rem;

--- a/modules/pilot/frontend/routes/index.tsx
+++ b/modules/pilot/frontend/routes/index.tsx
@@ -1,6 +1,3 @@
-import { Card, Panel } from "@pilot/components/dashboard.tsx";
-
-import DashboardTile from "../components/DashboardTile.tsx";
 import {
   moduleTilesForHost,
   serviceTilesForHost,
@@ -9,59 +6,35 @@ import { define } from "../utils.ts";
 
 export default define.page(() => {
   const moduleTiles = moduleTilesForHost();
-  const moduleCount = moduleTiles.length;
   const serviceTiles = serviceTilesForHost();
-  const serviceCount = serviceTiles.length;
+  const overlays = [
+    ...moduleTiles.map((tile) => ({ ...tile, key: `module-${tile.name}` })),
+    ...serviceTiles.map((tile) => ({ ...tile, key: `service-${tile.name}` })),
+  ];
 
   return (
     <section class="content">
-      <Panel
-        title="Psyched cockpit"
-        subtitle="Live system overview for Pete's modules and services"
-        accent="violet"
-      >
-        <div class="panel-grid panel-grid--stretch">
-          <Card title="Modules" subtitle="Managed by psh mod" tone="violet">
-            <p class="note">
-              {moduleCount} module{moduleCount === 1 ? "" : "s"}{" "}
-              exported a dashboard overlay. Expand a tile below to monitor or
-              control them without leaving the homepage.
+      <div class="overlay-grid">
+        {overlays.length > 0
+          ? overlays.map((tile) => {
+            const Overlay = tile.overlay;
+            return (
+              <div
+                key={tile.key}
+                class="overlay-grid__item"
+                data-kind={tile.kind}
+                data-name={tile.name}
+              >
+                <Overlay {...(tile.overlayProps ?? {})} />
+              </div>
+            );
+          })
+          : (
+            <p class="overlay-grid__empty">
+              No cockpit overlays are enabled for this host.
             </p>
-          </Card>
-          <Card title="Services" subtitle="Managed by psh srv" tone="cyan">
-            <p class="note">
-              {serviceCount} service{serviceCount === 1 ? "" : "s"}{" "}
-              expose live status from their docker compose stacks. Use the
-              cockpit controls to refresh or jump straight into lifecycle
-              tooling.
-            </p>
-          </Card>
-        </div>
-      </Panel>
-
-      <Panel
-        title="Module dashboards"
-        subtitle="Compact overlays sourced from each module's pilot bundle"
-        accent="teal"
-      >
-        <div class="dashboard-grid">
-          {moduleTiles.map((tile) => (
-            <DashboardTile key={tile.name} {...tile} />
-          ))}
-        </div>
-      </Panel>
-
-      <Panel
-        title="Service dashboards"
-        subtitle="Lifecycle telemetry for dockerised infrastructure"
-        accent="magenta"
-      >
-        <div class="dashboard-grid">
-          {serviceTiles.map((tile) => (
-            <DashboardTile key={tile.name} {...tile} />
-          ))}
-        </div>
-      </Panel>
+          )}
+      </div>
     </section>
   );
 });

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -366,6 +366,31 @@ main {
   }
 }
 
+.overlay-grid {
+  display: grid;
+  gap: var(--brand-spacing-lg);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 70rem) {
+  .overlay-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.overlay-grid__item {
+  min-width: 0;
+}
+
+.overlay-grid__empty {
+  margin: 0;
+  padding: var(--brand-spacing-lg);
+  border-radius: var(--brand-radius-md);
+  border: 1px dashed var(--brand-border);
+  color: var(--brand-text-muted);
+  text-align: center;
+}
+
 .dashboard-tile__helper {
   margin: 0;
   color: var(--brand-text-muted);


### PR DESCRIPTION
## Summary
- remove dashboard tile panels from the pilot homepage so module and service overlays render directly
- introduce a compact overlay grid style to keep the remaining overlays space efficient

## Testing
- `deno fmt modules/pilot/frontend/routes/index.tsx modules/pilot/frontend/static/styles.css modules/pilot/frontend/assets/styles.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e703a4c39c8320b1683728f83dbcdb