### PR TITLE
Add draggable overlay grid with persisted order

### DIFF
--- a/modules/pilot/frontend/assets/styles.css
+++ b/modules/pilot/frontend/assets/styles.css
@@ -248,19 +248,28 @@ body {
 }
 
 .overlay-grid {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-
-@media (min-width: 70rem) {
-  .overlay-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  align-items: stretch;
 }
 
 .overlay-grid__item {
   min-width: 0;
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.overlay-grid__item[draggable="true"] {
+  cursor: grab;
+}
+
+.overlay-grid__item--dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.22);
 }
 
 .overlay-grid__empty {

--- a/modules/pilot/frontend/islands/OverlayGrid.tsx
+++ b/modules/pilot/frontend/islands/OverlayGrid.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+import {
+  OVERLAY_ORDER_STORAGE_KEY,
+  parseOverlayOrderJson,
+  reconcileOverlayOrder,
+  serialiseOverlayOrder,
+} from "../lib/dashboard/persisted_order.ts";
+
+export interface OverlayGridProps {
+  /**
+   * Optional storage key override. Defaults to {@link OVERLAY_ORDER_STORAGE_KEY}.
+   */
+  storageKey?: string;
+  children: ComponentChildren;
+}
+
+/**
+ * Flexbox grid that supports drag-and-drop ordering for cockpit overlays.
+ *
+ * The component hydrates on the client so operators can rearrange dashboard
+ * tiles. Positions are persisted in {@link localStorage} which allows the grid
+ * to survive reloads on the same device.
+ */
+export default function OverlayGrid({
+  storageKey = OVERLAY_ORDER_STORAGE_KEY,
+  children,
+}: OverlayGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const storageNamespace = `${storageKey}:${window.location.host ?? "localhost"}`;
+
+    const ensureDraggable = (item: HTMLElement) => {
+      item.setAttribute("draggable", "true");
+      item.dataset.draggable = "true";
+    };
+
+    const attachListeners = (item: HTMLElement) => {
+      ensureDraggable(item);
+      item.addEventListener("dragstart", handleDragStart);
+      item.addEventListener("dragend", handleDragEnd);
+    };
+
+    let activeDrag: HTMLElement | null = null;
+
+    const detachListeners = (item: HTMLElement) => {
+      item.removeEventListener("dragstart", handleDragStart);
+      item.removeEventListener("dragend", handleDragEnd);
+      item.removeAttribute("draggable");
+      delete item.dataset.draggable;
+      item.classList.remove("overlay-grid__item--dragging");
+      if (activeDrag === item) {
+        activeDrag = null;
+      }
+    };
+
+    const commitOrder = () => {
+      const order = Array.from(container.children)
+        .map((child) => (child as HTMLElement).dataset.overlayKey)
+        .filter((key): key is string => Boolean(key));
+      window.localStorage.setItem(storageNamespace, serialiseOverlayOrder(order));
+    };
+
+    const applyStoredOrder = () => {
+      const elements = Array.from(container.children) as HTMLElement[];
+      const availableKeys = elements
+        .map((element) => element.dataset.overlayKey)
+        .filter((key): key is string => Boolean(key));
+      const storedKeys = parseOverlayOrderJson(
+        window.localStorage.getItem(storageNamespace),
+      );
+      const desiredOrder = reconcileOverlayOrder(availableKeys, storedKeys);
+      const lookup = new Map<string, HTMLElement>();
+      for (const element of elements) {
+        const key = element.dataset.overlayKey;
+        if (key) lookup.set(key, element);
+      }
+      for (const key of desiredOrder) {
+        const element = lookup.get(key);
+        if (element) {
+          container.appendChild(element);
+        }
+      }
+    };
+
+    const handleDragStart = (event: DragEvent) => {
+      const target = event.currentTarget as HTMLElement | null;
+      if (!target) return;
+      activeDrag = target;
+      target.classList.add("overlay-grid__item--dragging");
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        const key = target.dataset.overlayKey ?? "";
+        event.dataTransfer.setData("text/plain", key);
+      }
+    };
+
+    const handleDragEnd = () => {
+      if (!activeDrag) return;
+      activeDrag.classList.remove("overlay-grid__item--dragging");
+      activeDrag = null;
+      commitOrder();
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (!activeDrag) return;
+      event.preventDefault();
+      const target = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+        "[data-overlay-key]",
+      );
+      if (!target || target === activeDrag || target.parentElement !== container) {
+        return;
+      }
+      const targetRect = target.getBoundingClientRect();
+      const centerX = targetRect.left + targetRect.width / 2;
+      const centerY = targetRect.top + targetRect.height / 2;
+      const offsetX = event.clientX - centerX;
+      const offsetY = event.clientY - centerY;
+      const prioritizeHorizontal = Math.abs(offsetX) > Math.abs(offsetY);
+      const before = prioritizeHorizontal ? offsetX < 0 : offsetY < 0;
+      const referenceNode = before ? target : target.nextElementSibling;
+      if (referenceNode !== activeDrag) {
+        container.insertBefore(activeDrag, referenceNode ?? null);
+      }
+    };
+
+    const handleDrop = (event: DragEvent) => {
+      event.preventDefault();
+      commitOrder();
+    };
+
+    const initialItems = Array.from(container.children) as HTMLElement[];
+    for (const item of initialItems) {
+      attachListeners(item);
+    }
+    applyStoredOrder();
+
+    container.addEventListener("dragover", handleDragOver);
+    container.addEventListener("drop", handleDrop);
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLElement) {
+            attachListeners(node);
+          }
+        }
+        for (const node of mutation.removedNodes) {
+          if (node instanceof HTMLElement) {
+            detachListeners(node);
+          }
+        }
+      }
+      applyStoredOrder();
+    });
+    observer.observe(container, { childList: true });
+
+    return () => {
+      observer.disconnect();
+      const items = Array.from(container.children) as HTMLElement[];
+      for (const item of items) {
+        detachListeners(item);
+      }
+      container.removeEventListener("dragover", handleDragOver);
+      container.removeEventListener("drop", handleDrop);
+    };
+  }, [storageKey]);
+
+  return (
+    <div ref={containerRef} class="overlay-grid">
+      {children}
+    </div>
+  );
+}

--- a/modules/pilot/frontend/lib/dashboard/persisted_order.ts
+++ b/modules/pilot/frontend/lib/dashboard/persisted_order.ts
@@ -1,0 +1,77 @@
+/**
+ * Storage key used to persist cockpit overlay ordering in the dashboard.
+ *
+ * @example
+ * ```ts
+ * localStorage.getItem(OVERLAY_ORDER_STORAGE_KEY);
+ * ```
+ */
+export const OVERLAY_ORDER_STORAGE_KEY = "pilot.overlay-grid.order";
+
+/**
+ * Parse the persisted overlay order from local storage.
+ *
+ * @example
+ * ```ts
+ * const order = parseOverlayOrderJson('["module-a","module-b"]');
+ * // order -> ["module-a", "module-b"]
+ * ```
+ */
+export function parseOverlayOrderJson(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Reconcile the stored overlay order against the overlays that are currently
+ * available.
+ *
+ * Stored keys that do not match a rendered overlay are ignored and newly
+ * rendered overlays are appended to the end of the order.
+ *
+ * @example
+ * ```ts
+ * const order = reconcileOverlayOrder(["a", "b", "c"], ["c", "z", "a"]);
+ * // order -> ["c", "a", "b"]
+ * ```
+ */
+export function reconcileOverlayOrder(
+  availableKeys: readonly string[],
+  storedKeys: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const key of storedKeys) {
+    if (!availableKeys.includes(key)) continue;
+    if (seen.has(key)) continue;
+    ordered.push(key);
+    seen.add(key);
+  }
+
+  for (const key of availableKeys) {
+    if (seen.has(key)) continue;
+    ordered.push(key);
+  }
+
+  return ordered;
+}
+
+/**
+ * Serialise an overlay order for persistence.
+ *
+ * @example
+ * ```ts
+ * const payload = serialiseOverlayOrder(["module-a", "module-b"]);
+ * // payload -> '["module-a","module-b"]'
+ * ```
+ */
+export function serialiseOverlayOrder(order: readonly string[]): string {
+  return JSON.stringify(order);
+}

--- a/modules/pilot/frontend/lib/dashboard/persisted_order_test.ts
+++ b/modules/pilot/frontend/lib/dashboard/persisted_order_test.ts
@@ -1,0 +1,50 @@
+import {
+  OVERLAY_ORDER_STORAGE_KEY,
+  parseOverlayOrderJson,
+  reconcileOverlayOrder,
+  serialiseOverlayOrder,
+} from "./persisted_order.ts";
+
+Deno.test("overlay storage key exposes a stable identifier", () => {
+  if (OVERLAY_ORDER_STORAGE_KEY.length === 0) {
+    throw new Error("storage key should not be empty");
+  }
+});
+
+Deno.test("parseOverlayOrderJson returns an empty list for invalid payloads", () => {
+  const invalidInputs = [null, "{}", "\"foo\"", "[1,2,3]", "[\"\", null]"];
+  for (const input of invalidInputs) {
+    const result = parseOverlayOrderJson(input as string | null);
+    if (result.length !== 0) {
+      throw new Error(`Expected empty array for input ${input}, received ${result}`);
+    }
+  }
+});
+
+Deno.test("parseOverlayOrderJson recovers valid overlay keys", () => {
+  const order = parseOverlayOrderJson('["alpha","beta","gamma"]');
+  if (order.join(",") !== "alpha,beta,gamma") {
+    throw new Error(`Unexpected overlay order: ${order}`);
+  }
+});
+
+Deno.test("reconcileOverlayOrder drops missing overlays and preserves stored order", () => {
+  const result = reconcileOverlayOrder(["alpha", "beta", "gamma"], ["gamma", "zeta", "alpha"]);
+  if (result.join(",") !== "gamma,alpha,beta") {
+    throw new Error(`Unexpected reconciliation result: ${result}`);
+  }
+});
+
+Deno.test("reconcileOverlayOrder appends new overlays at the end", () => {
+  const result = reconcileOverlayOrder(["alpha", "beta", "gamma"], []);
+  if (result.join(",") !== "alpha,beta,gamma") {
+    throw new Error(`Unexpected reconciliation result: ${result}`);
+  }
+});
+
+Deno.test("serialiseOverlayOrder produces JSON arrays", () => {
+  const result = serialiseOverlayOrder(["alpha", "beta"]);
+  if (result !== '["alpha","beta"]') {
+    throw new Error(`Unexpected serialised payload: ${result}`);
+  }
+});

--- a/modules/pilot/frontend/routes/index.tsx
+++ b/modules/pilot/frontend/routes/index.tsx
@@ -1,3 +1,4 @@
+import OverlayGrid from "../islands/OverlayGrid.tsx";
 import {
   moduleTilesForHost,
   serviceTilesForHost,
@@ -14,27 +15,30 @@ export default define.page(() => {
 
   return (
     <section class="content">
-      <div class="overlay-grid">
-        {overlays.length > 0
-          ? overlays.map((tile) => {
-            const Overlay = tile.overlay;
-            return (
-              <div
-                key={tile.key}
-                class="overlay-grid__item"
-                data-kind={tile.kind}
-                data-name={tile.name}
-              >
-                <Overlay {...(tile.overlayProps ?? {})} />
-              </div>
-            );
-          })
-          : (
-            <p class="overlay-grid__empty">
-              No cockpit overlays are enabled for this host.
-            </p>
-          )}
-      </div>
+      {overlays.length > 0
+        ? (
+          <OverlayGrid>
+            {overlays.map((tile) => {
+              const Overlay = tile.overlay;
+              return (
+                <div
+                  key={tile.key}
+                  class="overlay-grid__item"
+                  data-kind={tile.kind}
+                  data-name={tile.name}
+                  data-overlay-key={tile.key}
+                >
+                  <Overlay {...(tile.overlayProps ?? {})} />
+                </div>
+              );
+            })}
+          </OverlayGrid>
+        )
+        : (
+          <p class="overlay-grid__empty">
+            No cockpit overlays are enabled for this host.
+          </p>
+        )}
     </section>
   );
 });

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -367,19 +367,28 @@ main {
 }
 
 .overlay-grid {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--brand-spacing-lg);
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-
-@media (min-width: 70rem) {
-  .overlay-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  align-items: stretch;
 }
 
 .overlay-grid__item {
   min-width: 0;
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.overlay-grid__item[draggable="true"] {
+  cursor: grab;
+}
+
+.overlay-grid__item--dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+  box-shadow: 0 0 0 2px var(--brand-border-strong);
 }
 
 .overlay-grid__empty {


### PR DESCRIPTION
## Summary
- replace the static cockpit overlay grid with an interactive island that supports drag-and-drop reordering
- persist overlay positions in localStorage with a reconciler that is covered by focused unit tests
- update overlay styling to a responsive flex layout so tiles stretch to fill available space and surface drag affordances

## Testing
- `deno fmt` *(fails: deno is not installed in the execution environment)*
- `deno test modules/pilot/frontend/lib/dashboard/persisted_order_test.ts` *(fails: deno is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74485e3d883209706e238402dfab2