### PR TITLE
Fix Vite prebundling for Preact signals

### DIFF
--- a/modules/pilot/frontend/AGENTS.md
+++ b/modules/pilot/frontend/AGENTS.md
@@ -2,3 +2,7 @@
 
 - Keep websocket bootstrap logic (`lib/cockpit_url.ts`) and its regression tests (`lib/cockpit_test.ts`) in sync whenever adjusting connection defaults or overrides.
 - Run `deno fmt` and the focused test suite (`deno test lib/cockpit_test.ts lib/cockpit_signals_test.ts`) after touching cockpit client utilities whenever Deno is available in the environment.
+- When wiring npm packages into the Fresh + Vite toolchain, add them to
+  `vite.config.ts` `optimizeDeps.include`/`ssr.noExternal` if they resolve deep
+  ESM entry points (for example `@preact/signals`). This keeps the dev server
+  from 404ing `node_modules/.deno/*` requests during hydration.

--- a/modules/pilot/frontend/vite.config.ts
+++ b/modules/pilot/frontend/vite.config.ts
@@ -8,4 +8,21 @@ export default defineConfig({
     host: "0.0.0.0",
     allowedHosts: true,
   },
+  optimizeDeps: {
+    /**
+     * The Preact signals packages rely on npm-style resolution. When Fresh runs
+     * through Vite in a Deno workspace we need to explicitly prebundle them so
+     * the dev server serves `signals-core.module.js` instead of 404ing the
+     * request. This mirrors the guidance from the Vite team for npm packages
+     * with deep ESM entry points.
+     */
+    include: ["@preact/signals", "@preact/signals-core"],
+  },
+  ssr: {
+    /**
+     * Keep the runtime aligned between server and browser renders to avoid
+     * double-instantiating the signals runtime when Fresh hydrates islands.
+     */
+    noExternal: ["@preact/signals", "@preact/signals-core"],
+  },
 });


### PR DESCRIPTION
## Summary
- prebundle the Preact signals packages so the Vite dev server serves their modules without 404s
- document the new prebundling requirement in the pilot frontend agent notes

## Testing
- deno test lib/cockpit_test.ts lib/cockpit_signals_test.ts *(fails: `deno` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e746f5bfd883209a907c6d81a7ae66