### PR TITLE
Restore tee-based logging for psh module launches

### DIFF
--- a/tools/psh/lib/module_test.ts
+++ b/tools/psh/lib/module_test.ts
@@ -41,7 +41,6 @@ Deno.test("composeLaunchCommand directs streams through the prefix helper", () =
     launchScript: "/tmp/launch.sh",
     logFile: "/var/log/demo module.log",
     module: "demo module",
-    ttyPath: null,
   });
   const prefixScript = join(
     repoRoot(),
@@ -56,33 +55,11 @@ Deno.test("composeLaunchCommand directs streams through the prefix helper", () =
   );
   assertStringIncludes(
     command,
-    `> >('${prefixScript}' 'demo module' 'stdout' '/var/log/demo module.log')`,
+    `> >('${prefixScript}' 'demo module' 'stdout' | tee -a '/var/log/demo module.log')`,
   );
   assertStringIncludes(
     command,
-    `2> >('${prefixScript}' 'demo module' 'stderr' '/var/log/demo module.log')`,
-  );
-});
-
-Deno.test("composeLaunchCommand includes tty forwarding when provided", () => {
-  const command = composeLaunchCommand({
-    envCommands: [],
-    launchScript: "/tmp/launch.sh",
-    logFile: "/var/log/demo module.log",
-    module: "demo module",
-    ttyPath: "/dev/pts/9",
-    callerPid: 42,
-  });
-  const prefixScript = join(
-    repoRoot(),
-    "tools",
-    "psh",
-    "scripts",
-    "prefix_logs.sh",
-  );
-  assertStringIncludes(
-    command,
-    `> >('${prefixScript}' 'demo module' 'stdout' '/var/log/demo module.log' '/dev/pts/9' '42')`,
+    `2> >('${prefixScript}' 'demo module' 'stderr' | tee -a '/var/log/demo module.log' >&2)`,
   );
 });
 

--- a/tools/psh/scripts/prefix_logs.sh
+++ b/tools/psh/scripts/prefix_logs.sh
@@ -1,25 +1,21 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# Prefix each line from stdin with the module name and mirror it into the log
-# file. Optionally forward coloured output to a controlling TTY while the
-# original `psh` process is alive. Intended usage:
+# Prefix each line from stdin with the module name and a stream-specific note.
+# Intended usage:
 #
 #   exec bash launch.sh \
-#     > >(tools/psh/scripts/prefix_logs.sh module stdout module.log "$TTY" "$PSH_PID")
+#     > >(tools/psh/scripts/prefix_logs.sh module stdout | tee -a module.log)
 
 set -euo pipefail
 
-if [[ $# -lt 3 ]]; then
-  printf 'usage: %s <module> <stream> <log-file> [tty-path] [caller-pid]\n' "$0" >&2
+if [[ $# -lt 2 ]]; then
+  printf 'usage: %s <module> <stream>\n' "$0" >&2
   exit 64
 fi
 
 module_name=$1
 stream_name=$2
-log_file=$3
-tty_path=${4-}
-caller_pid=${5-}
 
 case "$stream_name" in
   stdout)
@@ -42,54 +38,6 @@ fi
 
 log_prefix="[$module_name]${stream_suffix:+$stream_suffix}"
 
-# shellcheck disable=SC2094
-exec 3>>"$log_file"
-
-tty_active=0
-
-open_tty() {
-  if [[ -z "$tty_path" || $tty_active -eq 1 ]]; then
-    return
-  fi
-  if [[ -n "$caller_pid" ]] && ! kill -0 "$caller_pid" 2>/dev/null; then
-    tty_path=""
-    return
-  fi
-  # shellcheck disable=SC2094
-  if exec 4>>"$tty_path"; then
-    tty_active=1
-  else
-    tty_path=""
-  fi
-}
-
-close_tty() {
-  if [[ $tty_active -eq 1 ]]; then
-    exec 4>&-
-    tty_active=0
-  fi
-}
-
-open_tty || true
-
 while IFS= read -r line || [[ -n "$line" ]]; do
-  printf '%s %s\n' "$log_prefix" "$line" >&3
-
-  if [[ $tty_active -eq 1 && -n "$caller_pid" ]] && ! kill -0 "$caller_pid" 2>/dev/null; then
-    close_tty
-    tty_path=""
-  fi
-
-  if [[ $tty_active -eq 0 ]]; then
-    open_tty || true
-  fi
-
-  if [[ $tty_active -eq 1 ]]; then
-    if ! printf '%b%s %s%b\n' "$color_start" "$log_prefix" "$line" "$color_end" >&4; then
-      close_tty
-      tty_path=""
-    fi
-  fi
+  printf '%b%s %s%b\n' "$color_start" "$log_prefix" "$line" "$color_end"
 done
-
-close_tty


### PR DESCRIPTION
## Summary
- restore the tee-based module launch command so `psh up` mirrors output to both the console and log files
- simplify the prefix_logs helper to just prefix streams and update the accompanying unit test expectations

## Testing
- deno fmt tools/psh/lib/module.ts tools/psh/lib/module_test.ts tools/psh/scripts/prefix_logs.sh *(fails: deno not installed in container)*
- deno lint tools/psh/lib/module.ts tools/psh/lib/module_test.ts *(fails: deno not installed in container)*
- deno test --allow-all *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7477230f483209a944645fec0f44a