### PR TITLE
Restore Preact signals prebundling in cockpit frontend

### DIFF
--- a/modules/pilot/frontend/deno.json
+++ b/modules/pilot/frontend/deno.json
@@ -27,6 +27,8 @@
     "@pilot/lib/": "./lib/",
     "@pilot/components/": "../pilot/components/",
     "preact": "npm:preact@^10.27.2",
+    "@preact/signals": "npm:@preact/signals@^2.3.2",
+    "@preact/signals-core": "npm:@preact/signals-core@^1.12.1",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.4",
     "@preact/preset-vite": "npm:@preact/preset-vite@^2.10.2",
     "vite": "npm:vite@^7.1.3"

--- a/modules/pilot/frontend/deno.lock
+++ b/modules/pilot/frontend/deno.lock
@@ -28,6 +28,8 @@
     "npm:@babel/preset-react@^7.27.1": "7.27.1_@babel+core@7.28.4",
     "npm:@mjackson/node-fetch-server@0.7": "0.7.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
+    "npm:@preact/signals-core@^1.12.1": "1.12.1",
+    "npm:@preact/signals@^2.3.2": "2.3.2_preact@10.27.2",
     "npm:@preact/preset-vite@^2.10.2": "2.10.2_@babel+core@7.28.4_vite@7.1.9__picomatch@4.0.3_preact@10.27.2",
     "npm:@prefresh/vite@^2.4.8": "2.4.10_preact@10.27.2_vite@7.1.9__picomatch@4.0.3",
     "npm:dependency-graph@1.0.0": "1.0.0",
@@ -619,6 +621,16 @@
     },
     "@opentelemetry/api@1.9.0": {
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
+    "@preact/signals-core@1.12.1": {
+      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA=="
+    },
+    "@preact/signals@2.3.2_preact@10.27.2": {
+      "integrity": "sha512-Q22avIn4z0BQnmFeo6Y5HCnJTo8VufN84zN51OtqeNgZOVCYgdwEOcJKVX1x/IrjRVxUnOy6Ubn7H5aVFujXaQ==",
+      "dependencies": [
+        "@preact/signals-core",
+        "preact"
+      ]
     },
     "@preact/preset-vite@2.10.2_@babel+core@7.28.4_vite@7.1.9__picomatch@4.0.3_preact@10.27.2": {
       "integrity": "sha512-K9wHlJOtkE+cGqlyQ5v9kL3Ge0Ql4LlIZjkUTL+1zf3nNdF88F9UZN6VTV8jdzBX9Fl7WSzeNMSDG7qECPmSmg==",
@@ -1299,6 +1311,8 @@
     "dependencies": [
       "jsr:@fresh/core@^2.1.2",
       "jsr:@fresh/plugin-vite@^1.0.4",
+      "npm:@preact/signals-core@^1.12.1",
+      "npm:@preact/signals@^2.3.2",
       "npm:@preact/preset-vite@^2.10.2",
       "npm:dependency-graph@1.0.0",
       "npm:preact@^10.27.2",

--- a/modules/pilot/frontend/vite.config.ts
+++ b/modules/pilot/frontend/vite.config.ts
@@ -8,4 +8,20 @@ export default defineConfig({
     host: "0.0.0.0",
     allowedHosts: true,
   },
+  optimizeDeps: {
+    /**
+     * Fresh runs through Vite inside a Deno workspace, so npm packages that
+     * expose deep ESM entry points (like the Preact signals runtime) need to be
+     * explicitly prebundled. Otherwise the dev server serves bare
+     * `node_modules/.deno/...` paths that 404 in the browser.
+     */
+    include: ["@preact/signals", "@preact/signals-core"],
+  },
+  ssr: {
+    /**
+     * Keep the runtime aligned between server and browser renders so Fresh
+     * doesn't instantiate two copies of the signals runtime during hydration.
+     */
+    noExternal: ["@preact/signals", "@preact/signals-core"],
+  },
 });


### PR DESCRIPTION
## Summary
- add the @preact/signals runtime packages to the pilot frontend import map
- configure Vite to prebundle and keep the signals packages aligned between SSR and the browser
- lock the new npm dependencies so the workspace resolves them consistently

## Testing
- deno task check *(fails: deno is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e805ed78f8832092b0e8b2a5d167ab