### PR TITLE
Add cockpit telemetry panels for ear and voice modules

### DIFF
--- a/modules/ear/pilot/components/EarModulePanel.tsx
+++ b/modules/ear/pilot/components/EarModulePanel.tsx
@@ -1,15 +1,174 @@
+import { useCallback, useEffect, useMemo, useReducer, useState } from "preact/hooks";
+
+import { useCockpitTopic } from "@pilot/lib/cockpit.ts";
+
+import { Card, CONNECTION_STATUS_LABELS, toneFromConnection } from "../../../pilot/pilot/components/dashboard.tsx";
 import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+import { formatRelativeTime } from "../../../pilot/frontend/lib/format.ts";
 
 const DESCRIPTION = "Microphone ingestion and speech recognition interface.";
+const TRANSCRIPT_TOPIC = "/audio/transcript/final";
+const TRANSCRIPT_LIMIT = 12;
+const REFRESH_INTERVAL_MS = 1_000;
+
+type TranscriptMessage = { data?: string | null };
+
+interface TranscriptEntry {
+  text: string;
+  receivedAt: number;
+}
+
+interface TranscriptLogOptions {
+  limit?: number;
+  now?: () => number;
+}
+
+/**
+ * Adds a transcript line to the rolling log while preventing consecutive
+ * duplicates and keeping the newest entry first.
+ *
+ * @example
+ * ```ts
+ * appendTranscriptLog([], "Hello", { now: () => 0 });
+ * //=> [{ text: "Hello", receivedAt: 0 }]
+ * ```
+ */
+export function appendTranscriptLog(
+  log: TranscriptEntry[],
+  text: string,
+  options: TranscriptLogOptions = {},
+): TranscriptEntry[] {
+  const trimmed = text.trim();
+  if (!trimmed) return log;
+
+  const limit = options.limit ?? TRANSCRIPT_LIMIT;
+  const now = options.now ?? (() => Date.now());
+  const newest = log[0];
+  if (newest && newest.text === trimmed) {
+    return log;
+  }
+
+  const entry: TranscriptEntry = {
+    text: trimmed,
+    receivedAt: now(),
+  };
+  const next = [entry, ...log];
+  return next.length > limit ? next.slice(0, limit) : next;
+}
 
 /** Present lifecycle controls for the Ear audio capture module. */
 export default function EarModulePanel() {
+  const transcript = useCockpitTopic<TranscriptMessage>(TRANSCRIPT_TOPIC, {
+    replay: true,
+  });
+  const [log, setLog] = useState<TranscriptEntry[]>([]);
+  const [, forceRefresh] = useReducer((tick: number) => tick + 1, 0);
+
+  const addTranscript = useCallback((text: string) => {
+    setLog((previous) =>
+      appendTranscriptLog(previous, text, {
+        now: () => Date.now(),
+        limit: TRANSCRIPT_LIMIT,
+      })
+    );
+  }, []);
+
+  useEffect(() => {
+    const message = transcript.data?.data;
+    if (typeof message !== "string") {
+      return;
+    }
+    addTranscript(message);
+  }, [transcript.data?.data, addTranscript]);
+
+  useEffect(() => {
+    if (
+      typeof globalThis.setInterval !== "function" ||
+      typeof globalThis.clearInterval !== "function"
+    ) {
+      return;
+    }
+    const timer = globalThis.setInterval(() => {
+      forceRefresh();
+    }, REFRESH_INTERVAL_MS);
+    return () => globalThis.clearInterval(timer);
+  }, [forceRefresh]);
+
+  const connectionLabel = CONNECTION_STATUS_LABELS[transcript.status] ?? "Unknown";
+  const connectionTone = toneFromConnection(transcript.status);
+  const lastUpdated = useMemo(
+    () => formatRelativeTime(log[0]?.receivedAt ?? null),
+    [log]
+  );
+
   return (
     <ModuleOverview
       moduleName="ear"
       title="Ear module"
       description={DESCRIPTION}
       accent="cyan"
-    />
+    >
+      <Card
+        title="Transcripts"
+        subtitle="Final recogniser output"
+        tone="cyan"
+        icon={<TranscriptIcon />}
+      >
+        <dl class="stat-list">
+          <div class="stat-list__item">
+            <dt>Status</dt>
+            <dd>
+              <span class={`status-badge status-badge--${connectionTone}`}>
+                {connectionLabel}
+              </span>
+            </dd>
+          </div>
+          <div class="stat-list__item">
+            <dt>Last update</dt>
+            <dd>{lastUpdated}</dd>
+          </div>
+        </dl>
+        {log.length === 0 ? (
+          <p class="placeholder">No transcripts received yet.</p>
+        ) : (
+          <ol class="log-list" aria-live="polite">
+            {log.map((entry, index) => {
+              const iso = new Date(entry.receivedAt).toISOString();
+              return (
+                <li class="log-list__item" key={`${entry.receivedAt}-${index}`}>
+                  <p class="log-list__text">{entry.text}</p>
+                  <time class="log-list__meta" dateTime={iso}>
+                    {formatRelativeTime(entry.receivedAt)}
+                  </time>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+        {transcript.error && <p class="note note--alert">{transcript.error}</p>}
+      </Card>
+    </ModuleOverview>
   );
 }
+
+function TranscriptIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+      <path
+        d="M5 4h10l4 4v12H5z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 12h6M9 16h3"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+export const __test__ = { appendTranscriptLog };

--- a/modules/ear/pilot/components/EarModulePanel_test.ts
+++ b/modules/ear/pilot/components/EarModulePanel_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "$std/assert/mod.ts";
+
+import { __test__ } from "./EarModulePanel.tsx";
+
+const { appendTranscriptLog } = __test__;
+
+Deno.test("appendTranscriptLog keeps newest transcript first", () => {
+  let log = appendTranscriptLog([], "hello world", {
+    now: () => 1_000,
+    limit: 3,
+  });
+  assertEquals(log, [
+    { text: "hello world", receivedAt: 1_000 },
+  ]);
+
+  log = appendTranscriptLog(log, " second message ", {
+    now: () => 2_000,
+    limit: 3,
+  });
+  assertEquals(log, [
+    { text: "second message", receivedAt: 2_000 },
+    { text: "hello world", receivedAt: 1_000 },
+  ]);
+});
+
+Deno.test("appendTranscriptLog enforces length and ignores duplicates", () => {
+  const options = { limit: 2, now: () => 0 } as const;
+  let log = appendTranscriptLog([], "first", { ...options, now: () => 100 });
+  log = appendTranscriptLog(log, "second", { ...options, now: () => 200 });
+  log = appendTranscriptLog(log, "second", { ...options, now: () => 300 });
+  assertEquals(log, [
+    { text: "second", receivedAt: 200 },
+    { text: "first", receivedAt: 100 },
+  ]);
+
+  log = appendTranscriptLog(log, "third", { ...options, now: () => 400 });
+  assertEquals(log, [
+    { text: "third", receivedAt: 400 },
+    { text: "second", receivedAt: 200 },
+  ]);
+
+  log = appendTranscriptLog(log, "   ", { ...options, now: () => 500 });
+  assertEquals(log, [
+    { text: "third", receivedAt: 400 },
+    { text: "second", receivedAt: 200 },
+  ]);
+});

--- a/modules/pilot/frontend/static/styles.css
+++ b/modules/pilot/frontend/static/styles.css
@@ -806,6 +806,67 @@ main {
   font-feature-settings: "tnum" 1;
 }
 
+.log-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.log-list__item {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  border-radius: var(--brand-radius-sm);
+  background: rgba(12, 20, 36, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.log-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.log-list__text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.log-list__meta {
+  font-size: 0.75rem;
+  color: var(--brand-text-muted);
+}
+
+.conversation-form {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.conversation-form__input {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--brand-radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(12, 20, 36, 0.65);
+  color: var(--brand-text);
+  resize: vertical;
+  min-height: 120px;
+}
+
+.conversation-form__input:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
 .command-matrix {
   display: grid;
   gap: 0.8rem;

--- a/modules/voice/pilot/components/VoiceModulePanel.tsx
+++ b/modules/voice/pilot/components/VoiceModulePanel.tsx
@@ -1,15 +1,244 @@
+import type { TargetedEvent } from "preact";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "preact/hooks";
+
+import { useCockpitTopic } from "@pilot/lib/cockpit.ts";
+
+import { Card, CONNECTION_STATUS_LABELS, toneFromConnection } from "../../../pilot/pilot/components/dashboard.tsx";
 import ModuleOverview from "../../../pilot/pilot/components/ModuleOverview.tsx";
+import { formatRelativeTime } from "../../../pilot/frontend/lib/format.ts";
 
 const DESCRIPTION = "Speech synthesis bridge coordinating the TTS service.";
+const CONVERSATION_TOPIC = "/conversation";
+const CONVERSATION_LIMIT = 20;
+const REFRESH_INTERVAL_MS = 1_000;
 
-/** Lifecycle controls for the Voice output module. */
+type ConversationMessage = { data?: string | null };
+type ConversationSource = "local" | "remote";
+
+interface ConversationEntry {
+  text: string;
+  source: ConversationSource;
+  receivedAt: number;
+}
+
+interface ConversationLogOptions {
+  limit?: number;
+  now?: () => number;
+}
+
+interface AppendConversationArgs {
+  text: string;
+  source: ConversationSource;
+}
+
+/**
+ * Appends a conversational message to the rolling history, skipping consecutive
+ * duplicates so operator echoes do not pollute the log.
+ *
+ * @example
+ * ```ts
+ * appendConversationLog([], { text: "Hello", source: "local" }, { now: () => 0 });
+ * //=> [{ text: "Hello", source: "local", receivedAt: 0 }]
+ * ```
+ */
+export function appendConversationLog(
+  log: ConversationEntry[],
+  entry: AppendConversationArgs,
+  options: ConversationLogOptions = {},
+): ConversationEntry[] {
+  const trimmed = entry.text.trim();
+  if (!trimmed) return log;
+
+  const limit = options.limit ?? CONVERSATION_LIMIT;
+  const now = options.now ?? (() => Date.now());
+  const newest = log[0];
+  if (newest && newest.text === trimmed) {
+    return log;
+  }
+
+  const nextEntry: ConversationEntry = {
+    text: trimmed,
+    source: entry.source,
+    receivedAt: now(),
+  };
+  const next = [nextEntry, ...log];
+  return next.length > limit ? next.slice(0, limit) : next;
+}
+
+const SOURCE_LABELS: Record<ConversationSource, string> = {
+  local: "Operator",
+  remote: "Robot",
+};
+
+/** Lifecycle controls and TTS conversation surface for the Voice output module. */
 export default function VoiceModulePanel() {
+  const conversation = useCockpitTopic<ConversationMessage>(CONVERSATION_TOPIC, {
+    replay: true,
+  });
+  const [log, setLog] = useState<ConversationEntry[]>([]);
+  const [draft, setDraft] = useState("");
+  const [, forceRefresh] = useReducer((tick: number) => tick + 1, 0);
+
+  const appendMessage = useCallback(
+    (message: string, source: ConversationSource) => {
+      setLog((previous) =>
+        appendConversationLog(previous, { text: message, source }, {
+          limit: CONVERSATION_LIMIT,
+          now: () => Date.now(),
+        })
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const payload = conversation.data?.data;
+    if (typeof payload !== "string") {
+      return;
+    }
+    appendMessage(payload, "remote");
+  }, [conversation.data?.data, appendMessage]);
+
+  useEffect(() => {
+    if (
+      typeof globalThis.setInterval !== "function" ||
+      typeof globalThis.clearInterval !== "function"
+    ) {
+      return;
+    }
+    const timer = globalThis.setInterval(() => {
+      forceRefresh();
+    }, REFRESH_INTERVAL_MS);
+    return () => globalThis.clearInterval(timer);
+  }, [forceRefresh]);
+
+  const handleDraftChange = useCallback(
+    (event: TargetedEvent<HTMLTextAreaElement, Event>) => {
+      setDraft(event.currentTarget.value);
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      const message = draft.trim();
+      if (!message) {
+        return;
+      }
+      appendMessage(message, "local");
+      conversation.publish({ data: message });
+      setDraft("");
+    },
+    [draft, conversation, appendMessage],
+  );
+
+  const connectionLabel = CONNECTION_STATUS_LABELS[conversation.status] ?? "Unknown";
+  const connectionTone = toneFromConnection(conversation.status);
+  const lastUpdated = useMemo(
+    () => formatRelativeTime(log[0]?.receivedAt ?? null),
+    [log],
+  );
+  const canSend = draft.trim().length > 0;
+
   return (
     <ModuleOverview
       moduleName="voice"
       title="Voice module"
       description={DESCRIPTION}
       accent="cyan"
-    />
+    >
+      <Card
+        title="Conversation"
+        subtitle="Cockpit bridge to the TTS node"
+        tone="cyan"
+        icon={<ConversationIcon />}
+        footer={
+          <p class="note">
+            Messages are forwarded to the ROS <code>{CONVERSATION_TOPIC}</code> topic.
+          </p>
+        }
+      >
+        <dl class="stat-list">
+          <div class="stat-list__item">
+            <dt>Status</dt>
+            <dd>
+              <span class={`status-badge status-badge--${connectionTone}`}>
+                {connectionLabel}
+              </span>
+            </dd>
+          </div>
+          <div class="stat-list__item">
+            <dt>Last message</dt>
+            <dd>{lastUpdated}</dd>
+          </div>
+        </dl>
+
+        {log.length === 0 ? (
+          <p class="placeholder">No conversation messages yet.</p>
+        ) : (
+          <ol class="log-list" aria-live="polite">
+            {log.map((entry, index) => {
+              const iso = new Date(entry.receivedAt).toISOString();
+              return (
+                <li class="log-list__item" key={`${entry.receivedAt}-${index}`}>
+                  <div class="log-list__header">
+                    <span class="chip">{SOURCE_LABELS[entry.source]}</span>
+                    <time class="log-list__meta" dateTime={iso}>
+                      {formatRelativeTime(entry.receivedAt)}
+                    </time>
+                  </div>
+                  <p class="log-list__text">{entry.text}</p>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        <form class="conversation-form" onSubmit={handleSubmit}>
+          <label class="sr-only" htmlFor="voice-draft">Send message</label>
+          <textarea
+            id="voice-draft"
+            class="conversation-form__input"
+            rows={3}
+            placeholder="Type a phrase for Pete to speak"
+            value={draft}
+            onInput={handleDraftChange}
+          />
+          <div class="button-group">
+            <button
+              class="button button--primary"
+              type="submit"
+              disabled={!canSend}
+            >
+              Send to robot
+            </button>
+          </div>
+        </form>
+        {conversation.error && <p class="note note--alert">{conversation.error}</p>}
+      </Card>
+    </ModuleOverview>
   );
 }
+
+function ConversationIcon() {
+  return (
+    <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+      <path
+        d="M4 6h16v9H7l-3 3z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 10h6M9 13h4"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+export const __test__ = { appendConversationLog };

--- a/modules/voice/pilot/components/VoiceModulePanel_test.ts
+++ b/modules/voice/pilot/components/VoiceModulePanel_test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "$std/assert/mod.ts";
+
+import { __test__ } from "./VoiceModulePanel.tsx";
+
+const { appendConversationLog } = __test__;
+
+Deno.test("appendConversationLog records most recent messages first", () => {
+  let log = appendConversationLog([], {
+    text: "Hello",
+    source: "remote",
+  }, {
+    now: () => 1_000,
+    limit: 3,
+  });
+  assertEquals(log, [
+    { text: "Hello", source: "remote", receivedAt: 1_000 },
+  ]);
+
+  log = appendConversationLog(log, {
+    text: "Hi there",
+    source: "local",
+  }, {
+    now: () => 2_000,
+    limit: 3,
+  });
+  assertEquals(log, [
+    { text: "Hi there", source: "local", receivedAt: 2_000 },
+    { text: "Hello", source: "remote", receivedAt: 1_000 },
+  ]);
+});
+
+Deno.test("appendConversationLog trims list and avoids duplicate echoes", () => {
+  const options = { limit: 2 } as const;
+  let log = appendConversationLog([], {
+    text: "One",
+    source: "local",
+  }, { ...options, now: () => 100 });
+  log = appendConversationLog(log, {
+    text: "One",
+    source: "remote",
+  }, { ...options, now: () => 200 });
+  assertEquals(log, [
+    { text: "One", source: "local", receivedAt: 100 },
+  ]);
+
+  log = appendConversationLog(log, {
+    text: "Two",
+    source: "remote",
+  }, { ...options, now: () => 300 });
+  log = appendConversationLog(log, {
+    text: "Three",
+    source: "remote",
+  }, { ...options, now: () => 400 });
+  assertEquals(log, [
+    { text: "Three", source: "remote", receivedAt: 400 },
+    { text: "Two", source: "remote", receivedAt: 300 },
+  ]);
+
+  log = appendConversationLog(log, {
+    text: "   ",
+    source: "remote",
+  }, { ...options, now: () => 500 });
+  assertEquals(log, [
+    { text: "Three", source: "remote", receivedAt: 400 },
+    { text: "Two", source: "remote", receivedAt: 300 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add an interactive transcript console to the Ear module by subscribing to the `/audio/transcript/final` cockpit topic and buffering recent entries
- surface the `/conversation` topic in the Voice module with a chat-style log, operator input form, and client-side echo handling
- extend the cockpit stylesheet and add unit coverage for the new transcript and conversation log reducers

## Testing
- `deno test --config modules/pilot/frontend/deno.json modules/ear/pilot/components/EarModulePanel_test.ts modules/voice/pilot/components/VoiceModulePanel_test.ts` *(fails: deno is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea00942f808320ad66d5fadcc4cc46