### PR TITLE
Add pilot module configuration console

### DIFF
--- a/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
@@ -86,8 +86,15 @@ class PilotApp extends LitElement {
     if (typeof window === 'undefined') {
       return;
     }
-    const detail = [];
-    let index = 0;
+    const detail = [
+      {
+        id: 'pilot-config',
+        label: 'Module Configuration',
+        index: 0,
+        url: '/config/',
+      },
+    ];
+    let index = 1;
     for (const module of this.modules) {
       const slug = module.slug || module.name;
       if (!slug) continue;

--- a/modules/pilot/packages/pilot/pilot/frontend/config/app.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/config/app.js
@@ -1,0 +1,367 @@
+/**
+ * Minimal controller for the module configuration console.
+ *
+ * The page fetches module descriptors from the new `/api/module-config` endpoint
+ * and renders an editable JSON block for each module. Submissions are persisted
+ * immediately through a ``PUT`` request back to the same endpoint.
+ */
+
+const moduleState = new Map();
+const root = document.getElementById('config-app');
+const statusNode = document.querySelector('.config-status');
+const refreshButton = document.querySelector('[data-role="refresh"]');
+
+if (!root) {
+  throw new Error('Configuration root element not found');
+}
+
+if (refreshButton) {
+  refreshButton.addEventListener('click', () => loadModules({ announce: true }));
+}
+
+loadModules();
+
+/**
+ * Fetch the latest module configuration payload and refresh the UI.
+ *
+ * @param {{ announce?: boolean }} [options] Optional behaviour flags.
+ */
+async function loadModules(options = {}) {
+  setGlobalStatus('Loading module configuration…', 'info');
+  try {
+    const response = await fetch('/api/module-config');
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    const payload = await response.json();
+    const modules = Array.isArray(payload.modules) ? payload.modules : [];
+    moduleState.clear();
+    modules.forEach((module) => {
+      moduleState.set(module.name, {
+        original: module.config || {},
+        metadata: module,
+      });
+    });
+    renderModules(modules);
+    if (options.announce) {
+      setGlobalStatus('Refreshed host configuration.', 'success');
+    } else {
+      clearGlobalStatus();
+    }
+  } catch (error) {
+    console.error('Failed to load module configuration', error);
+    setGlobalStatus(
+      error instanceof Error ? error.message : 'Failed to load module configuration.',
+      'error',
+    );
+  }
+}
+
+/**
+ * Render the editor surface for each configured module.
+ *
+ * @param {Array<Record<string, any>>} modules Resolved module payloads.
+ */
+function renderModules(modules) {
+  root.innerHTML = '';
+  if (!modules.length) {
+    root.appendChild(emptyState());
+    return;
+  }
+
+  for (const module of modules) {
+    root.appendChild(renderModuleCard(module));
+  }
+}
+
+/**
+ * Return a card element allowing a specific module to be edited.
+ *
+ * @param {Record<string, any>} module Module payload emitted by the API.
+ * @returns {HTMLElement}
+ */
+function renderModuleCard(module) {
+  const card = document.createElement('section');
+  card.className = 'config-card';
+  card.dataset.moduleName = module.name;
+
+  const header = buildCardHeader(module);
+
+  const editor = document.createElement('textarea');
+  editor.className = 'config-card__editor';
+  editor.autocomplete = 'off';
+  editor.spellcheck = false;
+  editor.value = formatConfig(module.config || {});
+  editor.setAttribute('aria-label', `${module.display_name || module.name} configuration`);
+
+  const controls = document.createElement('div');
+  controls.className = 'config-card__controls';
+
+  const saveButton = document.createElement('button');
+  saveButton.type = 'button';
+  saveButton.className = 'config-card__save';
+  saveButton.textContent = 'Save changes';
+  saveButton.addEventListener('click', () => submitModule(card, editor));
+
+  const resetButton = document.createElement('button');
+  resetButton.type = 'button';
+  resetButton.className = 'config-card__reset';
+  resetButton.textContent = 'Reset';
+  resetButton.addEventListener('click', () => resetEditor(module.name, editor));
+
+  const status = document.createElement('p');
+  status.className = 'config-card__status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+
+  controls.appendChild(saveButton);
+  controls.appendChild(resetButton);
+
+  card.appendChild(header);
+  card.appendChild(editor);
+  card.appendChild(controls);
+  card.appendChild(status);
+
+  return card;
+}
+
+/**
+ * Submit the updated configuration for a module back to the server.
+ *
+ * @param {HTMLElement} card Card wrapper for the module being edited.
+ * @param {HTMLTextAreaElement} editor Editor containing the JSON payload.
+ */
+async function submitModule(card, editor) {
+  const name = card.dataset.moduleName;
+  if (!name) {
+    return;
+  }
+
+  const status = card.querySelector('.config-card__status');
+  const body = editor.value.trim();
+
+  let parsed;
+  try {
+    parsed = body ? JSON.parse(body) : {};
+  } catch (error) {
+    setCardStatus(status, 'Configuration must be valid JSON.', 'error');
+    editor.focus();
+    return;
+  }
+
+  setCardStatus(status, 'Saving…', 'info');
+  try {
+    const response = await fetch(`/api/module-config/${encodeURIComponent(name)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(parsed),
+    });
+    if (!response.ok) {
+      const message = await extractError(response);
+      throw new Error(message);
+    }
+    const payload = await response.json();
+    moduleState.set(name, {
+      original: payload.config || {},
+      metadata: payload,
+    });
+    refreshCardMetadata(card, payload);
+    editor.value = formatConfig(payload.config || {});
+    setCardStatus(status, 'Saved.', 'success');
+    setGlobalStatus(`Updated ${payload.display_name || name}.`, 'success');
+  } catch (error) {
+    console.error(`Failed to persist configuration for ${name}`, error);
+    setCardStatus(
+      status,
+      error instanceof Error ? error.message : 'Failed to persist configuration.',
+      'error',
+    );
+    setGlobalStatus(
+      error instanceof Error ? error.message : 'Failed to persist configuration.',
+      'error',
+    );
+  }
+}
+
+/**
+ * Reset an editor to the last known configuration fetched from the server.
+ *
+ * @param {string} moduleName Target module identifier.
+ * @param {HTMLTextAreaElement} editor Editor element to update.
+ */
+function resetEditor(moduleName, editor) {
+  const record = moduleState.get(moduleName);
+  if (!record) {
+    editor.value = '{}';
+    return;
+  }
+  editor.value = formatConfig(record.original || {});
+  setGlobalStatus(`Reverted ${record.metadata.display_name || moduleName}.`, 'info');
+}
+
+/**
+ * Display a shared status message for the whole page.
+ *
+ * @param {string} message Status text to surface.
+ * @param {'info' | 'success' | 'error'} tone Semantic tone for styling.
+ */
+function setGlobalStatus(message, tone) {
+  if (!statusNode) {
+    return;
+  }
+  statusNode.textContent = message;
+  statusNode.dataset.tone = tone;
+}
+
+/** Clear the shared status banner. */
+function clearGlobalStatus() {
+  if (!statusNode) {
+    return;
+  }
+  statusNode.textContent = '';
+  delete statusNode.dataset.tone;
+}
+
+/**
+ * Update the inline status element for a module card.
+ *
+ * @param {Element | null} node Target status node.
+ * @param {string} message Status message to present.
+ * @param {'info' | 'success' | 'error'} tone Semantic tone for styling.
+ */
+function setCardStatus(node, message, tone) {
+  if (!node) {
+    return;
+  }
+  node.textContent = message;
+  node.dataset.tone = tone;
+}
+
+/**
+ * Render a short “empty state” description when no modules are configured.
+ *
+ * @returns {HTMLElement}
+ */
+function emptyState() {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'config-empty';
+  wrapper.innerHTML = `
+    <h2>No modules configured</h2>
+    <p>The host manifest does not list any modules yet. Add entries under <code>host.modules</code> to begin configuring them.</p>
+  `;
+  return wrapper;
+}
+
+/**
+ * Produce a badge element used to highlight module metadata.
+ *
+ * @param {string} label Text to display inside the badge.
+ * @param {'success' | 'link'} [variant] Visual variant for styling.
+ * @returns {HTMLAnchorElement | HTMLSpanElement}
+ */
+function createBadge(label, variant) {
+  const element = variant === 'link' ? document.createElement('a') : document.createElement('span');
+  element.className = `config-badge${variant ? ` config-badge--${variant}` : ''}`;
+  element.textContent = label;
+  return element;
+}
+
+/**
+ * Build a module card header containing the title, badges, and description.
+ *
+ * @param {Record<string, any>} module Module metadata payload.
+ * @returns {HTMLElement}
+ */
+function buildCardHeader(module) {
+  const header = document.createElement('header');
+  header.className = 'config-card__header';
+
+  const title = document.createElement('h2');
+  title.textContent = module.display_name || module.name;
+  header.appendChild(title);
+
+  const badges = document.createElement('div');
+  badges.className = 'config-card__badges';
+
+  if (module.listed) {
+    badges.appendChild(createBadge('Listed on host'));
+  }
+  if (module.active) {
+    badges.appendChild(createBadge('Launch enabled', 'success'));
+  }
+  if (module.has_pilot) {
+    const link = module.dashboard_url || `/modules/${module.name}/`;
+    const badge = createBadge('Pilot dashboard', 'link');
+    badge.href = link;
+    badge.target = '_blank';
+    badge.rel = 'noopener';
+    badges.appendChild(badge);
+  }
+
+  if (badges.childNodes.length) {
+    header.appendChild(badges);
+  }
+
+  if (module.description) {
+    const description = document.createElement('p');
+    description.className = 'config-card__description';
+    description.textContent = module.description;
+    header.appendChild(description);
+  }
+
+  return header;
+}
+
+/**
+ * Refresh the visible metadata for a module card after a save.
+ *
+ * @param {HTMLElement} card Card element being updated.
+ * @param {Record<string, any>} module Latest module payload from the server.
+ */
+function refreshCardMetadata(card, module) {
+  card.dataset.moduleName = module.name;
+  const existing = card.querySelector('.config-card__header');
+  const updated = buildCardHeader(module);
+  if (existing && existing.parentNode === card) {
+    card.replaceChild(updated, existing);
+  } else {
+    card.insertBefore(updated, card.firstChild);
+  }
+}
+
+/**
+ * Format a configuration object into a JSON string.
+ *
+ * @param {Record<string, any>} value Arbitrary JSON-compatible value.
+ * @returns {string}
+ */
+function formatConfig(value) {
+  try {
+    return JSON.stringify(value && typeof value === 'object' ? value : {}, null, 2);
+  } catch (_error) {
+    return '{}';
+  }
+}
+
+/**
+ * Extract an error message from a failed ``fetch`` response.
+ *
+ * @param {Response} response Fetch response that failed.
+ * @returns {Promise<string>}
+ */
+async function extractError(response) {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object' && typeof payload.message === 'string') {
+      return payload.message;
+    }
+  } catch (_error) {
+    // Fall back to response text when JSON parsing fails.
+  }
+  try {
+    const text = await response.text();
+    return text || `Request failed with status ${response.status}`;
+  } catch (_error) {
+    return `Request failed with status ${response.status}`;
+  }
+}

--- a/modules/pilot/packages/pilot/pilot/frontend/config/index.html
+++ b/modules/pilot/packages/pilot/pilot/frontend/config/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Psyched Pilot – Module Configuration</title>
+    <link rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%230055ff'/%3E%3Ctext x='8' y='12' font-size='9' text-anchor='middle' fill='%23ffffff'%3E%CE%A8%3C/text%3E%3C/svg%3E" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+
+  <body class="lcars-body config-page">
+    <aside class="lcars-nav config-nav">
+      <div class="nav-title">Module Config</div>
+      <a class="nav-button nav-button--link" href="/">
+        <span class="nav-index">⟵</span>
+        <span class="nav-label">Back to Dashboards</span>
+      </a>
+      <p class="config-nav__hint">
+        Adjust module launch options and environment variables directly from the pilot. Saved changes are written to the host
+        manifest immediately.
+      </p>
+    </aside>
+
+    <main class="lcars-main config-main">
+      <header class="lcars-hero config-hero">
+        <div>
+          <h1>Module Configuration Console</h1>
+          <p>
+            Review and update the host manifest without leaving the cockpit. Each module exposes its launch settings in a
+            structured editor—submit a change to persist it instantly.
+          </p>
+          <p class="config-hero__hint">
+            Values must be valid JSON. Empty editors clear the module override while keeping the module listed on the host.
+          </p>
+        </div>
+      </header>
+
+      <section class="config-toolbar" aria-label="Configuration actions">
+        <button type="button" class="config-refresh" data-role="refresh">Refresh from host manifest</button>
+        <span class="config-status" role="status" aria-live="polite"></span>
+      </section>
+
+      <div id="config-app" class="config-app" aria-live="polite"></div>
+    </main>
+
+    <script type="module" src="/config/app.js"></script>
+  </body>
+</html>

--- a/modules/pilot/packages/pilot/pilot/frontend/index.html
+++ b/modules/pilot/packages/pilot/pilot/frontend/index.html
@@ -28,10 +28,13 @@
     </aside>
 
     <main class="lcars-main">
-      <header class="lcars-hero">
+      <header class="lcars-hero" id="pilot-config">
         <div>
           <h1>Module Dashboards</h1>
           <p>Explore the curated control panels authored by each module team. Every panel can combine ROS data and controls into the experience that makes the most sense for that system.</p>
+          <div class="lcars-hero__actions">
+            <a class="lcars-hero__link" href="/config/">Open module configuration console</a>
+          </div>
         </div>
       </header>
       <div id="pilot-app" class="app-root"></div>

--- a/modules/pilot/packages/pilot/pilot/frontend/styles.css
+++ b/modules/pilot/packages/pilot/pilot/frontend/styles.css
@@ -152,6 +152,33 @@ body {
   color: var(--lcars-muted);
 }
 
+.lcars-hero__actions {
+  margin-top: 1.25rem;
+}
+
+.lcars-hero__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(88, 178, 220, 0.2);
+  color: var(--lcars-text);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.lcars-hero__link::after {
+  content: '↗';
+  font-size: 0.9rem;
+}
+
+.lcars-hero__link:hover,
+.lcars-hero__link:focus {
+  background: rgba(88, 178, 220, 0.35);
+}
+
 .app-root {
   display: flex;
   flex-direction: column;
@@ -1499,4 +1526,233 @@ h5.audio-oscilloscope {
 .status.error,
 .error {
   color: var(--lcars-error);
+}
+
+/* Module configuration console ---------------------------------------------------- */
+
+.config-page {
+  background: var(--lcars-bg);
+}
+
+.config-nav {
+  gap: 1.25rem;
+}
+
+.config-nav__hint {
+  margin: 0;
+  color: var(--lcars-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.nav-button--link {
+  text-decoration: none;
+  justify-content: flex-start;
+}
+
+.config-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.config-hero__hint {
+  color: var(--lcars-muted);
+  margin-top: 0.75rem;
+}
+
+.config-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.config-refresh {
+  border: none;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(88, 178, 220, 0.2);
+  color: var(--lcars-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.config-refresh:hover,
+.config-refresh:focus {
+  background: rgba(88, 178, 220, 0.35);
+}
+
+.config-status {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  color: var(--lcars-muted);
+}
+
+.config-status[data-tone='success'] {
+  color: var(--lcars-success);
+}
+
+.config-status[data-tone='error'] {
+  color: var(--lcars-error);
+}
+
+.config-status[data-tone='info'] {
+  color: var(--lcars-accent-secondary);
+}
+
+.config-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.config-card {
+  background: rgba(27, 31, 42, 0.85);
+  border: 1px solid rgba(88, 178, 220, 0.35);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+}
+
+.config-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.config-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.config-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(88, 178, 220, 0.18);
+  color: var(--lcars-accent-secondary);
+  font-size: 0.8rem;
+  text-decoration: none;
+}
+
+.config-badge--success {
+  background: rgba(92, 209, 132, 0.2);
+  color: var(--lcars-success);
+}
+
+.config-badge--link {
+  border: 1px solid rgba(88, 178, 220, 0.4);
+}
+
+.config-card__description {
+  margin: 0;
+  color: var(--lcars-muted);
+  font-size: 0.95rem;
+}
+
+.config-card__editor {
+  width: 100%;
+  min-height: 220px;
+  resize: vertical;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(88, 178, 220, 0.35);
+  background: rgba(15, 17, 26, 0.55);
+  color: var(--lcars-text);
+  font-family: 'Source Code Pro', monospace;
+  font-size: 0.95rem;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.config-card__controls {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.config-card__save,
+.config-card__reset {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.config-card__save {
+  background: rgba(248, 128, 60, 0.25);
+  color: var(--lcars-text);
+}
+
+.config-card__save:hover,
+.config-card__save:focus {
+  background: rgba(248, 128, 60, 0.4);
+}
+
+.config-card__reset {
+  background: rgba(27, 31, 42, 0.6);
+  color: var(--lcars-muted);
+  border: 1px solid rgba(88, 178, 220, 0.25);
+}
+
+.config-card__reset:hover,
+.config-card__reset:focus {
+  background: rgba(27, 31, 42, 0.85);
+}
+
+.config-card__status {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: var(--lcars-muted);
+}
+
+.config-card__status[data-tone='success'] {
+  color: var(--lcars-success);
+}
+
+.config-card__status[data-tone='error'] {
+  color: var(--lcars-error);
+}
+
+.config-card__status[data-tone='info'] {
+  color: var(--lcars-accent-secondary);
+}
+
+.config-empty {
+  background: rgba(27, 31, 42, 0.75);
+  border: 1px solid rgba(88, 178, 220, 0.35);
+  border-radius: 1rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.config-empty h2 {
+  margin: 0 0 0.5rem;
+}
+
+.config-empty p {
+  margin: 0;
+  color: var(--lcars-muted);
+}
+
+@media (max-width: 900px) {
+  .lcars-nav {
+    position: static;
+    height: auto;
+  }
+
+  .config-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .config-card__controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/modules/pilot/packages/pilot/setup.py
+++ b/modules/pilot/packages/pilot/setup.py
@@ -17,6 +17,7 @@ setup(
         'setuptools',
         'aiohttp>=3.9,<4',
         'PyYAML>=6.0',
+        'tomli-w>=1.0',
     ],
     zip_safe=False,
     maintainer='Psyched Maintainers',


### PR DESCRIPTION
## Summary
- add backend helpers and API endpoints to expose and persist module configuration data
- ship a cockpit configuration console with navigation entry and styling updates
- cover the new behaviour with API tests for reading, updating, and validation

## Testing
- PYTHONPATH=modules/pilot/packages/pilot:$PYTHONPATH pytest modules/pilot/packages/pilot/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68ec0b83e91883209638127d846222b0