### PR TITLE
Add FELT feeling integrator module

### DIFF
--- a/modules/chat/packages/psyched_msgs/CMakeLists.txt
+++ b/modules/chat/packages/psyched_msgs/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(builtin_interfaces REQUIRED)
 set(msg_files
   "msg/HostHealth.msg"
   "msg/Message.msg"
+  "msg/FeelingIntent.msg"
+  "msg/SensationStamped.msg"
   "msg/TranscriptSegment.msg"
   "msg/TranscriptWord.msg"
   "msg/Transcript.msg"

--- a/modules/chat/packages/psyched_msgs/msg/FeelingIntent.msg
+++ b/modules/chat/packages/psyched_msgs/msg/FeelingIntent.msg
@@ -1,0 +1,16 @@
+builtin_interfaces/Time stamp
+string[] source_topics
+
+string attitude_emoji
+string thought_sentence
+string spoken_sentence
+string[] commands
+string[] goals
+string mood_delta
+
+string memory_collection_raw
+string memory_collection_text
+string memory_collection_emoji
+
+string episode_id
+string situation_id

--- a/modules/chat/packages/psyched_msgs/msg/SensationStamped.msg
+++ b/modules/chat/packages/psyched_msgs/msg/SensationStamped.msg
@@ -1,0 +1,5 @@
+builtin_interfaces/Time stamp
+string kind
+string collection_hint
+string json_payload
+float32[] vector

--- a/modules/felt/AGENTS.md
+++ b/modules/felt/AGENTS.md
@@ -1,0 +1,5 @@
+# Felt module guidelines
+
+- Add or update tests alongside code changes; run `PYTHONPATH=modules/felt/packages/felt:$PYTHONPATH pytest modules/felt/packages/felt/tests` after touching Python code.
+- Favor dependency injection for external services (LLM, rememberd) so tests can remain hermetic.
+- Keep launch and shutdown scripts POSIX-friendly and idempotent; preserve `set -euo pipefail` guards.

--- a/modules/felt/launch_unit.sh
+++ b/modules/felt/launch_unit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+export REPO_DIR
+
+ARGS=()
+
+if [[ -n "${FELT_DEBOUNCE_SECONDS:-}" ]]; then
+  ARGS+=("debounce_seconds:=${FELT_DEBOUNCE_SECONDS}")
+fi
+if [[ -n "${FELT_WINDOW_SECONDS:-}" ]]; then
+  ARGS+=("window_seconds:=${FELT_WINDOW_SECONDS}")
+fi
+
+exec ros2 launch felt felt.launch.py "${ARGS[@]}"

--- a/modules/felt/module.toml
+++ b/modules/felt/module.toml
@@ -1,0 +1,15 @@
+[unit.felt]
+apt = []
+pip = []
+launch = "modules/felt/launch_unit.sh"
+shutdown = "modules/felt/shutdown_unit.sh"
+pilot_control = "modules/felt/pilot/components/FeltModulePanel.tsx"
+
+[unit.felt.ros]
+workspace = "."
+packages = ["felt", "psyched_msgs"]
+
+[pilot]
+display_name = "Felt"
+description = "Feeling + will integrator"
+regimes = ["conversation", "navigation"]

--- a/modules/felt/packages/felt/felt/__init__.py
+++ b/modules/felt/packages/felt/felt/__init__.py
@@ -1,0 +1,15 @@
+"""Felt ROS package integrating sensations into high-level feeling intents."""
+
+from .models import FeelingIntentData, SensationRecord, SensationSummary
+from .prompt_builder import FeltPromptContext, build_prompt
+from .validators import FeelingIntentValidationError, parse_feeling_intent_json
+
+__all__ = [
+    "FeelingIntentData",
+    "SensationRecord",
+    "SensationSummary",
+    "FeltPromptContext",
+    "build_prompt",
+    "FeelingIntentValidationError",
+    "parse_feeling_intent_json",
+]

--- a/modules/felt/packages/felt/felt/memory_pipeline.py
+++ b/modules/felt/packages/felt/felt/memory_pipeline.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Sequence
+
+from .models import FeelingIntentData, SensationRecord
+
+
+@dataclass(slots=True)
+class MemoryBatch:
+    """Container for a combined rememberd vector + graph mutation request."""
+
+    feeling_id: str
+    vectors: List[Dict[str, Any]] = field(default_factory=list)
+    graph_mutations: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def _safe_json_loads(payload: str) -> Dict[str, Any]:
+    if not payload:
+        return {}
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError:
+        return {"raw": payload}
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def _default_collection(value: str, fallback: str) -> str:
+    value = value.strip()
+    return value or fallback
+
+
+def _sensation_ids(records: Iterable[SensationRecord]) -> List[str]:
+    ids: List[str] = []
+    for idx, record in enumerate(records):
+        sid = record.sensation_id()
+        if not sid:
+            sid = f"{record.topic}:{idx}"
+        ids.append(sid)
+    return ids
+
+
+def prepare_memory_batch(
+    *,
+    feeling: FeelingIntentData,
+    sensations: Sequence[SensationRecord],
+    source_topics: Sequence[str],
+    timestamp: datetime,
+    feeling_id: str,
+) -> MemoryBatch:
+    """Build the consolidated memory payload for rememberd."""
+
+    vectors: List[Dict[str, Any]] = []
+    source_topics = sorted(set(source_topics))
+    timestamp_iso = timestamp.isoformat()
+
+    emoji_collection = _default_collection(feeling.memory_collection_emoji, "emotions")
+    text_collection = _default_collection(feeling.memory_collection_text, "thoughts")
+
+    if feeling.attitude_emoji:
+        vectors.append(
+            {
+                "collection": emoji_collection,
+                "text": feeling.attitude_emoji,
+                "payload": {
+                    "kind": "emoji_attitude",
+                    "feeling_id": feeling_id,
+                    "episode_id": feeling.episode_id,
+                    "situation_id": feeling.situation_id,
+                    "source_topics": source_topics,
+                    "timestamp": timestamp_iso,
+                },
+            }
+        )
+
+    if feeling.thought_sentence:
+        vectors.append(
+            {
+                "collection": text_collection,
+                "text": feeling.thought_sentence,
+                "payload": {
+                    "kind": "thought",
+                    "feeling_id": feeling_id,
+                    "episode_id": feeling.episode_id,
+                    "situation_id": feeling.situation_id,
+                    "source_topics": source_topics,
+                    "timestamp": timestamp_iso,
+                },
+            }
+        )
+
+    for record in sensations:
+        if not record.vector:
+            continue
+        collection = _default_collection(record.collection_hint, feeling.memory_collection_raw or record.kind or "raw")
+        vectors.append(
+            {
+                "collection": collection,
+                "vector": list(record.vector),
+                "payload": {
+                    "kind": record.kind or "sensation",
+                    "sensation_id": record.sensation_id(),
+                    "topic": record.topic,
+                    "metadata": _safe_json_loads(record.json_payload),
+                    "feeling_id": feeling_id,
+                    "episode_id": feeling.episode_id,
+                    "situation_id": feeling.situation_id,
+                    "source_topics": source_topics,
+                    "timestamp": timestamp_iso,
+                },
+            }
+        )
+
+    sensation_ids = _sensation_ids(sensations)
+    graph_mutations = [
+        {
+            "cypher": (
+                "MERGE (e:Episodic {id:$episode_id})\n"
+                "MERGE (s:Situation {id:$situation_id})\n"
+                "MERGE (f:FeelingIntent {id:$feeling_id})\n"
+                "SET f.attitude_emoji=$attitude_emoji, f.thought=$thought_sentence, "
+                "f.spoken=$spoken_sentence, f.goals=$goals, f.mood_delta=$mood_delta, "
+                "f.timestamp=$timestamp, f.source_topics=$source_topics, "
+                "f.emoji_collection=$emoji_collection, f.text_collection=$text_collection\n"
+                "MERGE (e)-[:HAS_SITUATION]->(s)\n"
+                "MERGE (s)-[:EVOKED]->(f)\n"
+                "WITH f\n"
+                "UNWIND $sensation_ids AS sid\n"
+                "MERGE (z:Sensation {id:sid})\n"
+                "MERGE (z)-[:EVALUATED_AS]->(f)"
+            ),
+            "params": {
+                "episode_id": feeling.episode_id,
+                "situation_id": feeling.situation_id,
+                "feeling_id": feeling_id,
+                "attitude_emoji": feeling.attitude_emoji,
+                "thought_sentence": feeling.thought_sentence,
+                "spoken_sentence": feeling.spoken_sentence,
+                "goals": feeling.goals,
+                "mood_delta": feeling.mood_delta,
+                "timestamp": timestamp_iso,
+                "source_topics": source_topics,
+                "emoji_collection": emoji_collection,
+                "text_collection": text_collection,
+                "sensation_ids": sensation_ids,
+            },
+        }
+    ]
+
+    return MemoryBatch(feeling_id=feeling_id, vectors=vectors, graph_mutations=graph_mutations)

--- a/modules/felt/packages/felt/felt/models.py
+++ b/modules/felt/packages/felt/felt/models.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(slots=True)
+class FeelingIntentData:
+    """Structured representation of the feeling + will response.
+
+    Attributes mirror the :mod:`psyched_msgs.msg.FeelingIntent` message but are kept
+    in a plain-Python form so the validation logic and memory pipeline can operate
+    without importing ROS dependencies.  The class is intentionally lightweight so
+    unit tests can freely instantiate it.
+
+    Example
+    -------
+    >>> FeelingIntentData(
+    ...     attitude_emoji="🙂",
+    ...     thought_sentence="I should wave back.",
+    ...     spoken_sentence="Hello there!",
+    ...     commands=["say('Hello there!')"],
+    ... )
+    FeelingIntentData(attitude_emoji='🙂', thought_sentence='I should wave back.', spoken_sentence='Hello there!', commands=["say('Hello there!')"], goals=[], mood_delta='', memory_collection_raw='', memory_collection_text='', memory_collection_emoji='', episode_id='', situation_id='')
+    """
+
+    attitude_emoji: str
+    thought_sentence: str
+    spoken_sentence: str
+    commands: List[str] = field(default_factory=list)
+    goals: List[str] = field(default_factory=list)
+    mood_delta: str = ""
+    memory_collection_raw: str = ""
+    memory_collection_text: str = ""
+    memory_collection_emoji: str = ""
+    episode_id: str = ""
+    situation_id: str = ""
+
+
+@dataclass(slots=True)
+class SensationSummary:
+    """Concise description of an incoming sensation for prompt construction."""
+
+    topic: str
+    kind: str
+    collection_hint: str
+    json_payload: str
+    vector_length: int
+
+    def prompt_payload(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable payload summarising the sensation.
+
+        The summary keeps the raw metadata (if the JSON is parseable) but avoids
+        including the actual embedding vector which can be large and potentially
+        sensitive.  Instead the vector length is surfaced so the LLM is aware that
+        a raw vector exists.
+        """
+
+        import json
+
+        try:
+            payload = json.loads(self.json_payload) if self.json_payload else {}
+        except json.JSONDecodeError:
+            payload = {"raw": self.json_payload}
+
+        return {
+            "topic": self.topic,
+            "kind": self.kind,
+            "collection": self.collection_hint,
+            "payload": payload,
+            "vector_length": self.vector_length,
+        }
+
+
+@dataclass(slots=True)
+class SensationRecord:
+    """Representation of a sensation suitable for memory persistence."""
+
+    topic: str
+    kind: str
+    collection_hint: str
+    json_payload: str
+    vector: List[float] = field(default_factory=list)
+
+    @property
+    def vector_length(self) -> int:
+        """Return the length of the raw vector (0 if none)."""
+
+        return len(self.vector)
+
+    def to_summary(self) -> SensationSummary:
+        """Create a :class:`SensationSummary` for prompt construction."""
+
+        return SensationSummary(
+            topic=self.topic,
+            kind=self.kind,
+            collection_hint=self.collection_hint,
+            json_payload=self.json_payload,
+            vector_length=self.vector_length,
+        )
+
+    def sensation_id(self) -> Optional[str]:
+        """Extract a stable identifier from ``json_payload`` if available."""
+
+        import json
+
+        try:
+            payload = json.loads(self.json_payload) if self.json_payload else {}
+        except json.JSONDecodeError:
+            return None
+        value = payload.get("id")
+        return str(value) if value is not None else None

--- a/modules/felt/packages/felt/felt/node.py
+++ b/modules/felt/packages/felt/felt/node.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+from urllib import request, error
+from uuid import uuid4
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSHistoryPolicy, QoSProfile, ReliabilityPolicy
+from rosidl_runtime_py.convert import message_to_ordereddict
+from rosidl_runtime_py.utilities import get_message
+
+from psyched_msgs.msg import FeelingIntent, SensationStamped
+
+from .memory_pipeline import prepare_memory_batch
+from .models import SensationRecord
+from .prompt_builder import FeltPromptContext, build_prompt
+from .validators import FeelingIntentValidationError, parse_feeling_intent_json
+
+
+_LOGGER = logging.getLogger("psyched.felt.node")
+if not _LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [felt.node] %(message)s"))
+    _LOGGER.addHandler(handler)
+_LOGGER.setLevel(logging.INFO)
+
+
+class LLMClient:
+    """Abstract interface so tests can stub LLM calls."""
+
+    def generate(self, prompt: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OllamaLLMClient(LLMClient):
+    """HTTP client for Ollama's `/api/generate` endpoint."""
+
+    def __init__(self, model: str, host: Optional[str] = None, timeout: float = 30.0) -> None:
+        self.model = model
+        self.host = (host or os.environ.get("OLLAMA_HOST") or "http://127.0.0.1:11434").rstrip("/")
+        self.timeout = timeout
+
+    def generate(self, prompt: str) -> str:
+        payload = json.dumps({"model": self.model, "prompt": prompt, "stream": False}).encode("utf-8")
+        req = request.Request(
+            self.host + "/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout) as resp:
+                body = resp.read().decode("utf-8")
+        except Exception as exc:  # pragma: no cover - network failure path
+            raise RuntimeError(f"Failed to reach Ollama at {self.host}: {exc}") from exc
+
+        data = json.loads(body)
+        if isinstance(data, dict) and "response" in data:
+            return str(data["response"])
+        raise RuntimeError(f"Unexpected Ollama response: {data!r}")
+
+
+class RememberdClient:
+    """Minimal JSON-RPC client for rememberd."""
+
+    def __init__(self, endpoint: Optional[str] = None, timeout: float = 5.0) -> None:
+        self.endpoint = (endpoint or os.environ.get("REMEMBERD_URL", "")).strip()
+        self.timeout = timeout
+
+    def memorize(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not self.endpoint:
+            _LOGGER.debug("rememberd endpoint not configured; skipping memory write")
+            return None
+        body = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            self.endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout) as resp:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    return json.loads(resp.read().decode("utf-8"))
+                return None
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            _LOGGER.error("rememberd request failed: %s", exc)
+            return None
+
+
+def _ros_time_to_datetime(time_msg) -> datetime:
+    sec = getattr(time_msg, "sec", 0)
+    nanosec = getattr(time_msg, "nanosec", 0)
+    return datetime.fromtimestamp(float(sec) + float(nanosec) / 1e9, tz=timezone.utc)
+
+
+class FeltNode(Node):
+    """ROS node orchestrating the feeling + will integration pipeline."""
+
+    _DEFAULT_CONTEXT_TOPICS = [
+        {"topic": "/instant", "type": "std_msgs/msg/String"},
+        {"topic": "/situation", "type": "std_msgs/msg/String"},
+        {"topic": "/status", "type": "std_msgs/msg/String"},
+    ]
+    _DEFAULT_SENSATION_TOPICS = [
+        {"topic": "/sensations", "type": "psyched_msgs/msg/SensationStamped"}
+    ]
+
+    def __init__(self, *, llm_client: Optional[LLMClient] = None, rememberd: Optional[RememberdClient] = None) -> None:
+        super().__init__("felt")
+
+        self._llm_client = llm_client or OllamaLLMClient(model=os.environ.get("FELT_MODEL", "gpt-oss"))
+        self._rememberd = rememberd or RememberdClient()
+
+        self._debounce_seconds = self._declare_float_parameter("debounce_seconds", 3.0)
+        self._window_seconds = self._declare_float_parameter("window_seconds", 3.0)
+
+        self._topic_cache: Dict[str, Dict[str, Any]] = {}
+        self._sensation_records: List[tuple[float, SensationRecord]] = []
+        self._subscriptions: List[Any] = []
+        self._dirty = False
+
+        qos = QoSProfile(depth=10)
+        qos.history = QoSHistoryPolicy.KEEP_LAST
+        qos.reliability = ReliabilityPolicy.RELIABLE
+
+        self.publisher = self.create_publisher(FeelingIntent, "felt/intent", qos)
+
+        self._context_topics = self._load_topic_configs(
+            "context_topics", self._DEFAULT_CONTEXT_TOPICS, self._handle_context_message, qos
+        )
+        self._sensation_topics = self._load_topic_configs(
+            "sensation_topics", self._DEFAULT_SENSATION_TOPICS, self._handle_sensation_message, qos
+        )
+
+        self._timer = self.create_timer(self._debounce_seconds, self._on_timer)
+
+    def _declare_float_parameter(self, name: str, default: float) -> float:
+        param = self.declare_parameter(name, default)
+        value = getattr(param, "value", default)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _load_topic_configs(
+        self,
+        param_name: str,
+        default: List[Dict[str, Any]],
+        callback,
+        qos: QoSProfile,
+    ) -> Dict[str, Any]:
+        raw_param = self.declare_parameter(param_name, json.dumps(default)).value
+        if isinstance(raw_param, str):
+            try:
+                configs = json.loads(raw_param)
+            except json.JSONDecodeError:
+                self.get_logger().warning("Invalid JSON for %s, using defaults", param_name)
+                configs = default
+        elif isinstance(raw_param, list):
+            configs = raw_param
+        else:
+            configs = default
+
+        mapping: Dict[str, Any] = {}
+        for entry in configs:
+            if not isinstance(entry, dict):
+                continue
+            topic = entry.get("topic")
+            type_name = entry.get("type")
+            if not topic or not type_name:
+                continue
+            try:
+                msg_type = get_message(type_name)
+            except (AttributeError, ModuleNotFoundError, ValueError) as exc:
+                self.get_logger().error("Failed to import message type %s: %s", type_name, exc)
+                continue
+
+            subscription = self.create_subscription(msg_type, topic, lambda msg, t=topic: callback(t, msg), qos)
+            self._subscriptions.append(subscription)
+            mapping[topic] = msg_type
+        return mapping
+
+    def _handle_context_message(self, topic: str, msg: Any) -> None:
+        try:
+            data = message_to_ordereddict(msg)
+        except Exception:
+            data = str(msg)
+        self._topic_cache[topic] = {"data": data, "timestamp": time.time()}
+        self._dirty = True
+
+    def _handle_sensation_message(self, topic: str, msg: SensationStamped) -> None:
+        if not isinstance(msg, SensationStamped):
+            try:
+                data = message_to_ordereddict(msg)
+                kind = data.get("kind", "")
+                collection_hint = data.get("collection_hint", "")
+                json_payload = data.get("json_payload", "")
+                vector = list(data.get("vector", []))
+            except Exception:
+                return
+        else:
+            kind = msg.kind
+            collection_hint = msg.collection_hint
+            json_payload = msg.json_payload
+            vector = list(msg.vector)
+        record = SensationRecord(
+            topic=topic,
+            kind=kind,
+            collection_hint=collection_hint,
+            json_payload=json_payload,
+            vector=vector,
+        )
+        self._sensation_records.append((time.monotonic(), record))
+        self._dirty = True
+
+    def _recent_sensations(self) -> List[SensationRecord]:
+        cutoff = time.monotonic() - self._window_seconds
+        recent: List[tuple[float, SensationRecord]] = []
+        for timestamp, record in self._sensation_records:
+            if timestamp >= cutoff:
+                recent.append((timestamp, record))
+        self._sensation_records = recent
+        return [record for _, record in recent]
+
+    def _run_psh(self, args: Sequence[str]) -> str:
+        try:
+            proc = subprocess.run(args, check=False, capture_output=True, text=True)
+        except FileNotFoundError:
+            self.get_logger().warning("psh command not available: %s", args[0])
+            return ""
+        if proc.returncode != 0:
+            self.get_logger().warning("psh command failed (%s): %s", proc.returncode, proc.stderr.strip())
+            return ""
+        return proc.stdout
+
+    def _fetch_actions(self) -> List[str]:
+        try:
+            result = self._run_psh(["psh", "actions", "export", "--json"])
+            data = json.loads(result) if result else {}
+            actions = data.get("actions") if isinstance(data, dict) else data
+            if isinstance(actions, list):
+                return [str(action) for action in actions if isinstance(action, str)]
+        except Exception as exc:  # pragma: no cover - external command failure
+            self.get_logger().warning("Failed to fetch pilot actions: %s", exc)
+        return []
+
+    def _fetch_status(self) -> Dict[str, Any]:
+        try:
+            result = self._run_psh(["psh", "pilot", "status", "--json"])
+            data = json.loads(result) if result else {}
+            return data if isinstance(data, dict) else {}
+        except Exception as exc:  # pragma: no cover - external command failure
+            self.get_logger().warning("Failed to fetch pilot status: %s", exc)
+            return {}
+
+    def _build_prompt_context(self, actions: List[str], status: Dict[str, Any]) -> Optional[FeltPromptContext]:
+        if not self._topic_cache and not self._sensation_records:
+            return None
+        topics = {topic: entry["data"] for topic, entry in self._topic_cache.items()}
+        if status and "/status" not in topics:
+            topics["/status"] = status
+        sensations = [record.to_summary() for record in self._recent_sensations()]
+        return FeltPromptContext(
+            topics=topics,
+            status=status or topics.get("/status", {}),
+            sensations=sensations,
+            pilot_actions=actions,
+            window_seconds=self._window_seconds,
+        )
+
+    def _on_timer(self) -> None:
+        if not self._dirty and not self._sensation_records:
+            return
+        actions = self._fetch_actions()
+        status = self._fetch_status()
+        context = self._build_prompt_context(actions, status)
+        if not context:
+            return
+
+        prompt = build_prompt(context)
+        try:
+            raw_response = self._llm_client.generate(prompt)
+            feeling_data = parse_feeling_intent_json(raw_response, actions)
+        except (RuntimeError, FeelingIntentValidationError) as exc:
+            self.get_logger().error("Failed to generate FeelingIntent: %s", exc)
+            return
+
+        recent_records = self._recent_sensations()
+
+        msg = FeelingIntent()
+        msg.stamp = self.get_clock().now().to_msg()
+        source_topics = sorted(set(context.topics.keys()) | {record.topic for record in recent_records})
+        msg.source_topics = source_topics
+        msg.attitude_emoji = feeling_data.attitude_emoji
+        msg.thought_sentence = feeling_data.thought_sentence
+        msg.spoken_sentence = feeling_data.spoken_sentence
+        msg.commands = feeling_data.commands
+        msg.goals = feeling_data.goals
+        msg.mood_delta = feeling_data.mood_delta
+        msg.memory_collection_raw = feeling_data.memory_collection_raw
+        msg.memory_collection_text = feeling_data.memory_collection_text
+        msg.memory_collection_emoji = feeling_data.memory_collection_emoji
+        msg.episode_id = feeling_data.episode_id
+        msg.situation_id = feeling_data.situation_id
+
+        self.publisher.publish(msg)
+        self._dirty = False
+
+        timestamp = _ros_time_to_datetime(msg.stamp)
+        feeling_id = f"felt-{uuid4()}"
+        batch = prepare_memory_batch(
+            feeling=feeling_data,
+            sensations=recent_records,
+            source_topics=source_topics,
+            timestamp=timestamp,
+            feeling_id=feeling_id,
+        )
+        try:
+            self._rememberd.memorize(
+                {
+                    "graph_mutations": batch.graph_mutations,
+                    "vectors": batch.vectors,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - external service failure
+            self.get_logger().warning("Failed to write to rememberd: %s", exc)
+
+
+def main(args: Optional[Sequence[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = FeltNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/modules/felt/packages/felt/felt/prompt_builder.py
+++ b/modules/felt/packages/felt/felt/prompt_builder.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+from .models import SensationSummary
+
+_SYSTEM_PROMPT = """You are FELT, Pete’s feeling+will integrator. Produce one compact JSON ONLY.
+Rules:
+- \"attitude_emoji\": 1–3 Unicode emoji, NO WORDS.
+- \"thought_sentence\": exactly 1 sentence.
+- \"spoken_sentence\": 0 or 1 sentence (empty if none).
+- \"commands\": array of valid pilot actions listed below.
+- Keep JSON under 512 tokens. No commentary outside JSON."""
+
+_SCHEMA_HINT = {
+    "attitude_emoji": "🙂🤔",
+    "thought_sentence": "I should greet them and step closer to see better.",
+    "spoken_sentence": "Hey there—good to see you!",
+    "commands": ["resume_speech", "say('Hey there—good to see you!')", "move_to('person_estimated')"],
+    "goals": ["greet", "improve_viewing_conditions"],
+    "mood_delta": "uplifting",
+}
+
+
+@dataclass(slots=True)
+class FeltPromptContext:
+    """Context bundle passed to the LLM prompt renderer."""
+
+    topics: Dict[str, Any]
+    status: Dict[str, Any] | None
+    sensations: List[SensationSummary]
+    pilot_actions: List[str]
+    window_seconds: float
+
+
+def _format_topics(topics: Dict[str, Any]) -> Iterable[str]:
+    for topic, value in topics.items():
+        serialised = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        yield f"- {topic}: {serialised}"
+
+
+def _format_sensations(sensations: Iterable[SensationSummary]) -> str:
+    payloads = [s.prompt_payload() for s in sensations]
+    return json.dumps(payloads, ensure_ascii=False, sort_keys=True)
+
+
+def build_prompt(context: FeltPromptContext) -> str:
+    """Construct the single-shot LLM prompt for the feeling integrator."""
+
+    lines: List[str] = [_SYSTEM_PROMPT, "", "Context (examples merged each cycle)", "", "topics:"]
+    lines.extend(_format_topics(context.topics))
+
+    if context.status and "/status" not in context.topics:
+        lines.append(f"- /status: {json.dumps(context.status, ensure_ascii=False, sort_keys=True)}")
+
+    lines.append(
+        "- recent_sensations: "
+        + _format_sensations(context.sensations)
+    )
+    lines.append(
+        f"- window_seconds: {context.window_seconds:.2f}"
+    )
+    lines.append(
+        "pilot_actions (from `psh actions export --json`): "
+        + json.dumps(sorted(set(context.pilot_actions)), ensure_ascii=False)
+    )
+    lines.append("")
+    lines.append("Schema to emit")
+    lines.append("")
+    lines.append(json.dumps(_SCHEMA_HINT, ensure_ascii=False, indent=2))
+    return "\n".join(lines)

--- a/modules/felt/packages/felt/felt/validators.py
+++ b/modules/felt/packages/felt/felt/validators.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from typing import Iterable, Sequence
+
+from .models import FeelingIntentData
+
+
+class FeelingIntentValidationError(ValueError):
+    """Raised when the LLM response cannot be trusted."""
+
+
+_SENTENCE_TERMINATOR_PATTERN = re.compile(r"[.?!]")
+_MULTIPLE_SENTENCE_PATTERN = re.compile(r"[.?!].+?[.?!]")
+def _is_single_sentence(text: str) -> bool:
+    cleaned = " ".join(text.strip().split())
+    if not cleaned:
+        return False
+    if _MULTIPLE_SENTENCE_PATTERN.search(cleaned):
+        return False
+    terminators = _SENTENCE_TERMINATOR_PATTERN.findall(cleaned)
+    return len(terminators) <= 1
+
+
+def _is_valid_emoji_string(text: str) -> bool:
+    if not text:
+        return False
+    # Limit to 12 UTF-16 code units.
+    if len(text.encode("utf-16-le")) // 2 > 12:
+        return False
+    base_count = 0
+    for ch in text:
+        if ch.isspace():
+            return False
+        cat = unicodedata.category(ch)
+        if cat[0] in {"L", "N"} or cat[0] == "P":
+            return False
+        if cat not in {"Mn", "Me", "Cf"}:
+            base_count += 1
+    return 1 <= base_count <= 3
+
+
+def _normalise_command(command: str) -> str:
+    name = command.strip()
+    if "(" in name:
+        return name.split("(", 1)[0]
+    return name
+
+
+def _allowed_command_bases(actions: Iterable[str]) -> set[str]:
+    bases = set()
+    for action in actions:
+        action = action.strip()
+        if not action:
+            continue
+        bases.add(_normalise_command(action))
+    return bases
+
+
+def parse_feeling_intent_json(raw_json: str, allowed_actions: Sequence[str]) -> FeelingIntentData:
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise FeelingIntentValidationError("LLM output is not valid JSON") from exc
+
+    if not isinstance(payload, dict):
+        raise FeelingIntentValidationError("LLM output must be a JSON object")
+
+    attitude = str(payload.get("attitude_emoji", ""))
+    if not _is_valid_emoji_string(attitude):
+        raise FeelingIntentValidationError("attitude_emoji must contain only emoji (1-3 glyphs)")
+
+    thought = str(payload.get("thought_sentence", "")).strip()
+    if not _is_single_sentence(thought):
+        raise FeelingIntentValidationError("thought_sentence must be exactly one sentence")
+
+    spoken = str(payload.get("spoken_sentence", "")).strip()
+    if spoken and not _is_single_sentence(spoken):
+        raise FeelingIntentValidationError("spoken_sentence must be empty or a single sentence")
+
+    commands_raw = payload.get("commands", [])
+    if not isinstance(commands_raw, list) or not all(isinstance(c, str) for c in commands_raw):
+        raise FeelingIntentValidationError("commands must be a list of strings")
+
+    allowed_bases = _allowed_command_bases(allowed_actions)
+    validated_commands: list[str] = []
+    for command in commands_raw:
+        base = _normalise_command(command)
+        if base not in allowed_bases:
+            raise FeelingIntentValidationError(f"Unknown command: {command}")
+        validated_commands.append(command.strip())
+
+    goals_raw = payload.get("goals", [])
+    if not isinstance(goals_raw, list) or not all(isinstance(goal, str) for goal in goals_raw):
+        raise FeelingIntentValidationError("goals must be a list of strings")
+
+    mood_delta = str(payload.get("mood_delta", "")).strip()
+    memory_collection_raw = str(payload.get("memory_collection_raw", "")).strip()
+    memory_collection_text = str(payload.get("memory_collection_text", "")).strip()
+    memory_collection_emoji = str(payload.get("memory_collection_emoji", "")).strip()
+    episode_id = str(payload.get("episode_id", "")).strip()
+    situation_id = str(payload.get("situation_id", "")).strip()
+
+    return FeelingIntentData(
+        attitude_emoji=attitude,
+        thought_sentence=thought,
+        spoken_sentence=spoken,
+        commands=validated_commands,
+        goals=[goal.strip() for goal in goals_raw if goal.strip()],
+        mood_delta=mood_delta,
+        memory_collection_raw=memory_collection_raw,
+        memory_collection_text=memory_collection_text,
+        memory_collection_emoji=memory_collection_emoji,
+        episode_id=episode_id,
+        situation_id=situation_id,
+    )

--- a/modules/felt/packages/felt/launch/felt.launch.py
+++ b/modules/felt/packages/felt/launch/felt.launch.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    debounce_arg = DeclareLaunchArgument('debounce_seconds', default_value='3.0')
+    window_arg = DeclareLaunchArgument('window_seconds', default_value='3.0')
+
+    felt_node = Node(
+        package='felt',
+        executable='felt_node',
+        name='felt',
+        output='screen',
+        parameters=[
+            {
+                'debounce_seconds': LaunchConfiguration('debounce_seconds'),
+                'window_seconds': LaunchConfiguration('window_seconds'),
+            }
+        ],
+    )
+
+    return LaunchDescription([debounce_arg, window_arg, felt_node])

--- a/modules/felt/packages/felt/package.xml
+++ b/modules/felt/packages/felt/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="3">
+    <name>felt</name>
+    <version>0.1.0</version>
+    <description>Feeling + will integrator node.</description>
+    <maintainer email="tdreed@gmail.com">Psyched</maintainer>
+    <license>MIT</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+    <buildtool_depend>ament_python</buildtool_depend>
+
+    <exec_depend>rclpy</exec_depend>
+    <exec_depend>rosidl_runtime_py</exec_depend>
+    <exec_depend>std_msgs</exec_depend>
+    <exec_depend>psyched_msgs</exec_depend>
+    <exec_depend>builtin_interfaces</exec_depend>
+    <exec_depend>launch</exec_depend>
+    <exec_depend>launch_ros</exec_depend>
+
+    <export>
+        <build_type>ament_python</build_type>
+    </export>
+</package>

--- a/modules/felt/packages/felt/resource/felt
+++ b/modules/felt/packages/felt/resource/felt
@@ -1,0 +1,1 @@
+# Resource index for felt package

--- a/modules/felt/packages/felt/setup.cfg
+++ b/modules/felt/packages/felt/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/felt
+[install]
+install_scripts=$base/lib/felt

--- a/modules/felt/packages/felt/setup.py
+++ b/modules/felt/packages/felt/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = 'felt'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', ['launch/felt.launch.py']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Psyched',
+    maintainer_email='tdreed@gmail.com',
+    description='Feeling + will integrator producing FeelingIntent messages and memory writes.',
+    license='MIT',
+    entry_points={
+        'console_scripts': [
+            'felt_node = felt.node:main',
+        ],
+    },
+)

--- a/modules/felt/packages/felt/tests/test_memory_pipeline.py
+++ b/modules/felt/packages/felt/tests/test_memory_pipeline.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from felt.memory_pipeline import MemoryBatch, prepare_memory_batch
+from felt.models import FeelingIntentData, SensationRecord
+
+
+def test_prepare_memory_batch_includes_vectors_and_graph_links():
+    feeling = FeelingIntentData(
+        attitude_emoji="🙂",
+        thought_sentence="I should remember this moment.",
+        spoken_sentence="",
+        commands=["pause_speech"],
+        goals=["reflect"],
+        mood_delta="calming",
+        memory_collection_raw="faces",
+        memory_collection_text="thoughts",
+        memory_collection_emoji="emotions",
+        episode_id="ep1",
+        situation_id="sit1",
+    )
+
+    sensations = [
+        SensationRecord(
+            topic="/sensation/face",
+            kind="face",
+            collection_hint="faces",
+            json_payload="{\"id\": \"face_1\"}",
+            vector=[0.1, 0.2, 0.3],
+        )
+    ]
+
+    timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    batch = prepare_memory_batch(
+        feeling=feeling,
+        sensations=sensations,
+        source_topics=["/instant", "/sensation/face"],
+        timestamp=timestamp,
+        feeling_id="feel-123",
+    )
+
+    assert isinstance(batch, MemoryBatch)
+    assert batch.feeling_id == "feel-123"
+    collections = {entry.get("collection") for entry in batch.vectors}
+    assert {"faces", "thoughts", "emotions"}.issubset(collections)
+    assert batch.graph_mutations
+    params = batch.graph_mutations[0]["params"]
+    assert params["episode_id"] == "ep1"
+    assert params["sensation_ids"] == ["face_1"]
+    assert "source_topics" in params and "/instant" in params["source_topics"]

--- a/modules/felt/packages/felt/tests/test_prompt_builder.py
+++ b/modules/felt/packages/felt/tests/test_prompt_builder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from felt.prompt_builder import FeltPromptContext, SensationSummary, build_prompt
+
+
+def test_build_prompt_includes_topics_status_and_actions():
+    context = FeltPromptContext(
+        topics={"/instant": "Saw a familiar person waving.", "/status": {"speech": "paused"}},
+        status={"speech": "paused", "queue_length": 0},
+        sensations=[
+            SensationSummary(
+                topic="/sensation/face",
+                kind="face",
+                collection_hint="faces",
+                json_payload=json.dumps({"id": "f_93", "meta": {"name_hint": "Ava"}}),
+                vector_length=4,
+            )
+        ],
+        pilot_actions=["say(text)", "pause_speech"],
+        window_seconds=3.0,
+    )
+
+    prompt = build_prompt(context)
+
+    assert prompt.startswith("You are FELT")
+    assert "pause_speech" in prompt
+    assert "/instant" in prompt
+    assert "faces" in prompt
+    assert "recent_sensations" in prompt
+    assert "vector_length" in prompt

--- a/modules/felt/packages/felt/tests/test_validators.py
+++ b/modules/felt/packages/felt/tests/test_validators.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from felt.validators import FeelingIntentValidationError, parse_feeling_intent_json
+
+
+@pytest.fixture(name="allowed_actions")
+def _allowed_actions() -> list[str]:
+    return ["say(text)", "pause_speech", "resume_speech", "move_to(target)"]
+
+
+def test_parse_feeling_intent_json_success(allowed_actions):
+    payload = {
+        "attitude_emoji": "🙂🤔",
+        "thought_sentence": "I should greet them calmly.",
+        "spoken_sentence": "Hello there!",
+        "commands": ["resume_speech", "say('Hello there!')"],
+        "goals": ["greet", "inspect"],
+        "mood_delta": "uplifting",
+        "memory_collection_raw": "faces",
+        "memory_collection_text": "thoughts",
+        "memory_collection_emoji": "emotions",
+        "episode_id": "ep123",
+        "situation_id": "sit456",
+    }
+
+    result = parse_feeling_intent_json(json.dumps(payload), allowed_actions)
+
+    assert result.attitude_emoji == "🙂🤔"
+    assert result.spoken_sentence == "Hello there!"
+    assert result.commands == ["resume_speech", "say('Hello there!')"]
+    assert result.goals == ["greet", "inspect"]
+    assert result.mood_delta == "uplifting"
+    assert result.memory_collection_raw == "faces"
+    assert result.memory_collection_text == "thoughts"
+    assert result.memory_collection_emoji == "emotions"
+    assert result.episode_id == "ep123"
+    assert result.situation_id == "sit456"
+
+
+def test_parse_feeling_intent_json_rejects_bad_emoji(allowed_actions):
+    payload = {
+        "attitude_emoji": "abc",
+        "thought_sentence": "A single sentence only.",
+        "spoken_sentence": "",
+        "commands": [],
+        "goals": [],
+    }
+
+    with pytest.raises(FeelingIntentValidationError):
+        parse_feeling_intent_json(json.dumps(payload), allowed_actions)
+
+
+def test_parse_feeling_intent_json_rejects_multi_sentence_thought(allowed_actions):
+    payload = {
+        "attitude_emoji": "🙂",
+        "thought_sentence": "First sentence. Second sentence.",
+        "spoken_sentence": "",
+        "commands": [],
+        "goals": [],
+    }
+
+    with pytest.raises(FeelingIntentValidationError):
+        parse_feeling_intent_json(json.dumps(payload), allowed_actions)
+
+
+def test_parse_feeling_intent_json_rejects_unknown_command(allowed_actions):
+    payload = {
+        "attitude_emoji": "🙂",
+        "thought_sentence": "Respond with kindness.",
+        "spoken_sentence": "",
+        "commands": ["dance"],
+        "goals": [],
+    }
+
+    with pytest.raises(FeelingIntentValidationError):
+        parse_feeling_intent_json(json.dumps(payload), allowed_actions)

--- a/modules/felt/pilot/components/FeltModulePanel.tsx
+++ b/modules/felt/pilot/components/FeltModulePanel.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+/**
+ * Lightweight pilot panel for the Felt module.
+ */
+export function FeltModulePanel(): JSX.Element {
+  return (
+    <div className="felt-module-panel">
+      <h2>Felt</h2>
+      <p>
+        FELT fuses buffered sensations, pilot status, and available actions into
+        a single FeelingIntent message while streaming structured memories to
+        rememberd.
+      </p>
+    </div>
+  );
+}
+
+export default FeltModulePanel;

--- a/modules/felt/shutdown_unit.sh
+++ b/modules/felt/shutdown_unit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATTERN="ros2 launch felt felt.launch.py"
+TIMEOUT=${TIMEOUT:-10}
+
+if ! pgrep -f "${PATTERN}" >/dev/null 2>&1; then
+  echo "[felt/shutdown] No matching processes found for pattern: ${PATTERN}"
+  exit 0
+fi
+
+echo "[felt/shutdown] Sending SIGTERM to processes for: ${PATTERN}"
+pkill -TERM -f "${PATTERN}" || true
+
+for ((i = 0; i < TIMEOUT; i++)); do
+  sleep 1
+  if ! pgrep -f "${PATTERN}" >/dev/null 2>&1; then
+    echo "[felt/shutdown] All processes stopped"
+    exit 0
+  fi
+done
+
+echo "[felt/shutdown] Forcing SIGKILL for remaining processes"
+pkill -KILL -f "${PATTERN}" || true

--- a/modules/gps/packages/psyched_msgs/CMakeLists.txt
+++ b/modules/gps/packages/psyched_msgs/CMakeLists.txt
@@ -8,15 +8,18 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 set(msg_files
   "msg/HostHealth.msg"
   "msg/Message.msg"
+  "msg/FeelingIntent.msg"
+  "msg/SensationStamped.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  DEPENDENCIES std_msgs
+  DEPENDENCIES std_msgs builtin_interfaces
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/modules/gps/packages/psyched_msgs/msg/FeelingIntent.msg
+++ b/modules/gps/packages/psyched_msgs/msg/FeelingIntent.msg
@@ -1,0 +1,16 @@
+builtin_interfaces/Time stamp
+string[] source_topics
+
+string attitude_emoji
+string thought_sentence
+string spoken_sentence
+string[] commands
+string[] goals
+string mood_delta
+
+string memory_collection_raw
+string memory_collection_text
+string memory_collection_emoji
+
+string episode_id
+string situation_id

--- a/modules/gps/packages/psyched_msgs/msg/SensationStamped.msg
+++ b/modules/gps/packages/psyched_msgs/msg/SensationStamped.msg
@@ -1,0 +1,5 @@
+builtin_interfaces/Time stamp
+string kind
+string collection_hint
+string json_payload
+float32[] vector

--- a/modules/gps/packages/psyched_msgs/package.xml
+++ b/modules/gps/packages/psyched_msgs/package.xml
@@ -9,8 +9,10 @@
     <buildtool_depend>ament_cmake</buildtool_depend>
     <build_depend>rosidl_default_generators</build_depend>
     <build_depend>std_msgs</build_depend>
+    <build_depend>builtin_interfaces</build_depend>
     <exec_depend>rosidl_default_runtime</exec_depend>
     <exec_depend>std_msgs</exec_depend>
+    <exec_depend>builtin_interfaces</exec_depend>
 
     <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
## Summary
- add the FELT ROS module that composes buffered sensations into FeelingIntent messages and memory writes
- define FeelingIntent and SensationStamped interfaces in the shared psyched_msgs package
- cover prompt construction, response validation, and memory batching with unit tests

## Testing
- PYTHONPATH=modules/felt/packages/felt:$PYTHONPATH pytest modules/felt/packages/felt/tests

------
https://chatgpt.com/codex/tasks/task_e_68ec11bef86c83209f36031d9f1c6bf8