### PR TITLE
Expose cockpit git and psh controls

### DIFF
--- a/modules/pilot/packages/pilot/pilot/frontend/config/index.html
+++ b/modules/pilot/packages/pilot/pilot/frontend/config/index.html
@@ -37,7 +37,44 @@
       </header>
 
       <section class="config-toolbar" aria-label="Configuration actions">
-        <button type="button" class="config-refresh" data-role="refresh">Refresh from host manifest</button>
+        <div class="config-toolbar__actions">
+          <button type="button" class="config-action" data-role="refresh">
+            Refresh from host manifest
+          </button>
+          <button type="button" class="config-action" data-role="git-pull">
+            Git pull latest
+          </button>
+          <div
+            class="config-toolbar__group"
+            role="group"
+            aria-label="Bulk module lifecycle operations"
+          >
+            <button
+              type="button"
+              class="config-action"
+              data-role="psh-operation"
+              data-operation="module-setup"
+            >
+              psh mod setup
+            </button>
+            <button
+              type="button"
+              class="config-action"
+              data-role="psh-operation"
+              data-operation="module-up"
+            >
+              psh mod up
+            </button>
+            <button
+              type="button"
+              class="config-action"
+              data-role="psh-operation"
+              data-operation="module-down"
+            >
+              psh mod down
+            </button>
+          </div>
+        </div>
         <span class="config-status" role="status" aria-live="polite"></span>
       </section>
 

--- a/modules/pilot/packages/pilot/pilot/frontend/styles.css
+++ b/modules/pilot/packages/pilot/pilot/frontend/styles.css
@@ -1563,11 +1563,27 @@ h5.audio-oscilloscope {
 
 .config-toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
 }
 
-.config-refresh {
+.config-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.config-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-left: 0.6rem;
+  border-left: 1px solid rgba(88, 178, 220, 0.25);
+}
+
+.config-action {
   border: none;
   padding: 0.6rem 1.1rem;
   border-radius: 999px;
@@ -1575,15 +1591,27 @@ h5.audio-oscilloscope {
   color: var(--lcars-text);
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.config-refresh:hover,
-.config-refresh:focus {
+.config-action:hover,
+.config-action:focus {
   background: rgba(88, 178, 220, 0.35);
+  transform: translateY(-1px);
+}
+
+.config-action:active {
+  transform: translateY(0);
+}
+
+.config-action[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .config-status {
+  flex: 1 1 220px;
   min-height: 1.25rem;
   font-size: 0.95rem;
   color: var(--lcars-muted);


### PR DESCRIPTION
## Summary
- add backend endpoints for git pull and curated psh bulk actions and share command results
- extend the config console UI with buttons that trigger these operations and display status updates
- cover the new API handlers with pytest to ensure commands are dispatched correctly

## Testing
- PYTHONPATH=modules/pilot/packages/pilot:$PYTHONPATH pytest modules/pilot/packages/pilot/tests

------
https://chatgpt.com/codex/tasks/task_e_68ec435075248320b093e8a18f72fae8