### PR TITLE
Refine pilot dashboard styling

### DIFF
--- a/modules/chat/pilot/components/chat-dashboard.js
+++ b/modules/chat/pilot/components/chat-dashboard.js
@@ -27,45 +27,8 @@ class ChatDashboard extends LitElement {
     static styles = [
         surfaceStyles,
         css`
-      form {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-      }
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        font-size: 0.75rem;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        color: var(--metric-label-color);
-      }
-      input,
-      select,
-      textarea {
-        font: inherit;
-        padding: 0.5rem;
-        border-radius: 0.5rem;
-        border: 1px solid var(--control-surface-border);
-        background: rgba(0, 0, 0, 0.3);
-        color: var(--lcars-text);
-        font-family: var(--metric-value-font);
-      }
-      textarea {
-        resize: vertical;
-        min-height: 80px;
-        font-size: 0.85rem;
-      }
       .conversation-log {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
         max-height: 300px;
-        overflow-y: auto;
       }
       .conversation-entry {
         background: rgba(0, 0, 0, 0.3);
@@ -277,11 +240,11 @@ class ChatDashboard extends LitElement {
         const conversationStatus = this.status === 'Live' ? 'success' : this.status === 'Error' ? 'error' : undefined;
         const voiceStatusVariant = this.voiceStatus === 'Live' ? 'success' : this.voiceStatus === 'Error' ? 'error' : undefined;
         return html`
-      <div class="surface-grid surface-grid--wide">
-        <article class="surface-card">
+      <div class="surface-grid surface-grid--wide surface-grid--dense">
+        <article class="surface-card surface-card--compact">
           <h3 class="surface-card__title">Conversation Stream</h3>
           <p class="surface-status" data-variant="${conversationStatus ?? ''}">Status: ${this.status}</p>
-          <ul class="conversation-log">
+          <ul class="surface-list surface-list--scrollable conversation-log">
             ${this.messages.length === 0
                 ? html`<li class="conversation-empty">Waiting for conversation activity…</li>`
                 : this.messages.map(
@@ -298,45 +261,79 @@ class ChatDashboard extends LitElement {
           </ul>
         </article>
 
-        <article class="surface-card">
+        <article class="surface-card surface-card--compact">
           <h3 class="surface-card__title">Send to /conversation</h3>
-          <form @submit=${this.handleSendMessage}>
-            <label>
-              Role
-              <select .value=${this.composerRole} @change=${(e) => (this.composerRole = e.target.value)}>
+          <form class="surface-form surface-form--compact" @submit=${this.handleSendMessage}>
+            <label class="surface-field">
+              <span class="surface-label">Role</span>
+              <select
+                class="surface-select"
+                .value=${this.composerRole}
+                @change=${(e) => (this.composerRole = e.target.value)}
+              >
                 <option value="user">user</option>
                 <option value="assistant">assistant</option>
                 <option value="system">system</option>
                 <option value="pilot">pilot</option>
               </select>
             </label>
-            <label>
-              Speaker
-              <input type="text" .value=${this.composerSpeaker} @input=${(e) => (this.composerSpeaker = e.target.value)} placeholder="pilot" />
+            <label class="surface-field">
+              <span class="surface-label">Speaker</span>
+              <input
+                class="surface-input"
+                type="text"
+                .value=${this.composerSpeaker}
+                @input=${(e) => (this.composerSpeaker = e.target.value)}
+                placeholder="pilot"
+              />
             </label>
-            <label>
-              Confidence
-              <input type="number" step="0.01" min="0" max="1" .value=${this.composerConfidence} @input=${(e) => (this.composerConfidence = parseFloat(e.target.value))} />
+            <label class="surface-field">
+              <span class="surface-label">Confidence</span>
+              <input
+                class="surface-input surface-input--small"
+                type="number"
+                step="0.01"
+                min="0"
+                max="1"
+                .value=${this.composerConfidence}
+                @input=${(e) => (this.composerConfidence = parseFloat(e.target.value))}
+              />
             </label>
-            <label>
-              Message
-              <textarea rows="4" .value=${this.composerContent} @input=${(e) => (this.composerContent = e.target.value)} placeholder="What would you like to say?"></textarea>
+            <label class="surface-field">
+              <span class="surface-label">Message</span>
+              <textarea
+                class="surface-textarea"
+                rows="4"
+                .value=${this.composerContent}
+                @input=${(e) => (this.composerContent = e.target.value)}
+                placeholder="What would you like to say?"
+              ></textarea>
             </label>
-            <button class="surface-action" type="submit">Send</button>
+            <div class="surface-actions">
+              <button class="surface-button" type="submit">Send</button>
+            </div>
             ${this.formFeedback ? html`<p class="surface-status">${this.formFeedback}</p>` : ''}
           </form>
         </article>
 
-        <article class="surface-card">
+        <article class="surface-card surface-card--compact">
           <h3 class="surface-card__title">Voice Bridge</h3>
           <p class="surface-status" data-variant="${voiceStatusVariant ?? ''}">Status: ${this.voiceStatus}</p>
           <div class="surface-panel surface-mono voice-log">${this.voiceLast || '—'}</div>
-          <form @submit=${this.handleSendVoice}>
-            <label>
-              Speak this text
-              <textarea rows="3" .value=${this.voiceCommand} @input=${(e) => (this.voiceCommand = e.target.value)} placeholder="Hello from chat"></textarea>
+          <form class="surface-form surface-form--compact" @submit=${this.handleSendVoice}>
+            <label class="surface-field">
+              <span class="surface-label">Speak this text</span>
+              <textarea
+                class="surface-textarea"
+                rows="3"
+                .value=${this.voiceCommand}
+                @input=${(e) => (this.voiceCommand = e.target.value)}
+                placeholder="Hello from chat"
+              ></textarea>
             </label>
-            <button class="surface-action" type="submit">Send to /voice</button>
+            <div class="surface-actions">
+              <button class="surface-button" type="submit">Send to /voice</button>
+            </div>
             ${this.voiceFeedback ? html`<p class="surface-status">${this.voiceFeedback}</p>` : ''}
           </form>
         </article>

--- a/modules/memory/pilot/components/memory-dashboard.js
+++ b/modules/memory/pilot/components/memory-dashboard.js
@@ -33,58 +33,6 @@ class MemoryDashboard extends LitElement {
   static styles = [
     surfaceStyles,
     css`
-      form {
-        display: grid;
-        gap: 0.75rem;
-      }
-
-      .form-row {
-        display: grid;
-        gap: 0.5rem;
-      }
-
-      .form-row--split {
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 0.75rem;
-      }
-
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 0.35rem;
-        font-size: 0.75rem;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        color: var(--metric-label-color);
-      }
-
-      input,
-      textarea {
-        font: inherit;
-        padding: 0.6rem 0.75rem;
-        border-radius: 0.5rem;
-        border: 1px solid var(--control-surface-border);
-        background: rgba(0, 0, 0, 0.3);
-        color: var(--lcars-text);
-        font-family: var(--metric-value-font);
-      }
-
-      textarea {
-        resize: vertical;
-        min-height: 90px;
-      }
-
-      .results-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        max-height: 280px;
-        overflow-y: auto;
-      }
-
       .result-entry {
         background: rgba(0, 0, 0, 0.35);
         border: 1px solid var(--control-surface-border);
@@ -119,24 +67,26 @@ class MemoryDashboard extends LitElement {
 
   render() {
     return html`
-      <div class="surface-grid surface-grid--wide">
-        <article class="surface-card surface-card--wide">
+      <div class="surface-grid surface-grid--wide surface-grid--dense">
+        <article class="surface-card surface-card--wide surface-card--compact">
           <h3 class="surface-card__title">Memory search</h3>
           <p class="surface-status" data-variant="${this.statusTone}">${this.statusMessage}</p>
-          <form @submit=${this.handleQuerySubmit}>
-            <label>
-              Query text
+          <form class="surface-form surface-form--compact" @submit=${this.handleQuerySubmit}>
+            <label class="surface-field">
+              <span class="surface-label">Query text</span>
               <textarea
+                class="surface-textarea"
                 name="query"
                 placeholder="e.g. What did Pete observe during the afternoon patrol?"
                 .value=${this.queryText}
                 @input=${(event) => (this.queryText = event.target.value)}
               ></textarea>
             </label>
-            <div class="form-row form-row--split">
-              <label>
-                Results
+            <div class="surface-grid surface-grid--dense surface-grid--narrow">
+              <label class="surface-field">
+                <span class="surface-label">Results</span>
                 <input
+                  class="surface-input surface-input--small"
                   type="number"
                   min="1"
                   max="20"
@@ -156,7 +106,7 @@ class MemoryDashboard extends LitElement {
             </div>
           </form>
           ${this.queryResults.length
-            ? html`<ol class="results-list">
+            ? html`<ol class="surface-list surface-list--scrollable">
                 ${this.queryResults.map(
                   (entry) => html`<li class="result-entry">
                     <div class="result-entry__meta">
@@ -174,32 +124,35 @@ class MemoryDashboard extends LitElement {
             : html`<p class="surface-empty">No query results yet.</p>`}
         </article>
 
-        <article class="surface-card surface-card--wide">
+        <article class="surface-card surface-card--wide surface-card--compact">
           <h3 class="surface-card__title">Store new memory</h3>
           ${this.storeFeedback
             ? html`<p class="surface-status" data-variant="error">${this.storeFeedback}</p>`
             : ''}
-          <form @submit=${this.handleStoreSubmit}>
-            <label>
-              Title
+          <form class="surface-form surface-form--compact" @submit=${this.handleStoreSubmit}>
+            <label class="surface-field">
+              <span class="surface-label">Title</span>
               <input
+                class="surface-input"
                 type="text"
                 name="title"
                 .value=${this.storeTitle}
                 @input=${(event) => (this.storeTitle = event.target.value)}
               />
             </label>
-            <label>
-              Details
+            <label class="surface-field">
+              <span class="surface-label">Details</span>
               <textarea
+                class="surface-textarea"
                 name="body"
                 .value=${this.storeBody}
                 @input=${(event) => (this.storeBody = event.target.value)}
               ></textarea>
             </label>
-            <label>
-              Tags
+            <label class="surface-field">
+              <span class="surface-label">Tags</span>
               <input
+                class="surface-input"
                 type="text"
                 name="tags"
                 placeholder="comma,separated,tags"

--- a/modules/pilot/AGENTS.md
+++ b/modules/pilot/AGENTS.md
@@ -4,4 +4,5 @@
 - Run `PYTHONPATH=modules/pilot/packages/pilot:$PYTHONPATH pytest modules/pilot/packages/pilot/tests` after modifying backend code in this module.
 - Ensure test environments provide the runtime dependencies listed in `setup.py` (notably `aiohttp` and `PyYAML`) so pytest runs without skipping coverage.
 - Keep the cockpit frontend lightweight: static HTML, CSS, and browser JavaScript only (no bundlers or frameworks that require a build step).
+- Reuse the shared utilities in `/components/pilot-style.js` for layout, forms, and controls so dashboards stay visually consistent and compact.
 - Ensure HTTP endpoints have corresponding unit tests for their request/response contracts where practical.

--- a/modules/pilot/packages/pilot/pilot/frontend/components/pilot-style.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/components/pilot-style.js
@@ -15,23 +15,23 @@ export const surfaceStyles = css`
 
   .surface-grid {
     display: grid;
-    gap: 1rem;
+    gap: 0.85rem;
   }
 
   .surface-grid--dense {
-    gap: 0.75rem;
+    gap: 0.6rem;
   }
 
   .surface-grid--wide {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   }
 
   .surface-grid--medium {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
   .surface-grid--narrow {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 
   .surface-grid--stack {
@@ -42,12 +42,17 @@ export const surfaceStyles = css`
     background: var(--control-surface-bg);
     border: 1px solid var(--control-surface-border);
     border-radius: var(--control-surface-radius);
-    padding: var(--control-surface-padding);
+    padding: calc(var(--control-surface-padding) - 0.25rem);
     box-shadow: var(--control-surface-shadow);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
     backdrop-filter: blur(6px);
+  }
+
+  .surface-card--compact {
+    padding: calc(var(--control-surface-padding) - 0.35rem);
+    gap: 0.65rem;
   }
 
   .surface-card__title {
@@ -130,6 +135,159 @@ export const surfaceStyles = css`
     color: var(--lcars-text);
   }
 
+  .surface-form {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .surface-form--compact {
+    gap: 0.5rem;
+  }
+
+  .surface-form label,
+  .surface-card form label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--metric-label-color);
+  }
+
+  .surface-form label > input,
+  .surface-form label > select,
+  .surface-form label > textarea,
+  .surface-card form label > input,
+  .surface-card form label > select,
+  .surface-card form label > textarea {
+    font: inherit;
+    padding: 0.55rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--control-surface-border);
+    background: rgba(0, 0, 0, 0.28);
+    color: var(--lcars-text);
+    font-family: var(--metric-value-font);
+    box-sizing: border-box;
+  }
+
+  .surface-form label > textarea,
+  .surface-card form label > textarea {
+    resize: vertical;
+    min-height: 80px;
+  }
+
+  .surface-form label > select,
+  .surface-card form label > select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, rgba(255, 255, 255, 0.45) 50%),
+      linear-gradient(135deg, rgba(255, 255, 255, 0.45) 50%, transparent 50%),
+      linear-gradient(to right, transparent, transparent);
+    background-position: calc(100% - 18px) calc(50% - 4px), calc(100% - 13px) calc(50% - 4px), calc(100% - 2.1rem) 0.45rem;
+    background-size: 6px 6px, 6px 6px, 1px 70%;
+    background-repeat: no-repeat;
+  }
+
+  .surface-card form {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .surface-fieldset {
+    margin: 0;
+    padding: 0;
+    border: none;
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .surface-fieldset--inline {
+    gap: 0.5rem;
+  }
+
+  .surface-legend {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--metric-label-color);
+  }
+
+  .surface-field {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .surface-field--inline {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .surface-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--metric-label-color);
+  }
+
+  .surface-input,
+  .surface-select,
+  .surface-textarea,
+  .surface-input[type='number'],
+  .surface-input[type='text'],
+  .surface-input[type='password'],
+  .surface-input[type='search'] {
+    font: inherit;
+    padding: 0.55rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--control-surface-border);
+    background: rgba(0, 0, 0, 0.28);
+    color: var(--lcars-text);
+    font-family: var(--metric-value-font);
+    box-sizing: border-box;
+  }
+
+  .surface-input--small,
+  .surface-select--small {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.8rem;
+  }
+
+  .surface-textarea {
+    resize: vertical;
+    min-height: 80px;
+  }
+
+  .surface-select {
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, rgba(255, 255, 255, 0.4) 50%),
+      linear-gradient(135deg, rgba(255, 255, 255, 0.4) 50%, transparent 50%),
+      linear-gradient(to right, transparent, transparent);
+    background-position: calc(100% - 20px) calc(50% - 4px), calc(100% - 15px) calc(50% - 4px), calc(100% - 2.2rem) 0.45rem;
+    background-size: 6px 6px, 6px 6px, 1px 70%;
+    background-repeat: no-repeat;
+  }
+
+  .surface-select:focus {
+    outline: none;
+    border-color: rgba(88, 178, 220, 0.8);
+    box-shadow: 0 0 0 2px rgba(88, 178, 220, 0.25);
+  }
+
+  .surface-input:focus,
+  .surface-textarea:focus {
+    outline: none;
+    border-color: rgba(88, 178, 220, 0.7);
+    box-shadow: 0 0 0 2px rgba(88, 178, 220, 0.2);
+  }
+
+  .surface-input[disabled],
+  .surface-textarea[disabled],
+  .surface-select[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   .surface-log {
     list-style: none;
     margin: 0;
@@ -164,24 +322,83 @@ export const surfaceStyles = css`
     gap: 0.5rem;
   }
 
-  .surface-action {
-    background: rgba(88, 178, 220, 0.2);
-    border: 1px solid var(--control-surface-border);
-    border-radius: 0.5rem;
-    padding: 0.6rem 0.85rem;
+  .surface-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(88, 178, 220, 0.25);
+    color: var(--lcars-text);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+  }
+
+  .surface-button:hover,
+  .surface-button:focus {
+    outline: none;
+    background: rgba(88, 178, 220, 0.4);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  }
+
+  .surface-button[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  .surface-button--ghost {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--lcars-muted);
+  }
+
+  .surface-button--critical {
+    background: rgba(255, 111, 97, 0.25);
+    color: var(--lcars-error);
+  }
+
+  .surface-button--success {
+    background: rgba(92, 209, 132, 0.28);
+    color: var(--lcars-success);
+  }
+
+  .surface-action {
+    background: rgba(88, 178, 220, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 999px;
+    padding: 0.45rem 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
     font-size: 0.7rem;
     font-weight: 600;
     color: var(--lcars-text);
     cursor: pointer;
-    transition: background 150ms ease, transform 150ms ease;
+    transition: background 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
   }
 
   .surface-action:hover,
   .surface-action:focus {
-    background: rgba(88, 178, 220, 0.35);
+    background: rgba(88, 178, 220, 0.4);
     transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  }
+
+  .surface-action[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
   }
 
   .surface-panel {
@@ -189,6 +406,65 @@ export const surfaceStyles = css`
     border: 1px solid var(--control-surface-border);
     border-radius: 0.5rem;
     padding: 0.5rem;
+  }
+
+  .surface-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .surface-list--scrollable {
+    max-height: 260px;
+    overflow-y: auto;
+  }
+
+  .surface-empty {
+    margin: 0;
+    text-align: center;
+    font-size: 0.85rem;
+    font-style: italic;
+    color: var(--lcars-muted);
+  }
+
+  .surface-note {
+    font-size: 0.75rem;
+    color: var(--lcars-muted);
+  }
+
+  .surface-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .surface-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.1);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .surface-pill[data-variant='success'] {
+    background: rgba(92, 209, 132, 0.25);
+    color: var(--lcars-success);
+  }
+
+  .surface-pill[data-variant='muted'] {
+    color: var(--lcars-muted);
   }
 
   .surface-mono {


### PR DESCRIPTION
## Summary
- tighten the shared pilot surface styles to shrink card padding, grid breakpoints, and provide common form/button/list helpers
- refactor the chat and memory dashboards to consume the compact shared surface utilities for forms, lists, and actions
- remind contributors via the pilot AGENTS guide to reuse the shared styling primitives when updating dashboards

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68ec7740adec83209c4adb2af9126e68