### PR TITLE
Add pilot dashboards for sensory modules

### DIFF
--- a/modules/pilot/AGENTS.md
+++ b/modules/pilot/AGENTS.md
@@ -6,3 +6,4 @@
 - Keep the cockpit frontend lightweight: static HTML, CSS, and browser JavaScript only (no bundlers or frameworks that require a build step).
 - Reuse the shared utilities in `/components/pilot-style.js` for layout, forms, and controls so dashboards stay visually consistent and compact.
 - Ensure HTTP endpoints have corresponding unit tests for their request/response contracts where practical.
+- When introducing new module dashboards, register the component tag in `pilot/frontend/components/pilot-app.js` so the cockpit can render it.

--- a/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
@@ -2,13 +2,19 @@ import { LitElement, html } from 'https://unpkg.com/lit@3.1.4/index.js?module';
 
 // Component registry - maps module names to their component tag names
 const MODULE_COMPONENTS = {
-  foot: 'foot-dashboard',
-  imu: 'imu-dashboard',
   chat: 'chat-dashboard',
-  voice: 'voice-dashboard',
+  ear: 'ear-dashboard',
+  eye: 'eye-dashboard',
+  faces: 'faces-dashboard',
+  felt: 'felt-dashboard',
+  foot: 'foot-dashboard',
+  gps: 'gps-dashboard',
   hypothalamus: 'hypothalamus-dashboard',
-  viscera: 'viscera-dashboard',
+  imu: 'imu-dashboard',
+  memory: 'memory-dashboard',
   nav: 'nav-dashboard',
+  viscera: 'viscera-dashboard',
+  voice: 'voice-dashboard',
 };
 
 /**
@@ -171,13 +177,19 @@ class PilotApp extends LitElement {
   renderComponent(tagName) {
     // Create the component element dynamically based on tag name
     const tagMap = {
-      'foot-dashboard': html`<foot-dashboard></foot-dashboard>`,
-      'imu-dashboard': html`<imu-dashboard></imu-dashboard>`,
       'chat-dashboard': html`<chat-dashboard></chat-dashboard>`,
-      'voice-dashboard': html`<voice-dashboard></voice-dashboard>`,
+      'ear-dashboard': html`<ear-dashboard></ear-dashboard>`,
+      'eye-dashboard': html`<eye-dashboard></eye-dashboard>`,
+      'faces-dashboard': html`<faces-dashboard></faces-dashboard>`,
+      'felt-dashboard': html`<felt-dashboard></felt-dashboard>`,
+      'foot-dashboard': html`<foot-dashboard></foot-dashboard>`,
+      'gps-dashboard': html`<gps-dashboard></gps-dashboard>`,
       'hypothalamus-dashboard': html`<hypothalamus-dashboard></hypothalamus-dashboard>`,
-      'viscera-dashboard': html`<viscera-dashboard></viscera-dashboard>`,
+      'imu-dashboard': html`<imu-dashboard></imu-dashboard>`,
+      'memory-dashboard': html`<memory-dashboard></memory-dashboard>`,
       'nav-dashboard': html`<nav-dashboard></nav-dashboard>`,
+      'viscera-dashboard': html`<viscera-dashboard></viscera-dashboard>`,
+      'voice-dashboard': html`<voice-dashboard></voice-dashboard>`,
     };
     return tagMap[tagName] || html`<p>Component ${tagName} not found</p>`;
   }


### PR DESCRIPTION
## Summary
- register the ear, eye, faces, felt, gps, and memory module dashboards with the pilot shell so they render in the cockpit
- document the registration step in the pilot module handbook for future dashboard additions

## Testing
- PYTHONPATH=modules/pilot/packages/pilot:$PYTHONPATH pytest modules/pilot/packages/pilot/tests/test_module_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68ec7ba77c6083209729fac09033a5f3