### PR TITLE
Fix pilot sidebar navigation initialization

### DIFF
--- a/modules/pilot/AGENTS.md
+++ b/modules/pilot/AGENTS.md
@@ -7,3 +7,4 @@
 - Reuse the shared utilities in `/components/pilot-style.js` for layout, forms, and controls so dashboards stay visually consistent and compact.
 - Ensure HTTP endpoints have corresponding unit tests for their request/response contracts where practical.
 - When introducing new module dashboards, register the component tag in `pilot/frontend/components/pilot-app.js` so the cockpit can render it.
+- Frontend navigation helpers now have Node-based tests—run `node --test modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js` after editing them to keep the pilot sidebar aligned with the rendered modules.

--- a/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
@@ -1,4 +1,5 @@
 import { LitElement, html } from 'https://unpkg.com/lit@3.1.4/index.js?module';
+import { buildNavigationSections } from '../utils/navigation.js';
 
 // Component registry - maps module names to their component tag names
 const MODULE_COMPONENTS = {
@@ -107,26 +108,16 @@ class PilotApp extends LitElement {
     if (typeof window === 'undefined') {
       return;
     }
-    const detail = [
-      {
-        id: 'pilot-config',
-        label: 'Module Configuration',
-        index: 0,
-        url: '/config/',
-      },
-    ];
-    let index = 1;
-    for (const module of this.modules) {
-      const slug = module.slug || module.name;
-      if (!slug) continue;
-      detail.push({
-        id: `module-${slug}`,
-        label: module.display_name || module.name,
-        index: index++,
-        url: module.dashboard_url || (module.has_pilot ? `/modules/${module.name}/` : undefined),
-      });
-    }
-    window.dispatchEvent(new CustomEvent('pilot-sections', { detail }));
+
+    const sections = buildNavigationSections(this.modules);
+    const pilotGlobals = window.Pilot ? { ...window.Pilot } : {};
+    pilotGlobals.navigation = {
+      ...(pilotGlobals.navigation || {}),
+      sections,
+    };
+    window.Pilot = pilotGlobals;
+
+    window.dispatchEvent(new CustomEvent('pilot-sections', { detail: sections }));
   }
 
   render() {

--- a/modules/pilot/packages/pilot/pilot/frontend/index.html
+++ b/modules/pilot/packages/pilot/pilot/frontend/index.html
@@ -69,6 +69,17 @@
                 }
               }
             };
+            const applySections = (sections) => {
+              if (!Array.isArray(sections)) {
+                return;
+              }
+              this.sections = sections.map((section) => ({ ...section }));
+              this.topSectionId = this.sections.length ? this.sections[0].id : null;
+              if (this.sections.length && !this.activeId) {
+                this.activeId = this.sections[0].id;
+              }
+              updateActive();
+            };
             this.scrollTo = (id) => {
               const node = document.getElementById(id);
               if (node) {
@@ -82,14 +93,15 @@
             };
             this.padIndex = (value) => String(value + 1).padStart(2, '0');
             window.addEventListener('pilot-sections', (event) => {
-              this.sections = event.detail || [];
-              this.topSectionId = this.sections.length ? this.sections[0].id : null;
-              if (this.sections.length && !this.activeId) {
-                this.activeId = this.sections[0].id;
-              }
-              updateActive();
+              applySections(event.detail);
             });
             window.addEventListener('scroll', updateActive, { passive: true });
+            const cachedSections = window.Pilot && window.Pilot.navigation && Array.isArray(window.Pilot.navigation.sections)
+              ? window.Pilot.navigation.sections
+              : null;
+            if (cachedSections && cachedSections.length) {
+              applySections(cachedSections);
+            }
           },
         };
       }

--- a/modules/pilot/packages/pilot/pilot/frontend/utils/navigation.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/utils/navigation.js
@@ -1,0 +1,70 @@
+/**
+ * Build navigation section descriptors for the pilot sidebar.
+ *
+ * The helper mirrors the module sections rendered by <pilot-app> so the
+ * Alpine-powered navigation can keep pace even when the custom element fires
+ * its update event before Alpine attaches listeners.
+ *
+ * @example
+ * buildNavigationSections([{ name: 'imu', slug: 'imu', has_pilot: true }])
+ * // => [
+ * //      { id: 'pilot-config', label: 'Module Configuration', index: 0, url: '/config/' },
+ * //      { id: 'module-imu', label: 'imu', index: 1, url: '/modules/imu/' }
+ * //    ]
+ *
+ * @param {Array<object>} modules - Module payloads from the /api/modules endpoint.
+ * @returns {Array<object>} Ordered navigation section descriptors.
+ */
+export function buildNavigationSections(modules) {
+  const sections = [
+    {
+      id: 'pilot-config',
+      label: 'Module Configuration',
+      index: 0,
+      url: '/config/',
+    },
+  ];
+
+  if (!Array.isArray(modules)) {
+    return sections;
+  }
+
+  let index = 1;
+  for (const module of modules) {
+    if (!module || typeof module !== 'object') {
+      continue;
+    }
+
+    const name = typeof module.name === 'string' ? module.name : '';
+    const slugCandidate = typeof module.slug === 'string' ? module.slug.trim() : '';
+    const slug = slugCandidate || name;
+    if (!slug) {
+      continue;
+    }
+
+    const displayName = typeof module.display_name === 'string' && module.display_name.trim()
+      ? module.display_name.trim()
+      : name || slug;
+
+    const entry = {
+      id: `module-${slug}`,
+      label: displayName,
+      index: index++,
+    };
+
+    const dashboardUrl = typeof module.dashboard_url === 'string' && module.dashboard_url.trim()
+      ? module.dashboard_url.trim()
+      : '';
+    const hasPilot = Boolean(module.has_pilot);
+
+    if (dashboardUrl) {
+      entry.url = dashboardUrl;
+    } else if (hasPilot && name) {
+      entry.url = `/modules/${name}/`;
+    }
+
+    sections.push(entry);
+  }
+
+  return sections;
+}

--- a/modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildNavigationSections } from './navigation.js';
+
+test('includes the configuration section first', () => {
+  const sections = buildNavigationSections([]);
+  assert.equal(sections.length, 1);
+  assert.deepEqual(sections[0], {
+    id: 'pilot-config',
+    label: 'Module Configuration',
+    index: 0,
+    url: '/config/',
+  });
+});
+
+test('appends dashboard sections for known modules in order', () => {
+  const sections = buildNavigationSections([
+    { name: 'imu', display_name: 'IMU', slug: 'imu', has_pilot: true },
+    { name: 'voice', display_name: 'Voice', slug: 'voice', dashboard_url: '/modules/voice/' },
+  ]);
+
+  assert.equal(sections.length, 3);
+  assert.deepEqual(sections[1], {
+    id: 'module-imu',
+    label: 'IMU',
+    index: 1,
+    url: '/modules/imu/',
+  });
+  assert.deepEqual(sections[2], {
+    id: 'module-voice',
+    label: 'Voice',
+    index: 2,
+    url: '/modules/voice/',
+  });
+});
+
+test('skips entries without slugs or names and preserves numbering', () => {
+  const sections = buildNavigationSections([
+    { slug: '', display_name: 'Missing Name' },
+    { name: 'gps', display_name: 'GPS Dashboard', has_pilot: true },
+  ]);
+
+  assert.equal(sections.length, 2);
+  assert.deepEqual(sections[1], {
+    id: 'module-gps',
+    label: 'GPS Dashboard',
+    index: 1,
+    url: '/modules/gps/',
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the pilot app broadcasts navigation data through a shared helper so listeners stay in sync with rendered modules
- update the static pilot shell to hydrate cached navigation entries when Alpine initialises and document the new test workflow
- add unit coverage for the navigation helper to keep module links aligned with the dashboard

## Testing
- node --test modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed3ab7c31c83209c00bc3616ed91e7