### PR TITLE
Fix pilot nav binding to Alpine data scope

### DIFF
--- a/modules/pilot/AGENTS.md
+++ b/modules/pilot/AGENTS.md
@@ -8,3 +8,4 @@
 - Ensure HTTP endpoints have corresponding unit tests for their request/response contracts where practical.
 - When introducing new module dashboards, register the component tag in `pilot/frontend/components/pilot-app.js` so the cockpit can render it.
 - Frontend navigation helpers now have Node-based tests—run `node --test modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js` after editing them to keep the pilot sidebar aligned with the rendered modules.
+- After editing `pilot/frontend/index.html`, run `node --test modules/pilot/packages/pilot/pilot/frontend/index.test.js` to verify the Alpine-bound navigation stays connected to its data scope.

--- a/modules/pilot/packages/pilot/pilot/frontend/index.html
+++ b/modules/pilot/packages/pilot/pilot/frontend/index.html
@@ -11,8 +11,8 @@
     <script type="module" src="/app.js"></script>
   </head>
 
-  <body x-data="pilotNav()" x-init="init()" class="lcars-body">
-    <aside class="lcars-nav">
+  <body class="lcars-body">
+    <nav x-data="pilotNav()" x-init="init()" class="lcars-nav" aria-label="Pilot navigation">
       <div class="nav-title">PSYCHED PILOT</div>
       <template x-for="section in sections" :key="section.id">
         <div class="nav-item">
@@ -36,7 +36,7 @@
           </template>
         </div>
       </template>
-    </aside>
+    </nav>
 
     <main class="lcars-main">
       <header class="lcars-hero" id="pilot-config">
@@ -107,5 +107,4 @@
       }
     </script>
   </body>
-</html>
 </html>

--- a/modules/pilot/packages/pilot/pilot/frontend/index.test.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/index.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const pilotIndexHtml = readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+
+test('anchors the pilot navigation inside the Alpine component', () => {
+  assert.ok(
+    /<nav[^>]*\s+x-data="pilotNav\(\)"[^>]*class="lcars-nav"/i.test(pilotIndexHtml),
+    'navigation should be a nav element that participates in the Alpine program',
+  );
+  assert.ok(
+    !/<body[^>]*\s+x-data="pilotNav\(\)"/.test(pilotIndexHtml),
+    'the body should not host the Alpine data scope so the nav can receive updates',
+  );
+});
+
+test('keeps the navigation adjacent to the main content column', () => {
+  const navIndex = pilotIndexHtml.indexOf('<nav');
+  const mainIndex = pilotIndexHtml.indexOf('<main');
+  assert.ok(navIndex !== -1, 'nav element should be present');
+  assert.ok(mainIndex !== -1, 'main element should be present');
+  assert.ok(navIndex < mainIndex, 'nav should render before the main content to maintain layout');
+});


### PR DESCRIPTION
## Summary
- convert the pilot sidebar to a nav element scoped inside the Alpine component so module sections render
- document the new layout regression check in the pilot module agent guidelines
- add a Node-based regression test that verifies the navigation markup stays adjacent to the main column and bound to its data scope

## Testing
- node --test modules/pilot/packages/pilot/pilot/frontend/index.test.js modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed429900c4832098c86d0fce8655ed