### PR TITLE
Simplify module launch command

### DIFF
--- a/tools/psh/lib/module_test.ts
+++ b/tools/psh/lib/module_test.ts
@@ -6,7 +6,6 @@ import {
   assertStringIncludes,
 } from "$std/testing/asserts.ts";
 import { delay } from "$std/async/delay.ts";
-import { join } from "$std/path/mod.ts";
 import { colors } from "$cliffy/ansi/colors.ts";
 import {
   AptPackagePlanner,
@@ -21,7 +20,6 @@ import {
   RosBuildPlanner,
   RosBuildPlannerRunner,
 } from "./module.ts";
-import { repoRoot } from "./paths.ts";
 
 Deno.test("listModules discovers known modules", () => {
   const modules = listModules();
@@ -41,32 +39,14 @@ Deno.test("moduleStatuses reports state for each module", () => {
   }
 });
 
-Deno.test("composeLaunchCommand directs streams through the prefix helper", () => {
+Deno.test("composeLaunchCommand prepares a direct module launch", () => {
   const command = composeLaunchCommand({
     envCommands: ["source /tmp/env"],
     launchScript: "/tmp/launch.sh",
     logFile: "/var/log/demo module.log",
     module: "demo module",
   });
-  const prefixScript = join(
-    repoRoot(),
-    "tools",
-    "psh",
-    "scripts",
-    "prefix_logs.sh",
-  );
-  assertStringIncludes(
-    command,
-    "source /tmp/env && exec bash '/tmp/launch.sh'",
-  );
-  assertStringIncludes(
-    command,
-    `> >('${prefixScript}' 'demo module' 'stdout' | tee -a '/var/log/demo module.log')`,
-  );
-  assertStringIncludes(
-    command,
-    `2> >('${prefixScript}' 'demo module' 'stderr' | tee -a '/var/log/demo module.log' >&2)`,
-  );
+  assertEquals(command, "source /tmp/env && exec '/tmp/launch.sh'");
 });
 
 Deno.test("composeLaunchCommand escapes single quotes", () => {


### PR DESCRIPTION
## Summary
- run module launch scripts directly instead of piping through the log prefix helper
- update module launch tests to reflect the simplified invocation

## Testing
- not run (deno unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed4188d8448320a3eaafd45cc4dc88