### PR TITLE
Add pilot module cockpit dashboard

### DIFF
--- a/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
+++ b/modules/pilot/packages/pilot/pilot/frontend/components/pilot-app.js
@@ -15,6 +15,7 @@ const MODULE_COMPONENTS = {
   imu: 'imu-dashboard',
   memory: 'memory-dashboard',
   nav: 'nav-dashboard',
+  pilot: 'pilot-dashboard',
   viscera: 'viscera-dashboard',
   voice: 'voice-dashboard',
 };
@@ -183,6 +184,7 @@ class PilotApp extends LitElement {
       'imu-dashboard': html`<imu-dashboard></imu-dashboard>`,
       'memory-dashboard': html`<memory-dashboard></memory-dashboard>`,
       'nav-dashboard': html`<nav-dashboard></nav-dashboard>`,
+      'pilot-dashboard': html`<pilot-dashboard></pilot-dashboard>`,
       'viscera-dashboard': html`<viscera-dashboard></viscera-dashboard>`,
       'voice-dashboard': html`<voice-dashboard></voice-dashboard>`,
     };

--- a/modules/pilot/packages/pilot/tests/test_api.py
+++ b/modules/pilot/packages/pilot/tests/test_api.py
@@ -170,6 +170,10 @@ async def _exercise_modules_endpoint(config_file: Path, tmp_path: Path) -> None:
     imu_entry = next(module for module in modules if module["name"] == "imu")
     assert imu_entry["has_pilot"] is True
 
+    pilot_entry = next(module for module in modules if module["name"] == "pilot")
+    assert pilot_entry["has_pilot"] is True
+    assert pilot_entry["dashboard_url"].endswith("/modules/pilot/")
+
     viscera_entry = next(module for module in modules if module["name"] == "viscera")
     assert viscera_entry["has_pilot"] is True
     assert viscera_entry["dashboard_url"].endswith("/modules/viscera/")

--- a/modules/pilot/packages/pilot/tests/test_module_catalog.py
+++ b/modules/pilot/packages/pilot/tests/test_module_catalog.py
@@ -31,3 +31,15 @@ def test_nav_module_reports_pilot_dashboard() -> None:
 
     assert nav_info.pilot_assets is True
     assert nav_info.dashboard_url.endswith("/modules/nav/")
+
+
+def test_pilot_module_surfaces_self_dashboard() -> None:
+    """Pilot should expose a cockpit dashboard for its own orchestration tools."""
+
+    modules_root = REPO_ROOT / "modules"
+    catalog = ModuleCatalog(modules_root)
+
+    pilot_info = catalog.get_module("pilot")
+
+    assert pilot_info.pilot_assets is True
+    assert pilot_info.dashboard_url.endswith("/modules/pilot/")

--- a/modules/pilot/pilot/components/pilot-dashboard.helpers.js
+++ b/modules/pilot/pilot/components/pilot-dashboard.helpers.js
@@ -1,0 +1,129 @@
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '', '0.0.0.0']);
+
+/**
+ * Normalise host metadata returned by the pilot backend.
+ *
+ * @param {object | null | undefined} hostRaw Host payload from /api/modules.
+ * @returns {{ name: string, shortname: string }} Display-friendly metadata.
+ */
+export function normaliseHostMetadata(hostRaw) {
+  const host = typeof hostRaw === 'object' && hostRaw !== null ? hostRaw : {};
+  const rawName = typeof host.name === 'string' && host.name.trim() ? host.name.trim() : '';
+  const rawShortname = typeof host.shortname === 'string' && host.shortname.trim()
+    ? host.shortname.trim()
+    : '';
+  const shortname = rawShortname || (rawName ? rawName.split('.')[0] : '') || 'host';
+  const name = rawName || shortname;
+  return { name, shortname };
+}
+
+/**
+ * Summarise module metadata for pilot dashboards.
+ *
+ * @param {Array<object>} modulesRaw Modules array from /api/modules.
+ * @returns {{ total: number, withPilot: number, withoutPilot: number, modules: Array<object> }}
+ */
+export function summariseModules(modulesRaw) {
+  const modules = Array.isArray(modulesRaw) ? modulesRaw : [];
+  const normalised = [];
+  const seen = new Set();
+
+  for (const entry of modules) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+    const slugCandidate = typeof entry.slug === 'string' ? entry.slug.trim() : '';
+    const slug = slugCandidate || name;
+    if (!slug) {
+      continue;
+    }
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+
+    const displayName = typeof entry.display_name === 'string' && entry.display_name.trim()
+      ? entry.display_name.trim()
+      : name || slug;
+    const description = typeof entry.description === 'string' ? entry.description.trim() : '';
+    const hasPilot = Boolean(entry.has_pilot);
+    const dashboardUrlRaw = typeof entry.dashboard_url === 'string' ? entry.dashboard_url.trim() : '';
+    const dashboardUrl = dashboardUrlRaw || (hasPilot && name ? `/modules/${name}/` : '');
+
+    normalised.push({ name, slug, displayName, description, hasPilot, dashboardUrl });
+  }
+
+  normalised.sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }));
+
+  const withPilot = normalised.filter((module) => module.hasPilot).length;
+  const total = normalised.length;
+  const withoutPilot = total - withPilot;
+
+  return { total, withPilot, withoutPilot, modules: normalised };
+}
+
+/**
+ * Normalise bridge configuration so dashboards can surface operator hints.
+ *
+ * @param {object | null | undefined} bridgeRaw Bridge metadata from /api/modules.
+ * @param {Location | { protocol?: string, hostname?: string, href?: string } | null} [location]
+ *   Optional location-like value used to resolve relative rosbridge URLs during tests.
+ * @returns {{
+ *   mode: string,
+ *   rosbridgeUri: string,
+ *   effectiveRosbridgeUri: string,
+ *   videoBase: string,
+ *   videoPort: number | null,
+ * }}
+ */
+export function normaliseBridgeSettings(bridgeRaw, location = typeof window !== 'undefined' ? window.location : undefined) {
+  const bridge = typeof bridgeRaw === 'object' && bridgeRaw !== null ? bridgeRaw : {};
+  const mode = typeof bridge.mode === 'string' && bridge.mode.trim() ? bridge.mode.trim() : 'rosbridge';
+  const rosbridgeUri = typeof bridge.rosbridge_uri === 'string' && bridge.rosbridge_uri.trim()
+    ? bridge.rosbridge_uri.trim()
+    : 'ws://127.0.0.1:9090';
+  const videoBase = typeof bridge.video_base === 'string' && bridge.video_base.trim() ? bridge.video_base.trim() : '';
+  const videoPort = Number.isFinite(bridge.video_port) ? Number(bridge.video_port) : null;
+
+  const effectiveRosbridgeUri = resolveRosbridgeUri(rosbridgeUri, location);
+
+  return { mode, rosbridgeUri, effectiveRosbridgeUri, videoBase, videoPort };
+}
+
+function resolveRosbridgeUri(rawUri, location) {
+  const fallbackProtocol = location && location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const fallbackHost = location && location.hostname ? location.hostname : '127.0.0.1';
+  const baseHref = location && location.href ? location.href : undefined;
+
+  try {
+    const url = new URL(rawUri, baseHref);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    }
+    if (LOOPBACK_HOSTS.has(url.hostname)) {
+      url.hostname = fallbackHost;
+    }
+    if (!url.port) {
+      const parsedPort = extractPort(rawUri, baseHref);
+      url.port = parsedPort || '9090';
+    }
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      url.protocol = fallbackProtocol;
+    }
+    return url.toString();
+  } catch (_error) {
+    return `${fallbackProtocol}//${fallbackHost}:9090`;
+  }
+}
+
+function extractPort(rawUri, baseHref) {
+  try {
+    const url = new URL(rawUri, baseHref);
+    return url.port;
+  } catch (_error) {
+    return '';
+  }
+}
+
+export const __test__ = { resolveRosbridgeUri };

--- a/modules/pilot/pilot/components/pilot-dashboard.helpers.test.js
+++ b/modules/pilot/pilot/components/pilot-dashboard.helpers.test.js
@@ -1,0 +1,56 @@
+import {
+  normaliseHostMetadata,
+  summariseModules,
+  normaliseBridgeSettings,
+  __test__,
+} from './pilot-dashboard.helpers.js';
+
+Deno.test('normaliseHostMetadata falls back to derived shortname', () => {
+  const host = normaliseHostMetadata({ name: 'pete.local' });
+  if (host.shortname !== 'pete') {
+    throw new Error(`expected shortname to be pete but received ${host.shortname}`);
+  }
+  const fallback = normaliseHostMetadata(null);
+  if (fallback.name !== 'host' || fallback.shortname !== 'host') {
+    throw new Error('missing metadata should fall back to host');
+  }
+});
+
+Deno.test('summariseModules deduplicates payloads and counts dashboards', () => {
+  const summary = summariseModules([
+    { name: 'imu', slug: 'imu', display_name: 'IMU', has_pilot: true },
+    { name: 'imu', slug: 'imu', has_pilot: true },
+    { name: 'pilot', display_name: 'Pilot', has_pilot: false },
+    { name: '', slug: '', has_pilot: true },
+  ]);
+  if (summary.total !== 2) {
+    throw new Error(`expected 2 modules but received ${summary.total}`);
+  }
+  if (summary.withPilot !== 1 || summary.withoutPilot !== 1) {
+    throw new Error(`unexpected pilot counts: ${summary.withPilot}/${summary.withoutPilot}`);
+  }
+  if (summary.modules[0].displayName !== 'IMU') {
+    throw new Error('modules should be sorted by display name');
+  }
+  if (!summary.modules[0].dashboardUrl.endsWith('/modules/imu/')) {
+    throw new Error('dashboard URL should default to module route');
+  }
+});
+
+Deno.test('normaliseBridgeSettings resolves relative rosbridge URLs', () => {
+  const location = { protocol: 'https:', hostname: 'pilot.example', href: 'https://pilot.example/dashboard' };
+  const bridge = normaliseBridgeSettings({ rosbridge_uri: 'http://localhost:9090', video_port: 8089 }, location);
+  if (bridge.effectiveRosbridgeUri !== 'wss://pilot.example:9090/') {
+    throw new Error(`unexpected rosbridge URI: ${bridge.effectiveRosbridgeUri}`);
+  }
+  if (bridge.videoPort !== 8089) {
+    throw new Error(`expected explicit video port to be retained but received ${bridge.videoPort}`);
+  }
+});
+
+Deno.test('resolveRosbridgeUri falls back on invalid payload', () => {
+  const resolved = __test__.resolveRosbridgeUri('not a url', { protocol: 'ws:', hostname: 'control.local' });
+  if (resolved !== 'ws://control.local:9090') {
+    throw new Error(`invalid URI should fallback to ws://control.local:9090 but received ${resolved}`);
+  }
+});

--- a/modules/pilot/pilot/components/pilot-dashboard.js
+++ b/modules/pilot/pilot/components/pilot-dashboard.js
@@ -1,0 +1,289 @@
+import { LitElement, html, css } from 'https://unpkg.com/lit@3.1.4/index.js?module';
+import { surfaceStyles } from '/components/pilot-style.js';
+import {
+  normaliseHostMetadata,
+  summariseModules,
+  normaliseBridgeSettings,
+} from './pilot-dashboard.helpers.js';
+
+/**
+ * Pilot operations console that summarises host metadata and bridge endpoints.
+ *
+ * The dashboard provides a quick snapshot of the cockpit's own health so
+ * operators can confirm rosbridge and video relays before diving into other
+ * module consoles.
+ *
+ * @example
+ * ```html
+ * <pilot-dashboard></pilot-dashboard>
+ * ```
+ */
+class PilotDashboard extends LitElement {
+  static properties = {
+    loading: { state: true },
+    errorMessage: { state: true },
+    host: { state: true },
+    bridge: { state: true },
+    summary: { state: true },
+    lastUpdated: { state: true },
+  };
+
+  static styles = [
+    surfaceStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .dashboard-status {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .dashboard-status__meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .dashboard-status__actions {
+        display: flex;
+        align-items: center;
+      }
+
+      .module-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.85rem;
+      }
+
+      .module-list__item {
+        display: grid;
+        gap: 0.5rem;
+        padding: 0.75rem 0.9rem;
+        border-radius: 0.5rem;
+        background: rgba(0, 0, 0, 0.3);
+      }
+
+      .module-list__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .module-list__name {
+        font-family: var(--metric-value-font);
+        font-size: 1.05rem;
+      }
+
+      .module-list__description {
+        margin: 0;
+        color: var(--lcars-muted);
+        font-size: 0.85rem;
+      }
+
+      .module-list__meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        font-size: 0.75rem;
+        color: var(--lcars-muted);
+      }
+
+      .module-list__link {
+        color: var(--lcars-accent);
+        text-decoration: none;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }
+    `,
+  ];
+
+  constructor() {
+    super();
+    this.loading = true;
+    this.errorMessage = '';
+    this.host = normaliseHostMetadata(null);
+    this.bridge = normaliseBridgeSettings(null);
+    this.summary = summariseModules([]);
+    this.lastUpdated = null;
+    this._abortController = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.refresh();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._abortFetch();
+  }
+
+  render() {
+    return html`
+      <div class="surface-grid surface-grid--stack">
+        <article class="surface-card">
+          <header class="dashboard-status">
+            <div class="dashboard-status__meta">
+              <h3 class="surface-card__title">Pilot overview</h3>
+              ${this._renderStatus()}
+            </div>
+            <div class="dashboard-status__actions">
+              <button
+                type="button"
+                class="surface-action"
+                ?disabled=${this.loading}
+                @click=${() => this.refresh()}
+              >
+                ${this.loading ? 'Refreshing…' : 'Refresh'}
+              </button>
+            </div>
+          </header>
+          <div class="metric-grid">
+            ${this._renderHostCard()}
+            ${this._renderBridgeCard()}
+            ${this._renderModuleSummaryCard()}
+          </div>
+        </article>
+        <article class="surface-card surface-card--compact">
+          <h3 class="surface-card__title">Active modules</h3>
+          ${this._renderModuleList()}
+        </article>
+      </div>
+    `;
+  }
+
+  _renderStatus() {
+    if (this.errorMessage) {
+      return html`<p class="surface-status" data-variant="error">${this.errorMessage}</p>`;
+    }
+    if (this.loading) {
+      return html`<p class="surface-status">Loading pilot metadata…</p>`;
+    }
+    const timestamp = this.lastUpdated instanceof Date ? this.lastUpdated.toLocaleTimeString() : 'Never';
+    return html`<p class="surface-status">Updated ${timestamp}</p>`;
+  }
+
+  _renderHostCard() {
+    return html`
+      <section class="surface-metric">
+        <span class="surface-metric__label">Host</span>
+        <span class="surface-metric__value surface-metric__value--large">${this.host.name}</span>
+        <span class="surface-status">Shortname: ${this.host.shortname}</span>
+      </section>
+    `;
+  }
+
+  _renderBridgeCard() {
+    return html`
+      <section class="surface-metric">
+        <span class="surface-metric__label">ROS Bridge</span>
+        <span class="surface-metric__value">${this.bridge.mode}</span>
+        <span class="surface-status">Primary: ${this.bridge.effectiveRosbridgeUri}</span>
+        ${this.bridge.videoBase
+          ? html`<span class="surface-status">Video base: ${this.bridge.videoBase}${this.bridge.videoPort ? `:${this.bridge.videoPort}` : ''}</span>`
+          : ''}
+      </section>
+    `;
+  }
+
+  _renderModuleSummaryCard() {
+    const { total, withPilot, withoutPilot } = this.summary;
+    return html`
+      <section class="surface-metric">
+        <span class="surface-metric__label">Modules</span>
+        <span class="surface-metric__value surface-metric__value--large">${total}</span>
+        <span class="surface-status">Dashboards ready: ${withPilot}</span>
+        <span class="surface-status">Awaiting dashboards: ${withoutPilot}</span>
+      </section>
+    `;
+  }
+
+  _renderModuleList() {
+    if (this.errorMessage) {
+      return html`<p class="surface-status" data-variant="error">${this.errorMessage}</p>`;
+    }
+    if (this.loading && !this.summary.modules.length) {
+      return html`<p class="surface-status">Loading modules…</p>`;
+    }
+    if (!this.summary.modules.length) {
+      return html`<p class="surface-status">No modules reported by the pilot host.</p>`;
+    }
+    return html`
+      <ul class="module-list">
+        ${this.summary.modules.map((module) => this._renderModule(module))}
+      </ul>
+    `;
+  }
+
+  _renderModule(module) {
+    return html`
+      <li class="module-list__item">
+        <div class="module-list__header">
+          <span class="module-list__name">${module.displayName}</span>
+          <span class="surface-chip" data-variant=${module.hasPilot ? 'success' : 'warning'}>
+            ${module.hasPilot ? 'Dashboard ready' : 'No dashboard'}
+          </span>
+        </div>
+        ${module.description
+          ? html`<p class="module-list__description">${module.description}</p>`
+          : ''}
+        <div class="module-list__meta">
+          <span>Slug: ${module.slug}</span>
+          ${module.dashboardUrl
+            ? html`<a class="module-list__link" href="${module.dashboardUrl}" target="_blank" rel="noreferrer">Open dashboard</a>`
+            : ''}
+        </div>
+      </li>
+    `;
+  }
+
+  async refresh() {
+    this._abortFetch();
+    const controller = new AbortController();
+    this._abortController = controller;
+    this.loading = true;
+    this.errorMessage = '';
+
+    try {
+      const response = await fetch('/api/modules', { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const payload = await response.json();
+      this.host = normaliseHostMetadata(payload.host);
+      this.bridge = normaliseBridgeSettings(payload.bridge);
+      this.summary = summariseModules(payload.modules);
+      this.lastUpdated = new Date();
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      this.errorMessage = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (this._abortController === controller) {
+        this._abortController = null;
+      }
+      this.loading = false;
+    }
+  }
+
+  _abortFetch() {
+    if (this._abortController) {
+      this._abortController.abort();
+      this._abortController = null;
+    }
+  }
+}
+
+customElements.define('pilot-dashboard', PilotDashboard);

--- a/modules/pilot/pilot/index.html
+++ b/modules/pilot/pilot/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pilot Operations Console</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <script type="module">
+      import '/js/pilot.js';
+      import '/modules/pilot/components/pilot-dashboard.js';
+
+      window.addEventListener('DOMContentLoaded', () => {
+        const mount = document.querySelector('#module-root');
+        if (mount && !mount.querySelector('pilot-dashboard')) {
+          mount.appendChild(document.createElement('pilot-dashboard'));
+        }
+      });
+    </script>
+  </head>
+  <body class="pilot-solo">
+    <main class="pilot-solo__main">
+      <header class="pilot-solo__header">
+        <h1>Pilot Operations Console</h1>
+        <p>Review host metadata and confirm ROS bridge endpoints before launching other modules.</p>
+      </header>
+      <section id="module-root" class="pilot-solo__surface"></section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated pilot dashboard component with helper utilities and solo index page
- register the pilot component in the cockpit shell and expose helper coverage
- tighten API and catalog tests to require the pilot module to surface cockpit assets

## Testing
- PYTHONPATH=modules/pilot/packages/pilot:$PYTHONPATH pytest modules/pilot/packages/pilot/tests -q
- node --test modules/pilot/packages/pilot/pilot/frontend/utils/navigation.test.js
- deno test modules/pilot/pilot/components/pilot-dashboard.helpers.test.js *(fails: deno missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed41c9afa88320b0f48ad4790a2514