### PR TITLE
🎨 Palette: Add standard surface classes to empty states and retry button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-03-24 - Initial Journal Entry\n**Learning:** This repo is using LitElement to render the components.\n**Action:** Use lit syntax for UX improvements.

--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,7 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-button" @click=${() => this.refresh()}>🔄 Retry</button>
       </section>`;
     }
     if (!this.modules.length) {

--- a/modules/pilot/cockpit/components/pilot-dashboard.js
+++ b/modules/pilot/cockpit/components/pilot-dashboard.js
@@ -348,7 +348,7 @@ class PilotDashboard extends LitElement {
               </ul>
             `
           : html`
-              <p class="empty-placeholder">No context topics observed yet.</p>
+              <p class="surface-empty empty-placeholder">No context topics observed yet.</p>
             `}
         </section>
         <section>
@@ -367,7 +367,7 @@ class PilotDashboard extends LitElement {
               </ul>
             `
           : html`
-              <p class="empty-placeholder">No sensation streams recorded yet.</p>
+              <p class="surface-empty empty-placeholder">No sensation streams recorded yet.</p>
             `}
         </section>
       `,
@@ -447,7 +447,7 @@ class PilotDashboard extends LitElement {
             </ul>
           `
           : html`
-            <p class="empty-placeholder">
+            <p class="surface-empty empty-placeholder">
               No FeelingIntent messages received from the pilot yet.
             </p>
           `}
@@ -469,7 +469,7 @@ class PilotDashboard extends LitElement {
           <p class="section-note">
             Prompt history will appear here once the planner publishes telemetry.
           </p>
-          <p class="empty-placeholder">No prompt captured yet.</p>
+          <p class="surface-empty empty-placeholder">No prompt captured yet.</p>
         `,
     });
 
@@ -516,7 +516,7 @@ class PilotDashboard extends LitElement {
               </ul>
             `
           : html`
-              <p class="empty-placeholder">No sensations recorded in the current window.</p>
+              <p class="surface-empty empty-placeholder">No sensations recorded in the current window.</p>
             `}
         `,
     });
@@ -589,7 +589,7 @@ class PilotDashboard extends LitElement {
             </ul>
           `
           : html`
-            <p class="empty-placeholder">No command scripts executed yet.</p>
+            <p class="surface-empty empty-placeholder">No command scripts executed yet.</p>
           `}
       `,
     });


### PR DESCRIPTION
💡 What: 
- Added the `surface-button` class to the "Retry" button in `cockpit-app.js`.
- Added the `surface-empty` class to multiple empty state `<p>` tags in `pilot-dashboard.js`.
- Created `.Jules/palette.md` to log critical learnings.

🎯 Why: 
- To ensure visual consistency with the rest of the application's design system. The "Retry" button was previously unstyled, and the empty placeholders were missing the `surface-empty` utility class for standardized italic/muted formatting.

📸 Before/After: N/A (Standardized existing elements, tested via Playwright screenshot).

♿ Accessibility: Ensures buttons and empty states have adequate visual contrast and standard sizing according to the existing CSS variables.

---
*PR created automatically by Jules for task [17808315603467542867](https://jules.google.com/task/17808315603467542867) started by @dancxjo*