### PR TITLE
⚡ Bolt: Replace `.keys()` with direct dictionary iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## $(date +%Y-%m-%d) - Replaced .keys() with direct dictionary iteration
+**Learning:** Python dictionary iteration is natively optimized. Calling `.keys()` forces the allocation of a view object, which is slightly slower than direct dictionary iteration `for key in my_dict:`.
+**Action:** Avoid `.keys()` when only keys are needed in iteration; simply iterate over the dictionary object directly.

--- a/modules/cockpit/packages/cockpit/cockpit/module_api.py
+++ b/modules/cockpit/packages/cockpit/cockpit/module_api.py
@@ -224,7 +224,7 @@ def _allowed_argument_keys(parameters: Optional[Mapping[str, Any]]) -> set[str]:
         return set()
     props = parameters.get("properties")
     if isinstance(props, Mapping):
-        return {str(key) for key in props.keys()}
+        return {str(key) for key in props}
     return set()
 
 
@@ -662,7 +662,7 @@ def _render_signature(name: str, parameters: Optional[Mapping[str, Any]]) -> str
         return f"{name}()"
 
     ordered = OrderedDict()
-    for key in props.keys():
+    for key in props:
         ordered[str(key)] = props[key]
 
     parts: list[str] = []

--- a/modules/memory/pilot/topic_translator.py
+++ b/modules/memory/pilot/topic_translator.py
@@ -54,7 +54,7 @@ def summarise_pilot_feed(payload: Any) -> str:
         return f'Memory update ({kind}): "{summary}".'
     metadata = record.get("metadata")
     if isinstance(metadata, Mapping):
-        keys = sorted(str(key) for key in metadata.keys())
+        keys = sorted(str(key) for key in metadata)
         if keys:
             return f"Memory update ({kind}) with metadata keys: {', '.join(keys)}."
     return f"Memory update ({kind})."

--- a/modules/pilot/packages/pilot/pilot/cockpit_helpers.py
+++ b/modules/pilot/packages/pilot/pilot/cockpit_helpers.py
@@ -39,7 +39,7 @@ def render_action_signature(name: str, parameters: Mapping[str, Any] | None) -> 
         return f"{name}()"
 
     ordered = OrderedDict()
-    for key in props.keys():
+    for key in props:
         ordered[str(key)] = props[key]
 
     parts: list[str] = []

--- a/modules/pilot/packages/pilot/pilot/node.py
+++ b/modules/pilot/packages/pilot/pilot/node.py
@@ -606,7 +606,7 @@ def _expand_positional_arguments(
 
     # Respect the order declared in the JSON schema so positional arguments map
     # to predictable parameter names.
-    candidate_names = [str(name) for name in props.keys()]
+    candidate_names = [str(name) for name in props]
     available = [name for name in candidate_names if name not in normalised]
 
     if len(values) > len(available):

--- a/modules/pilot/packages/pilot/pilot/prompt_builder.py
+++ b/modules/pilot/packages/pilot/pilot/prompt_builder.py
@@ -248,7 +248,7 @@ def _condense_status(status: Any) -> Dict[str, Any]:
     modules = status.get("modules")
     module_names: List[str] = []
     if isinstance(modules, Mapping):
-        module_names = sorted(str(key) for key in modules.keys())
+        module_names = sorted(str(key) for key in modules)
     elif isinstance(modules, Sequence) and not isinstance(modules, (str, bytes, bytearray)):
         for entry in modules:
             if isinstance(entry, Mapping):


### PR DESCRIPTION
💡 What: Replaced all unnecessary usages of `.keys()` when iterating over mappings with direct dictionary iteration (e.g., `for key in my_dict:`).
🎯 Why: Direct iteration is idiomatic Python and avoids allocating a dictionary view object and making an additional method call, making the loop slightly faster.
📊 Impact: Expected to reduce memory overhead from view allocation and speed up loop iterations slightly (measurable in micro-benchmarks).
🔬 Measurement: Run a local micro-benchmark with `timeit` comparing `[k for k in dict.keys()]` vs `[k for k in dict]`.

---
*PR created automatically by Jules for task [60605001541822136](https://jules.google.com/task/60605001541822136) started by @dancxjo*