### PR TITLE
🎨 Palette: Add consistent styling to Retry button in cockpit-app

### DIFF
--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,7 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-button" @click=${() => this.refresh()}>🔄 Retry</button>
       </section>`;
     }
     if (!this.modules.length) {


### PR DESCRIPTION
## 🎨 Palette: Add `surface-button` class to Retry button

💡 **What**: Added the `surface-button` class to the "Retry" button within the `cockpit-app.js` error state.
🎯 **Why**: The button was missing the standard `surface-button` class, meaning it rendered as a default browser button and lacked the hover, focus, and visual styling consistent with the rest of the cockpit's LCARS-like design system. This minor change improves the visual polish and interaction consistency of the error state.
📸 **Before/After**: Visually, the button now looks like other buttons in the app instead of an unstyled HTML button.
♿ **Accessibility**: Inherits the `focus-visible` outline and clear visual feedback states defined in `cockpit-style.js`, improving keyboard navigation clarity when the application encounters an error.

---
*PR created automatically by Jules for task [2518351093446078737](https://jules.google.com/task/2518351093446078737) started by @dancxjo*