### PR TITLE
🎨 Palette: Improve Config page button accessibility and focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-15 - [ARIA Labels for Repeated Action Buttons]
+**Learning:** When generating multiple instances of identical interactive elements (like "Save" or "Reset" buttons in a list of configuration cards), a screen reader will read them all identically ("Save changes, button") unless specific `aria-label`s are applied to provide context about what is being saved.
+**Action:** Always interpolate the context or ID into the `aria-label` when dynamically creating repeated action buttons (e.g. `Save changes to ${module.name}`).

--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,7 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-button" aria-label="Retry loading modules" @click=${() => this.refresh()}>🔄 Retry</button>
       </section>`;
     }
     if (!this.modules.length) {

--- a/modules/cockpit/packages/cockpit/cockpit/frontend/config/app.js
+++ b/modules/cockpit/packages/cockpit/cockpit/frontend/config/app.js
@@ -265,12 +265,14 @@ function renderModuleCard(module) {
   saveButton.type = 'button';
   saveButton.className = 'config-card__save';
   saveButton.textContent = 'Save changes';
+  saveButton.setAttribute('aria-label', `Save changes to ${module.display_name || module.name}`);
   saveButton.addEventListener('click', () => submitModule(card, editor));
 
   const resetButton = document.createElement('button');
   resetButton.type = 'button';
   resetButton.className = 'config-card__reset';
   resetButton.textContent = 'Reset';
+  resetButton.setAttribute('aria-label', `Reset changes to ${module.display_name || module.name}`);
   resetButton.addEventListener('click', () => resetEditor(module.name, editor));
 
   const status = document.createElement('p');

--- a/modules/cockpit/packages/cockpit/cockpit/frontend/styles.css
+++ b/modules/cockpit/packages/cockpit/cockpit/frontend/styles.css
@@ -1826,6 +1826,11 @@ h5.audio-oscilloscope {
   background: rgba(248, 128, 60, 0.4);
 }
 
+.config-card__save:focus-visible {
+  outline: 2px solid rgba(248, 128, 60, 0.75);
+  outline-offset: 2px;
+}
+
 .config-card__reset {
   background: rgba(27, 31, 42, 0.6);
   color: var(--lcars-muted);
@@ -1835,6 +1840,11 @@ h5.audio-oscilloscope {
 .config-card__reset:hover,
 .config-card__reset:focus {
   background: rgba(27, 31, 42, 0.85);
+}
+
+.config-card__reset:focus-visible {
+  outline: 2px solid rgba(88, 178, 220, 0.75);
+  outline-offset: 2px;
 }
 
 .config-card__status {


### PR DESCRIPTION
💡 **What**: Added contextual `aria-label` attributes to the "Save changes" and "Reset" buttons, added `:focus-visible` styles to those buttons for keyboard navigation, and applied standard `.surface-button` styling with an `aria-label` to the "Retry" button.
🎯 **Why**: When a user navigates via keyboard, they need clear visual indicators of focus. For screen reader users, hearing "Save changes" ten times without context is confusing; adding the module name to the `aria-label` solves this. The "Retry" button styling unifies the app's visual language.
♿ **Accessibility**: Enhanced keyboard navigation focus states and provided screen reader context for repeated action buttons.

---
*PR created automatically by Jules for task [5926114736563054177](https://jules.google.com/task/5926114736563054177) started by @dancxjo*