### PR TITLE
🎨 Palette: Add focus-visible indicator to surface buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-16 - Ensure Focus Visible Ring is Maintained on Buttons
+**Learning:** By default, buttons in the `surface-button` and `surface-action` classes disabled default browser outlines using `outline: none;`. This caused keyboard navigation to rely solely on hover/focus background color shifts and drop shadows which aren't adequate focus rings for accessibility.
+**Action:** When removing default outlines in custom components, always explicitly provide a clear visual indicator for keyboard focus using `:focus-visible` (e.g. `box-shadow: 0 0 0 2px <color>;`) so keyboard users can clearly see the currently focused element.

--- a/modules/cockpit/cockpit/components/cockpit-style.js
+++ b/modules/cockpit/cockpit/components/cockpit-style.js
@@ -453,6 +453,11 @@ export const surfaceStyles = css`
     outline: none;
   }
 
+  .surface-button:focus-visible,
+  .surface-action:focus-visible {
+    box-shadow: 0 0 0 2px rgba(88, 178, 220, 0.8), 0 4px 10px rgba(0, 0, 0, 0.25);
+  }
+
   .surface-button[disabled],
   .surface-action[disabled] {
     opacity: 0.45;


### PR DESCRIPTION
💡 **What:** Added a clear `box-shadow` focus ring to `.surface-button` and `.surface-action` components when they receive keyboard focus using the `:focus-visible` pseudo-class.

🎯 **Why:** To improve keyboard navigation accessibility. Previously, the buttons disabled default browser outlines via `outline: none;` without providing an explicit, high-contrast visual indicator for focused states, making it difficult for keyboard-only users to discern the currently focused interactive element. 

📸 **Before/After:** Before, only a slight translation and a subtle drop shadow was applied on focus. Now, a prominent blue ring explicitly marks the focused element.
*(See attached screenshot from Playwright tests for verification)*

♿ **Accessibility:** This ensures compliance with WCAG success criterion 2.4.7 (Focus Visible) by providing a clear, visible focus indicator for custom button components.

Also logged the critical learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [13995278757136557757](https://jules.google.com/task/13995278757136557757) started by @dancxjo*