### PR TITLE
🎨 Palette: [UX improvement] Refactor error retry button

### DIFF
--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,10 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-action" aria-label="Retry loading modules" title="Retry" @click=${() => this.refresh()}>
+          <span class="surface-action__icon" aria-hidden="true">🔄</span>
+          <span class="surface-action__label" aria-hidden="true">Retry</span>
+        </button>
       </section>`;
     }
     if (!this.modules.length) {


### PR DESCRIPTION
## 💡 What
Updated the "Retry" button that appears when module dashboards fail to load. The button has been upgraded from an unstyled default `<button>` with a raw emoji to a properly styled `.surface-action` component.

## 🎯 Why
The raw `🔄 Retry` string within an unstyled button was visually out of place with the rest of the cockpit interface, which heavily relies on `surface-action` and `surface-button` design tokens. Moreover, the emoji was not hidden from screen readers.

## 📸 Before/After
*(Visual verification was conducted locally via Playwright screenshot capture).*
**Before:** An unstyled browser default button with text "🔄 Retry".
**After:** A themed `.surface-action` button matching the application's design system with proper hover and active states.

## ♿ Accessibility
- Added `aria-label="Retry loading modules"` to provide descriptive text to screen readers.
- Added `aria-hidden="true"` to the inner `span` elements (icon and label) to prevent redundant screen reader announcements (e.g. "refresh button, retry").
- Added a `title="Retry"` tooltip for mouse users.

---
*PR created automatically by Jules for task [10441294348494780987](https://jules.google.com/task/10441294348494780987) started by @dancxjo*