### PR TITLE
🎨 Palette: Style fallback retry button in cockpit dashboard

### DIFF
--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,7 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-button" @click=${() => this.refresh()}>🔄 Retry</button>
       </section>`;
     }
     if (!this.modules.length) {


### PR DESCRIPTION
💡 **What**: Added the `surface-button` class to the "Retry" button within the `cockpit-error` state in `modules/cockpit/cockpit/components/cockpit-app.js`.
🎯 **Why**: The fallback "Retry" button previously lacked any design system styling, rendering as a default, unstyled browser button when modules failed to load. Applying `surface-button` ensures consistency with the rest of the application's interactive elements and provides proper layout, typography, and states (hover/focus).
📸 **Before/After**: See the attached screenshots from the playwright verification script for the final result.
♿ **Accessibility**: Inherits the focus-visible styles established for the `surface-button` class, ensuring clear keyboard navigation indicators.

---
*PR created automatically by Jules for task [17296669892824751029](https://jules.google.com/task/17296669892824751029) started by @dancxjo*