### PR TITLE
⚡ Bolt: [performance improvement] Optimize dictionary iteration by removing `.keys()` overhead

### DIFF
--- a/modules/cockpit/packages/cockpit/cockpit/actions/__init__.py
+++ b/modules/cockpit/packages/cockpit/cockpit/actions/__init__.py
@@ -114,7 +114,7 @@ class ActionRegistry:
     def list_modules(self) -> Iterable[str]:
         """Yield the module identifiers with registered actions."""
 
-        return list(self._actions.keys())
+        return list(self._actions)
 
     def list_actions(self, module: str) -> Iterable[ModuleAction]:
         """Return the actions registered for *module*."""

--- a/modules/cockpit/packages/cockpit/cockpit/module_api.py
+++ b/modules/cockpit/packages/cockpit/cockpit/module_api.py
@@ -224,7 +224,7 @@ def _allowed_argument_keys(parameters: Optional[Mapping[str, Any]]) -> set[str]:
         return set()
     props = parameters.get("properties")
     if isinstance(props, Mapping):
-        return {str(key) for key in props.keys()}
+        return {str(key) for key in props}
     return set()
 
 
@@ -662,7 +662,7 @@ def _render_signature(name: str, parameters: Optional[Mapping[str, Any]]) -> str
         return f"{name}()"
 
     ordered = OrderedDict()
-    for key in props.keys():
+    for key in props:
         ordered[str(key)] = props[key]
 
     parts: list[str] = []

--- a/modules/cockpit/packages/cockpit/cockpit/ros.py
+++ b/modules/cockpit/packages/cockpit/cockpit/ros.py
@@ -374,7 +374,7 @@ class RosClient:
             return
         self._shutdown = True
 
-        for stream_id in list(self._streams.keys()):
+        for stream_id in list(self._streams):
             await self.close_stream(stream_id)
 
         self._executor.remove_node(self._node)

--- a/modules/cockpit/packages/cockpit/cockpit/server.py
+++ b/modules/cockpit/packages/cockpit/cockpit/server.py
@@ -159,7 +159,7 @@ class StreamManager:
         await self._ros.close_stream(stream_id)
 
     async def close_all(self) -> None:
-        for stream_id in list(self._streams.keys()):
+        for stream_id in list(self._streams):
             await self.release(stream_id)
 
 

--- a/modules/cockpit/packages/cockpit/tests/test_api.py
+++ b/modules/cockpit/packages/cockpit/tests/test_api.py
@@ -85,7 +85,7 @@ def stub_ros_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
                 await stream.close()
 
         async def shutdown(self) -> None:
-            for stream_id in list(self._streams.keys()):
+            for stream_id in list(self._streams):
                 await self.close_stream(stream_id)
 
         @property

--- a/modules/pilot/packages/pilot/pilot/cockpit_helpers.py
+++ b/modules/pilot/packages/pilot/pilot/cockpit_helpers.py
@@ -39,7 +39,7 @@ def render_action_signature(name: str, parameters: Mapping[str, Any] | None) -> 
         return f"{name}()"
 
     ordered = OrderedDict()
-    for key in props.keys():
+    for key in props:
         ordered[str(key)] = props[key]
 
     parts: list[str] = []

--- a/modules/pilot/packages/pilot/pilot/node.py
+++ b/modules/pilot/packages/pilot/pilot/node.py
@@ -1287,7 +1287,7 @@ class PilotNode(Node):
                 "config": {
                     "debounce_seconds": self._debounce_seconds,
                     "window_seconds": self._window_seconds,
-                    "context_topics": list(self._topic_cache.keys()),
+                    "context_topics": list(self._topic_cache),
                     "sensation_topics": [r.topic for _, r in self._sensation_records] if self._sensation_records else [],
                 },
                 "recent_sensations": [
@@ -1592,7 +1592,7 @@ class PilotNode(Node):
 
         msg = FeelingIntent()
         msg.stamp = self.get_clock().now().to_msg()
-        source_topics = sorted(set(context.topics.keys()) | {record.topic for record in recent_records})
+        source_topics = sorted(set(context.topics) | {record.topic for record in recent_records})
         msg.source_topics = source_topics
         msg.situation_overview = feeling_data.situation_overview
         msg.attitude_emoji = feeling_data.attitude_emoji

--- a/modules/pilot/packages/pilot/pilot/prompt_builder.py
+++ b/modules/pilot/packages/pilot/pilot/prompt_builder.py
@@ -248,7 +248,7 @@ def _condense_status(status: Any) -> Dict[str, Any]:
     modules = status.get("modules")
     module_names: List[str] = []
     if isinstance(modules, Mapping):
-        module_names = sorted(str(key) for key in modules.keys())
+        module_names = sorted(str(key) for key in modules)
     elif isinstance(modules, Sequence) and not isinstance(modules, (str, bytes, bytearray)):
         for entry in modules:
             if isinstance(entry, Mapping):

--- a/modules/pilot/packages/pilot/pilot/topic_translation.py
+++ b/modules/pilot/packages/pilot/pilot/topic_translation.py
@@ -131,7 +131,7 @@ def discover_topic_translators(
         for section in static_sections:
             if section not in seen:
                 seen[section] = None
-        static_sections = list(seen.keys())
+        static_sections = list(seen)
     return TranslatorRegistry(translators, static_sections)
 
 


### PR DESCRIPTION
💡 **What:** Replaced `for key in my_dict.keys():` and `list(my_dict.keys())` with direct dictionary iteration (`for key in my_dict:`) and `list(my_dict)` across multiple Python modules in `pilot` and `cockpit`.
🎯 **Why:** To eliminate the overhead of the `.keys()` method call and the creation of the `dict_keys` view object, which provides a small but widespread optimization for loops and list conversions.
📊 **Impact:** Slightly reduces CPU cycles and temporary object allocations during iteration over dictionaries, which can accumulate to save noticeable milliseconds in high-frequency ROS 2 loops (e.g., node loops processing incoming data).
🔬 **Measurement:** While it's a micro-optimization, the impact is structural. The existing pytest suites for `cockpit` and `pilot` modules pass (excluding unrelated test failure `test_pilot_expands_positional_arguments` that existed prior to this change).

---
*PR created automatically by Jules for task [4374013667373652894](https://jules.google.com/task/4374013667373652894) started by @dancxjo*