### PR TITLE
🎨 Palette: Fix accessibility and interactions for surface actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Surface Action Button Structure
+
+**Learning:** In the cockpit UI, `.surface-action` buttons require a specific internal markup structure to function correctly with screen readers and to trigger the intended CSS hover-to-expand transition. They should wrap their content in `<span class="surface-action__icon" aria-hidden="true">` and `<span class="surface-action__label" aria-hidden="true">` spans, with the parent `<button>` containing `aria-label` and `title` attributes.
+
+**Action:** When implementing or fixing icon-and-text buttons in the web cockpit, ensure the `.surface-action` pattern uses the `aria-label`/`title` on the parent button and sets `aria-hidden="true"` on the internal structural spans to prevent redundant screen reader announcements while maintaining visual hover effects.

--- a/modules/foot/cockpit/components/foot-dashboard.js
+++ b/modules/foot/cockpit/components/foot-dashboard.js
@@ -9,14 +9,14 @@ import "/components/joystick-control.js";
 import { normaliseTopic, streamActionForTopic } from "../utils/streams.js";
 
 import {
+  buildDefineSongPayload,
   buildParameterRequest,
   buildPowerLedPayload,
-  buildDefineSongPayload,
   formatJointState,
   formatOdometry,
   formatParameterEvent,
-  SONG_LIMITS,
   parseSongSheet,
+  SONG_LIMITS,
   toAsciiPayload,
 } from "./foot-dashboard.helpers.js";
 
@@ -33,9 +33,11 @@ function createFootSocket(options, onError) {
     ...options,
     ...(action
       ? {
-          action,
-          arguments: Object.keys(actionArguments).length ? actionArguments : undefined,
-        }
+        action,
+        arguments: Object.keys(actionArguments).length
+          ? actionArguments
+          : undefined,
+      }
       : {}),
   });
   const handler = typeof onError === "function" ? onError : () => undefined;
@@ -882,7 +884,8 @@ class FootDashboard extends LitElement {
         "create_msgs/msg/DefineSong",
       );
       socket.send(JSON.stringify(payload));
-      this.songStatus = `Song ${payload.song} programmed with ${payload.length} notes.`;
+      this.songStatus =
+        `Song ${payload.song} programmed with ${payload.length} notes.`;
     } catch (error) {
       this.songStatus = error instanceof Error ? error.message : String(error);
     }
@@ -1006,10 +1009,24 @@ class FootDashboard extends LitElement {
         <article class="surface-card">
           <h3 class="surface-card__title">Mobility actions</h3>
           <div class="surface-actions surface-actions--grid">
-            <button class="surface-action" @click="${() =>
-              this.sendSimple("dock")}">⚓ Dock</button>
-            <button class="surface-action" @click="${() =>
-              this.sendSimple("undock")}">🛫 Undock</button>
+            <button
+              class="surface-action"
+              aria-label="Dock"
+              title="Dock"
+              @click="${() => this.sendSimple("dock")}"
+            >
+              <span class="surface-action__icon" aria-hidden="true">⚓</span>
+              <span class="surface-action__label" aria-hidden="true">Dock</span>
+            </button>
+            <button
+              class="surface-action"
+              aria-label="Undock"
+              title="Undock"
+              @click="${() => this.sendSimple("undock")}"
+            >
+              <span class="surface-action__icon" aria-hidden="true">🛫</span>
+              <span class="surface-action__label" aria-hidden="true">Undock</span>
+            </button>
           </div>
           ${this.actionStatus
             ? html`
@@ -1061,7 +1078,16 @@ class FootDashboard extends LitElement {
               />
             </label>
             <div class="surface-actions">
-              <button class="surface-action" type="submit">🔤 Update ASCII</button>
+              <button
+                class="surface-action"
+                aria-label="Update ASCII"
+                title="Update ASCII"
+                type="submit"
+              >
+                <span class="surface-action__icon" aria-hidden="true">🔤</span>
+                <span class="surface-action__label" aria-hidden="true"
+                >Update ASCII</span>
+              </button>
             </div>
           </form>
           <form @submit="${(event) => this.sendPowerLed(event)}">
@@ -1094,7 +1120,16 @@ class FootDashboard extends LitElement {
               />
             </label>
             <div class="surface-actions">
-              <button class="surface-action" type="submit">💡 Update power LED</button>
+              <button
+                class="surface-action"
+                aria-label="Update power LED"
+                title="Update power LED"
+                type="submit"
+              >
+                <span class="surface-action__icon" aria-hidden="true">💡</span>
+                <span class="surface-action__label" aria-hidden="true"
+                >Update power LED</span>
+              </button>
             </div>
           </form>
         </article>
@@ -1126,10 +1161,26 @@ class FootDashboard extends LitElement {
               </label>
             </div>
             <div class="surface-actions surface-actions--grid">
-              <button class="surface-action" type="submit">🎼 Define song</button>
-              <button class="surface-action" type="button" @click="${(event) =>
-                this.playSong(event)}">
-                🎵 Play song
+              <button
+                class="surface-action"
+                aria-label="Define song"
+                title="Define song"
+                type="submit"
+              >
+                <span class="surface-action__icon" aria-hidden="true">🎼</span>
+                <span class="surface-action__label" aria-hidden="true"
+                >Define song</span>
+              </button>
+              <button
+                class="surface-action"
+                aria-label="Play song"
+                title="Play song"
+                type="button"
+                @click="${(event) => this.playSong(event)}"
+              >
+                <span class="surface-action__icon" aria-hidden="true">🎵</span>
+                <span class="surface-action__label" aria-hidden="true"
+                >Play song</span>
               </button>
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added correct span structure (`.surface-action__icon`, `.surface-action__label`), `aria-label`s, and `title` tags to 6 `.surface-action` buttons within the foot-dashboard UI.
🎯 Why: Without these spans, the global CSS rule for `.surface-action` hover state (`.surface-button:hover .surface-action__label`) couldn't expand the button text on hover, resulting in a degraded experience. It also fixes screen readers redundantly announcing icons and text differently without aria-labels and aria-hidden attributes properly configured.
📸 Before/After: Hovering the buttons expands smoothly and shows an appropriate aria-label.
♿ Accessibility: Ensures that icons are hidden (`aria-hidden="true"`) from screen readers while providing semantic meaning to the parent button through `aria-label`s.

---
*PR created automatically by Jules for task [14879854647342519230](https://jules.google.com/task/14879854647342519230) started by @dancxjo*