### PR TITLE
⚡ Bolt: [performance improvement] Optimize base64 binary conversion

### DIFF
--- a/modules/ear/cockpit/browser-ear.html
+++ b/modules/ear/cockpit/browser-ear.html
@@ -221,7 +221,15 @@
               type: 'chunk',
               sample_rate: state.targetSampleRate,
               channels: 1,
-              pcm: btoa(String.fromCharCode.apply(null, pcm)),
+              pcm: (() => {
+                let binary = '';
+                const chunkSize = 8192;
+                for (let i = 0; i < pcm.length; i += chunkSize) {
+                  const chunk = pcm.subarray(i, i + chunkSize);
+                  binary += String.fromCharCode.apply(null, chunk);
+                }
+                return btoa(binary);
+              })(),
             };
             state.ws.send(JSON.stringify(payload));
           };

--- a/modules/eye/cockpit/browser-eye.html
+++ b/modules/eye/cockpit/browser-eye.html
@@ -223,7 +223,11 @@
         const arrayBuffer = await blob.arrayBuffer();
         const bytes = new Uint8Array(arrayBuffer);
         let binary = '';
-        bytes.forEach((b) => { binary += String.fromCharCode(b); });
+        const chunkSize = 8192;
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          const chunk = bytes.subarray(i, i + chunkSize);
+          binary += String.fromCharCode.apply(null, chunk);
+        }
         const payload = {
           type: 'frame',
           sequence: ++state.sequence,

--- a/modules/pilot/cockpit/components/pilot-dashboard.helpers.js
+++ b/modules/pilot/cockpit/components/pilot-dashboard.helpers.js
@@ -36,16 +36,22 @@ export function encodeBytesToBase64(bytes) {
   if (!bytes) {
     return "";
   }
-  const view = bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const view = bytes instanceof ArrayBuffer
+    ? new Uint8Array(bytes)
+    : new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   let binary = "";
-  for (let i = 0; i < view.byteLength; i += 1) {
-    binary += String.fromCharCode(view[i]);
+  const chunkSize = 8192;
+  for (let i = 0; i < view.byteLength; i += chunkSize) {
+    const chunk = view.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, chunk);
   }
   if (typeof btoa === "function") {
     return btoa(binary);
   }
   // Fallback for environments without btoa (e.g., Node tests)
+  // deno-lint-ignore no-node-globals
   if (typeof Buffer !== "undefined") {
+    // deno-lint-ignore no-node-globals
     return Buffer.from(binary, "binary").toString("base64");
   }
   throw new Error("No base64 encoder available");
@@ -237,8 +243,8 @@ export function normaliseDebugSnapshot(snapshot) {
       const vectorLength = Number.isFinite(Number(entry.vector_len))
         ? Number(entry.vector_len)
         : Array.isArray(entry.vector)
-          ? entry.vector.length
-          : 0;
+        ? entry.vector.length
+        : 0;
       return {
         topic,
         kind: cleanString(entry.kind),

--- a/services/asr/app/static/harness.html
+++ b/services/asr/app/static/harness.html
@@ -475,8 +475,10 @@
         function int16ToBase64(int16Array) {
           const bytes = new Uint8Array(int16Array.buffer, int16Array.byteOffset, int16Array.byteLength);
           let binary = '';
-          for (let i = 0; i < bytes.length; i += 1) {
-            binary += String.fromCharCode(bytes[i] & 0xff);
+          const chunkSize = 8192;
+          for (let i = 0; i < bytes.length; i += chunkSize) {
+            const chunk = bytes.subarray(i, i + chunkSize);
+            binary += String.fromCharCode.apply(null, chunk);
           }
           return btoa(binary);
         }


### PR DESCRIPTION
### 💡 What: The optimization implemented
Replaced simple `for` loop `String.fromCharCode` usages with a chunked logic that builds string segments via `String.fromCharCode.apply(null, chunk)` in 8192-byte chunks across files handling base64 conversion from ArrayBuffer / Uint8Array data arrays.

### 🎯 Why: The performance problem it solves
In JavaScript, executing string concatenations in a simple `for` loop character by character over large byte buffers like media content incurs a major runtime complexity penalty and causes significant sluggishness.

When doing `String.fromCharCode.apply(null, buffer)`, applying a single very large array results in V8 / Javascript engine "Maximum call stack size exceeded" errors.

By processing large buffers in 8192-byte chunks, we avoid string concatenation performance traps and eliminate call stack errors, providing robust and blazingly fast runtime executions.

### 📊 Impact: Expected performance improvement
Significantly decreases processing times to build base64 representations from continuous stream arrays, directly providing smoother browser-side behaviors and less CPU drain when capturing or receiving multimedia streams.

### 🔬 Measurement: How to verify the improvement
Start any browser harness application (`browser-eye.html` or `browser-ear.html`) and log the timespent running the new base64 conversions inside functions like `sendFrame`. The impact scales with buffer lengths and should be a fraction of previous conversion lengths.

---
*PR created automatically by Jules for task [11575013825364795285](https://jules.google.com/task/11575013825364795285) started by @dancxjo*