### PR TITLE
🎨 Palette: [UX improvement] Add ARIA live regions to dynamic status messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-01 - Dynamic Status Messages ARIA Accessibility
+**Learning:** Dynamic status messages rendered by Lit components (e.g., `<p class="surface-status">`) are not automatically announced by screen readers when their content changes unless proper ARIA live region attributes are used.
+**Action:** Always add `role="status" aria-live="polite"` to regular dynamic updates and `role="alert" aria-live="assertive"` to error or critical feedback messages in Lit templates to ensure accessibility.

--- a/modules/cockpit/cockpit/components/cockpit-dashboard.js
+++ b/modules/cockpit/cockpit/components/cockpit-dashboard.js
@@ -141,11 +141,9 @@ class CockpitDashboard extends LitElement {
                 @click="${() => this.refresh()}"
               >
                 <span class="surface-action__icon" aria-hidden="true"
-                  >${refreshIcon}</span
-                >
+                >${refreshIcon}</span>
                 <span class="surface-action__label" aria-hidden="true"
-                  >${refreshLabel}</span
-                >
+                >${refreshLabel}</span>
               </button>
             </div>
           </header>
@@ -161,19 +159,30 @@ class CockpitDashboard extends LitElement {
   _renderStatus() {
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading) {
       return html`
-        <p class="surface-status">Loading cockpit metadata…</p>
+        <p class="surface-status" role="status" aria-live="polite">
+          Loading cockpit metadata…
+        </p>
       `;
     }
     const timestamp = this.lastUpdated instanceof Date
       ? this.lastUpdated.toLocaleTimeString()
       : "Never";
     return html`
-      <p class="surface-status">Updated ${timestamp}</p>
+      <p class="surface-status" role="status" aria-live="polite">
+        Updated ${timestamp}
+      </p>
     `;
   }
 
@@ -190,7 +199,8 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Host</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${this.host.name}</span>
-        <span class="surface-status">Shortname: ${this.host.shortname}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Shortname: ${this.host.shortname}</span>
         <div class="host-actions">
           <button
             type="button"
@@ -201,12 +211,8 @@ class CockpitDashboard extends LitElement {
             title="${shutdownLabel}"
             @click="${() => this._confirmHostOperation("shutdown")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${shutdownIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${shutdownLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${shutdownIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${shutdownLabel}</span>
           </button>
           <button
             type="button"
@@ -217,18 +223,23 @@ class CockpitDashboard extends LitElement {
             title="${restartLabel}"
             @click="${() => this._confirmHostOperation("restart")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${restartIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${restartLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${restartIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${restartLabel}</span>
           </button>
         </div>
         ${this.hostActionStatus
           ? html`
-            <p class="surface-status" data-variant="${this.hostActionVariant ||
-              undefined}">${this.hostActionStatus}</p>
+            <p
+              class="surface-status"
+              data-variant="${this.hostActionVariant ||
+                undefined}"
+              role="${this.hostActionVariant === "error" ? "alert" : "status"}"
+              aria-live="${this.hostActionVariant === "error"
+                ? "assertive"
+                : "polite"}"
+            >
+              ${this.hostActionStatus}
+            </p>
           `
           : ""}
       </section>
@@ -240,11 +251,12 @@ class CockpitDashboard extends LitElement {
       <section class="surface-metric">
         <span class="surface-metric__label">ROS Bridge</span>
         <span class="surface-metric__value">${this.bridge.mode}</span>
-        <span class="surface-status">Primary: ${this.bridge
+        <span class="surface-status" role="status" aria-live="polite"
+        >Primary: ${this.bridge
           .effectiveRosbridgeUri}</span>
         ${this.bridge.videoBase
           ? html`
-            <span class="surface-status">
+            <span class="surface-status" role="status" aria-live="polite">
               Video base:
               <a
                 href="${this.bridge.videoUrl || this.bridge.videoBase}"
@@ -268,8 +280,10 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Modules</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${total}</span>
-        <span class="surface-status">Dashboards ready: ${withCockpit}</span>
-        <span class="surface-status">Awaiting dashboards: ${withoutCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Dashboards ready: ${withCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Awaiting dashboards: ${withoutCockpit}</span>
       </section>
     `;
   }
@@ -322,7 +336,7 @@ class CockpitDashboard extends LitElement {
     const hostName = this.host && this.host.name ? this.host.name : "the host";
     if (
       typeof window === "undefined" ||
-      window.confirm(`Are you sure you want to ${verb} ${hostName}?`)
+      globalThis.confirm(`Are you sure you want to ${verb} ${hostName}?`)
     ) {
       await this._runHostOperation(canonical);
     }


### PR DESCRIPTION
💡 **What**: Added `role="status"` with `aria-live="polite"` to regular dynamic status messages, and `role="alert"` with `aria-live="assertive"` to error messages in the `cockpit-dashboard.js` component.
🎯 **Why**: When the cockpit dashboard dynamically fetches and updates its status metadata or encounters errors (e.g., when refreshing or triggering host actions), screen readers previously had no way of knowing the content had changed. This makes those important updates proactively announced.
📸 **Before/After**: Visually unchanged.
♿ **Accessibility**: Improves screen reader compatibility for dynamic components without requiring manual focus.

Also created `.Jules/palette.md` to journal this critical learning regarding Lit element dynamic text updates.

---
*PR created automatically by Jules for task [11724741524345239167](https://jules.google.com/task/11724741524345239167) started by @dancxjo*