### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons for better UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-02 - Add tooltips to icon-only buttons for hover accessibility
+**Learning:** I discovered that several icon-only buttons with "aria-label" in the cockpit web UI were missing the "title" attribute. This lack of "title" caused a missing native hover tooltip for users relying on mouse navigation.
+**Action:** Ensure all icon-only buttons not only have "aria-label" or "aria-hidden" spans but also have the "title" attribute attached so hover tooltips appear natively.

--- a/modules/cockpit/packages/cockpit/cockpit/frontend/config/index.html
+++ b/modules/cockpit/packages/cockpit/cockpit/frontend/config/index.html
@@ -1,81 +1,118 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Psyched Cockpit – Module Configuration</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%230055ff'/%3E%3Ctext x='8' y='12' font-size='9' text-anchor='middle' fill='%23ffffff'%3E%CE%A8%3C/text%3E%3C/svg%3E"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Psyched Cockpit – Module Configuration</title>
-  <link rel="icon"
-    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%230055ff'/%3E%3Ctext x='8' y='12' font-size='9' text-anchor='middle' fill='%23ffffff'%3E%CE%A8%3C/text%3E%3C/svg%3E" />
-  <link rel="stylesheet" href="/styles.css" />
-</head>
+  <body class="lcars-body config-page">
+    <aside class="lcars-nav config-nav">
+      <div class="nav-title">config</div>
+      <a class="nav-button nav-button--link" href="/">
+        <span class="nav-index">⟵</span>
+        <span class="nav-label">Back to Dashboards</span>
+      </a>
+      <p class="config-nav__hint">
+        Adjust module launch options and environment variables directly from the
+        cockpit. Saved changes are written to the host manifest immediately.
+      </p>
+    </aside>
 
-<body class="lcars-body config-page">
-  <aside class="lcars-nav config-nav">
-    <div class="nav-title">config</div>
-    <a class="nav-button nav-button--link" href="/">
-      <span class="nav-index">⟵</span>
-      <span class="nav-label">Back to Dashboards</span>
-    </a>
-    <p class="config-nav__hint">
-      Adjust module launch options and environment variables directly from the cockpit. Saved changes are written to the
-      host
-      manifest immediately.
-    </p>
-  </aside>
-
-  <main class="lcars-main config-main">
-    <header class="lcars-hero config-hero">
-      <div>
-        <h1>Module Configuration Console</h1>
-        <p>
-          Review and update the host manifest without leaving the cockpit. Each module exposes its launch settings in a
-          structured editor—submit a change to persist it instantly.
-        </p>
-        <p class="config-hero__hint">
-          Values must be valid JSON. Empty editors clear the module override while keeping the module listed on the
-          host.
-        </p>
-      </div>
-    </header>
-
-    <section class="config-toolbar" aria-label="Configuration actions">
-      <div class="config-toolbar__actions">
-        <button type="button" class="config-action icon-button icon-button--compact" data-role="refresh">
-          <span class="icon-button__icon" aria-hidden="true">🔄</span>
-          <span class="icon-button__label" aria-hidden="true">Refresh from host manifest</span>
-          <span class="icon-button__sr">Refresh from host manifest</span>
-        </button>
-        <button type="button" class="config-action icon-button icon-button--compact" data-role="git-pull">
-          <span class="icon-button__icon" aria-hidden="true">📥</span>
-          <span class="icon-button__label" aria-hidden="true">Git pull latest</span>
-          <span class="icon-button__sr">Git pull latest</span>
-        </button>
-        <div class="config-toolbar__group" role="group" aria-label="Bulk module lifecycle operations">
-          <button type="button" class="config-action icon-button icon-button--compact" data-role="psh-operation" data-operation="module-setup">
-            <span class="icon-button__icon" aria-hidden="true">🛠️</span>
-            <span class="icon-button__label" aria-hidden="true">psh mod setup</span>
-            <span class="icon-button__sr">psh mod setup</span>
-          </button>
-          <button type="button" class="config-action icon-button icon-button--compact" data-role="psh-operation" data-operation="module-up">
-            <span class="icon-button__icon" aria-hidden="true">🚀</span>
-            <span class="icon-button__label" aria-hidden="true">psh mod up</span>
-            <span class="icon-button__sr">psh mod up</span>
-          </button>
-          <button type="button" class="config-action icon-button icon-button--compact" data-role="psh-operation" data-operation="module-down">
-            <span class="icon-button__icon" aria-hidden="true">🛑</span>
-            <span class="icon-button__label" aria-hidden="true">psh mod down</span>
-            <span class="icon-button__sr">psh mod down</span>
-          </button>
+    <main class="lcars-main config-main">
+      <header class="lcars-hero config-hero">
+        <div>
+          <h1>Module Configuration Console</h1>
+          <p>
+            Review and update the host manifest without leaving the cockpit.
+            Each module exposes its launch settings in a structured
+            editor—submit a change to persist it instantly.
+          </p>
+          <p class="config-hero__hint">
+            Values must be valid JSON. Empty editors clear the module override
+            while keeping the module listed on the host.
+          </p>
         </div>
-      </div>
-      <span class="config-status" role="status" aria-live="polite"></span>
-    </section>
+      </header>
 
-    <div id="config-app" class="config-app" aria-live="polite"></div>
-  </main>
+      <section class="config-toolbar" aria-label="Configuration actions">
+        <div class="config-toolbar__actions">
+          <button
+            type="button"
+            class="config-action icon-button icon-button--compact"
+            data-role="refresh"
+            title="Refresh from host manifest"
+          >
+            <span class="icon-button__icon" aria-hidden="true">🔄</span>
+            <span class="icon-button__label" aria-hidden="true"
+            >Refresh from host manifest</span>
+            <span class="icon-button__sr">Refresh from host manifest</span>
+          </button>
+          <button
+            type="button"
+            class="config-action icon-button icon-button--compact"
+            data-role="git-pull"
+            title="Git pull latest"
+          >
+            <span class="icon-button__icon" aria-hidden="true">📥</span>
+            <span class="icon-button__label" aria-hidden="true"
+            >Git pull latest</span>
+            <span class="icon-button__sr">Git pull latest</span>
+          </button>
+          <div
+            class="config-toolbar__group"
+            role="group"
+            aria-label="Bulk module lifecycle operations"
+          >
+            <button
+              type="button"
+              class="config-action icon-button icon-button--compact"
+              data-role="psh-operation"
+              data-operation="module-setup"
+              title="psh mod setup"
+            >
+              <span class="icon-button__icon" aria-hidden="true">🛠️</span>
+              <span class="icon-button__label" aria-hidden="true"
+              >psh mod setup</span>
+              <span class="icon-button__sr">psh mod setup</span>
+            </button>
+            <button
+              type="button"
+              class="config-action icon-button icon-button--compact"
+              data-role="psh-operation"
+              data-operation="module-up"
+              title="psh mod up"
+            >
+              <span class="icon-button__icon" aria-hidden="true">🚀</span>
+              <span class="icon-button__label" aria-hidden="true"
+              >psh mod up</span>
+              <span class="icon-button__sr">psh mod up</span>
+            </button>
+            <button
+              type="button"
+              class="config-action icon-button icon-button--compact"
+              data-role="psh-operation"
+              data-operation="module-down"
+              title="psh mod down"
+            >
+              <span class="icon-button__icon" aria-hidden="true">🛑</span>
+              <span class="icon-button__label" aria-hidden="true"
+              >psh mod down</span>
+              <span class="icon-button__sr">psh mod down</span>
+            </button>
+          </div>
+        </div>
+        <span class="config-status" role="status" aria-live="polite"></span>
+      </section>
 
-  <script type="module" src="/config/app.js"></script>
-</body>
+      <div id="config-app" class="config-app" aria-live="polite"></div>
+    </main>
 
+    <script type="module" src="/config/app.js"></script>
+  </body>
 </html>

--- a/modules/cockpit/packages/cockpit/cockpit/frontend/js/collapsible-cards.js
+++ b/modules/cockpit/packages/cockpit/cockpit/frontend/js/collapsible-cards.js
@@ -132,7 +132,11 @@ function ensureToggle(header) {
     toggle.className = "surface-card__toggle icon-button icon-button--compact";
     header.appendChild(toggle);
   } else {
-    toggle.classList.add("surface-card__toggle", "icon-button", "icon-button--compact");
+    toggle.classList.add(
+      "surface-card__toggle",
+      "icon-button",
+      "icon-button--compact",
+    );
   }
   return toggle;
 }
@@ -200,6 +204,7 @@ function applyCollapsedState(card, toggle, content, collapsed, titleText) {
   }
   toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
   toggle.setAttribute("aria-label", hiddenLabel);
+  toggle.setAttribute("title", hiddenLabel);
 }
 
 function monitorShadowRoot(shadowRoot) {


### PR DESCRIPTION
💡 **What:** Added native `title` attributes to multiple icon-only `.surface-action` and toggle buttons across the cockpit web interface so they provide browser tooltips matching their screen-reader `aria-label` text.
🎯 **Why:** To improve discoverability. While these buttons successfully exposed their names to screen readers via `aria-label`, users navigating with a mouse had no visual hint (tooltip) regarding the icon's action, causing friction in the UI.
📸 **Before/After:** Before, hovering over the refresh and operation buttons showed no text tooltip. Now, hovering reveals standard browser tooltips (e.g., "Refresh from host manifest").
♿ **Accessibility:** This aligns mouse-user discoverability with screen-reader functionality. By combining `aria-label` and `title`, we ensure that the button purpose is explicitly communicated to all users, regardless of how they interface with the application.

---
*PR created automatically by Jules for task [12502068992635826770](https://jules.google.com/task/12502068992635826770) started by @dancxjo*