### PR TITLE
🎨 Palette: Add ARIA live regions for screen reader status announcements

### DIFF
--- a/modules/cockpit/cockpit/components/cockpit-dashboard.js
+++ b/modules/cockpit/cockpit/components/cockpit-dashboard.js
@@ -141,11 +141,9 @@ class CockpitDashboard extends LitElement {
                 @click="${() => this.refresh()}"
               >
                 <span class="surface-action__icon" aria-hidden="true"
-                  >${refreshIcon}</span
-                >
+                >${refreshIcon}</span>
                 <span class="surface-action__label" aria-hidden="true"
-                  >${refreshLabel}</span
-                >
+                >${refreshLabel}</span>
               </button>
             </div>
           </header>
@@ -161,19 +159,30 @@ class CockpitDashboard extends LitElement {
   _renderStatus() {
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading) {
       return html`
-        <p class="surface-status">Loading cockpit metadata…</p>
+        <p class="surface-status" role="status" aria-live="polite">
+          Loading cockpit metadata…
+        </p>
       `;
     }
     const timestamp = this.lastUpdated instanceof Date
       ? this.lastUpdated.toLocaleTimeString()
       : "Never";
     return html`
-      <p class="surface-status">Updated ${timestamp}</p>
+      <p class="surface-status" role="status" aria-live="polite">
+        Updated ${timestamp}
+      </p>
     `;
   }
 
@@ -201,12 +210,8 @@ class CockpitDashboard extends LitElement {
             title="${shutdownLabel}"
             @click="${() => this._confirmHostOperation("shutdown")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${shutdownIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${shutdownLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${shutdownIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${shutdownLabel}</span>
           </button>
           <button
             type="button"
@@ -217,18 +222,23 @@ class CockpitDashboard extends LitElement {
             title="${restartLabel}"
             @click="${() => this._confirmHostOperation("restart")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${restartIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${restartLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${restartIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${restartLabel}</span>
           </button>
         </div>
         ${this.hostActionStatus
           ? html`
-            <p class="surface-status" data-variant="${this.hostActionVariant ||
-              undefined}">${this.hostActionStatus}</p>
+            <p
+              class="surface-status"
+              data-variant="${this.hostActionVariant ||
+                undefined}"
+              role="${this.hostActionVariant === "error" ? "alert" : "status"}"
+              aria-live="${this.hostActionVariant === "error"
+                ? "assertive"
+                : "polite"}"
+            >
+              ${this.hostActionStatus}
+            </p>
           `
           : ""}
       </section>
@@ -322,7 +332,7 @@ class CockpitDashboard extends LitElement {
     const hostName = this.host && this.host.name ? this.host.name : "the host";
     if (
       typeof window === "undefined" ||
-      window.confirm(`Are you sure you want to ${verb} ${hostName}?`)
+      globalThis.confirm(`Are you sure you want to ${verb} ${hostName}?`)
     ) {
       await this._runHostOperation(canonical);
     }


### PR DESCRIPTION
💡 What:
Added ARIA attributes (`role` and `aria-live`) to the dynamic status messages in the cockpit dashboard component.

🎯 Why:
To ensure that screen readers automatically announce important status changes (like starting up, encountering an error, or dispatching a restart/shutdown command) to the user without requiring them to manually move focus to read the text.

📸 Before/After:
No visual difference. The updates only apply to the ARIA tree exposed to assistive technologies. 

♿ Accessibility:
- Adds `role="status" aria-live="polite"` for non-critical updates like loading or refresh completion.
- Adds `role="alert" aria-live="assertive"` for critical error messages or failures.
- Now when users interact with the Shutdown/Restart buttons, screen readers will immediately announce the dispatch status.

---
*PR created automatically by Jules for task [4261698274008259811](https://jules.google.com/task/4261698274008259811) started by @dancxjo*