### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded NEO4J_AUTH secret

### DIFF
--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `docker-compose.yml` file for the `graphs` service contained a hardcoded database password (`neo4j/password`) for `NEO4J_AUTH`. Hardcoding credentials in version control is a major security risk.
🎯 Impact: An attacker with access to the repository could extract the database credentials and gain unauthorized access to the Neo4j graph database, leading to potential data breaches or modification of critical memory data.
🔧 Fix: Replaced the hardcoded credentials with `${NEO4J_AUTH?must be set}`. This ensures the environment variable is passed in dynamically and acts as a strict safeguard, causing Docker Compose to fail securely with an explicit error if the authentication variable is missing, rather than failing open or falling back to defaults.
✅ Verification: Ran `docker compose config` with and without the `NEO4J_AUTH` environment variable set to confirm that it properly injects the variable and correctly throws a "required variable is missing" error when unset.

---
*PR created automatically by Jules for task [13313270976128849051](https://jules.google.com/task/13313270976128849051) started by @dancxjo*