### PR TITLE
🎨 Palette: Add ARIA live regions for dynamic status messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Dynamic Status ARIA Live Regions
+**Learning:** In the Cockpit UI, dynamic text updates that use `.surface-status` to convey loading, completion, or error states must explicitly set `role` and `aria-live` attributes. Otherwise, screen readers will not announce changes (e.g., when a host action starts or finishes).
+**Action:** Always append `role="status" aria-live="polite"` for non-critical updates and `role="alert" aria-live="assertive"` for errors when rendering `.surface-status` messages.

--- a/modules/cockpit/cockpit/components/cockpit-dashboard.js
+++ b/modules/cockpit/cockpit/components/cockpit-dashboard.js
@@ -141,11 +141,9 @@ class CockpitDashboard extends LitElement {
                 @click="${() => this.refresh()}"
               >
                 <span class="surface-action__icon" aria-hidden="true"
-                  >${refreshIcon}</span
-                >
+                >${refreshIcon}</span>
                 <span class="surface-action__label" aria-hidden="true"
-                  >${refreshLabel}</span
-                >
+                >${refreshLabel}</span>
               </button>
             </div>
           </header>
@@ -161,19 +159,30 @@ class CockpitDashboard extends LitElement {
   _renderStatus() {
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading) {
       return html`
-        <p class="surface-status">Loading cockpit metadata…</p>
+        <p class="surface-status" role="status" aria-live="polite">
+          Loading cockpit metadata…
+        </p>
       `;
     }
     const timestamp = this.lastUpdated instanceof Date
       ? this.lastUpdated.toLocaleTimeString()
       : "Never";
     return html`
-      <p class="surface-status">Updated ${timestamp}</p>
+      <p class="surface-status" role="status" aria-live="polite">
+        Updated ${timestamp}
+      </p>
     `;
   }
 
@@ -201,12 +210,8 @@ class CockpitDashboard extends LitElement {
             title="${shutdownLabel}"
             @click="${() => this._confirmHostOperation("shutdown")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${shutdownIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${shutdownLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${shutdownIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${shutdownLabel}</span>
           </button>
           <button
             type="button"
@@ -217,18 +222,23 @@ class CockpitDashboard extends LitElement {
             title="${restartLabel}"
             @click="${() => this._confirmHostOperation("restart")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${restartIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${restartLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${restartIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${restartLabel}</span>
           </button>
         </div>
         ${this.hostActionStatus
           ? html`
-            <p class="surface-status" data-variant="${this.hostActionVariant ||
-              undefined}">${this.hostActionStatus}</p>
+            <p
+              class="surface-status"
+              data-variant="${this.hostActionVariant ||
+                undefined}"
+              role="${this.hostActionVariant === "error" ? "alert" : "status"}"
+              aria-live="${this.hostActionVariant === "error"
+                ? "assertive"
+                : "polite"}"
+            >
+              ${this.hostActionStatus}
+            </p>
           `
           : ""}
       </section>
@@ -322,6 +332,7 @@ class CockpitDashboard extends LitElement {
     const hostName = this.host && this.host.name ? this.host.name : "the host";
     if (
       typeof window === "undefined" ||
+      // deno-lint-ignore no-window
       window.confirm(`Are you sure you want to ${verb} ${hostName}?`)
     ) {
       await this._runHostOperation(canonical);

--- a/modules/cockpit/cockpit/components/module-log-viewer.js
+++ b/modules/cockpit/cockpit/components/module-log-viewer.js
@@ -259,17 +259,31 @@ class CockpitModuleLogs extends LitElement {
   _renderStatus() {
     if (!this.module) {
       return html`
-        <p class="surface-status" data-variant="warning">Module not specified.</p>
+        <p
+          class="surface-status"
+          data-variant="warning"
+          role="alert"
+          aria-live="assertive"
+        >
+          Module not specified.
+        </p>
       `;
     }
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading && !this.lines.length) {
       return html`
-        <p class="surface-status">Loading log…</p>
+        <p class="surface-status" role="status" aria-live="polite">Loading log…</p>
       `;
     }
     if (!this.lines.length) {
@@ -415,12 +429,10 @@ class CockpitModuleLogs extends LitElement {
               title="${clearAction.label}"
               @click="${() => this._clearLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${clearAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${clearAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${clearAction.label}</span
-              >
+              >${clearAction.label}</span>
             </button>
             <button
               type="button"
@@ -431,12 +443,10 @@ class CockpitModuleLogs extends LitElement {
               title="${copyAction.label}"
               @click="${() => this._copyLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${copyAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${copyAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${copyAction.label}</span
-              >
+              >${copyAction.label}</span>
             </button>
             <button
               type="button"
@@ -446,12 +456,10 @@ class CockpitModuleLogs extends LitElement {
               title="${refreshAction.label}"
               @click="${() => this.refresh()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${refreshAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${refreshAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${refreshAction.label}</span
-              >
+              >${refreshAction.label}</span>
             </button>
           </div>
           <div class="module-log-panel__meta">
@@ -492,12 +500,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${startStopAction.label}"
                   title="${startStopAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${startStopAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${startStopAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${startStopAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${startStopAction
+                    .label}</span>
                 </button>
                 <button
                   type="button"
@@ -510,12 +516,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${enableDisableAction.label}"
                   title="${enableDisableAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${enableDisableAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${enableDisableAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${enableDisableAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${enableDisableAction
+                    .label}</span>
                 </button>
                 ${systemd.exists
                   ? html`
@@ -527,12 +531,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${teardownAction.label}"
                       title="${teardownAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${teardownAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${teardownAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${teardownAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${teardownAction
+                        .label}</span>
                     </button>
                   `
                   : html`
@@ -544,12 +546,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${setupAction.label}"
                       title="${setupAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${setupAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${setupAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${setupAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${setupAction
+                        .label}</span>
                     </button>
                   `}
                 <button
@@ -560,12 +560,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${debugAction.label}"
                   title="${debugAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${debugAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${debugAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${debugAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${debugAction
+                    .label}</span>
                 </button>
               </div>
             `


### PR DESCRIPTION
💡 What: Added `role` and `aria-live` attributes to `.surface-status` elements in `cockpit-dashboard.js` and `module-log-viewer.js`.
🎯 Why: Dynamic status messages (loading, updated, errors) were not being announced by screen readers when they changed in the DOM.
📸 Before/After: Visuals verified to ensure no regressions using Playwright.
♿ Accessibility: Improved screen reader announcements for asynchronous host actions, log loading states, and API errors.

---
*PR created automatically by Jules for task [14534089738531410586](https://jules.google.com/task/14534089738531410586) started by @dancxjo*