### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded NEO4J_AUTH in docker-compose.yml

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Hardcoded Database Credentials in Docker Compose
+**Vulnerability:** Hardcoded database credentials (`NEO4J_AUTH: neo4j/password`) were found in `services/graphs/docker-compose.yml`. This exposes sensitive database access information in version control.
+**Learning:** When trying to make development easy, we often hardcode credentials. However, removing them and replacing them with standard fallback environments (like `${NEO4J_AUTH:-none}`) is insecure because it fails open, completely disabling authentication mechanisms.
+**Prevention:** Always use `${VAR?must be set}` syntax for critical authentication environment variables in `docker-compose.yml`. This ensures the application "fails securely" (refuses to start) rather than "failing open" if the credential is forgotten.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Hardcoded database credentials (`neo4j/password`) were found in `services/graphs/docker-compose.yml`.
🎯 **Impact:** Anyone with access to the codebase would have the credentials to access the graph database, which is a significant risk if the code is public or leaked.
🔧 **Fix:** Replaced the hardcoded credentials with an environment variable requirement (`${NEO4J_AUTH?must be set}`) to fail securely. This ensures that the application will refuse to start if the variable is not provided, rather than falling back to an insecure default.
✅ **Verification:** Tested with `docker compose config` with and without the variable set to ensure it fails when missing and passes when provided.

---
*PR created automatically by Jules for task [9765538695211407380](https://jules.google.com/task/9765538695211407380) started by @dancxjo*