### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded neo4j passwords

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-14 - Prevent Hardcoded Credentials Failing Open
+
+**Vulnerability:** A hardcoded `neo4j/password` for `NEO4J_AUTH` existed in `services/graphs/docker-compose.yml`. Even worse, simply removing it without enforcing its existence could cause the database authentication to silently fail open or use insecure defaults.
+**Learning:** Hardcoded credentials should be removed without completely disabling the underlying authentication mechanisms (e.g., hardcoding `NEO4J_AUTH: none`) or using insecure environment fallbacks like `${VAR:-none}`.
+**Prevention:** Always enforce the presence of the environment variable (e.g., `${NEO4J_AUTH?must be set}`) in Docker Compose to ensure the system fails securely rather than failing open.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded `neo4j/password` for `NEO4J_AUTH` existed in `services/graphs/docker-compose.yml`, which could expose the database credentials.
🎯 **Impact:** If deployed with this hardcoded configuration, any attacker gaining access to the Neo4j instance could bypass authentication. Furthermore, silently removing the hardcoded value without enforcing its existence could cause the database authentication to fail open or use insecure defaults.
🔧 **Fix:** Replaced the hardcoded password with `${NEO4J_AUTH?must be set}` to enforce the presence of the environment variable in Docker Compose, ensuring the system fails securely rather than failing open. Documented this critical learning in `.jules/sentinel.md`.
✅ **Verification:** Ran `docker compose -f services/graphs/docker-compose.yml config` to verify that the configuration correctly requires `NEO4J_AUTH` and fails when it is absent.

---
*PR created automatically by Jules for task [12261323556941097051](https://jules.google.com/task/12261323556941097051) started by @dancxjo*