### PR TITLE
🎨 Palette: Add ARIA live regions to dynamic status messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-04-09 - Accessible Dynamic Status Messages
+
+**Learning:** Dynamic status messages indicating loading states, errors, or timestamp updates in the cockpit UI (often using the `.surface-status` class) were frequently inaccessible to screen reader users because they lacked proper ARIA live region declarations. Without these, assistive technologies would not announce state changes unless the user explicitly navigated to them.
+
+**Action:** Consistently apply `role="status"` with `aria-live="polite"` for non-critical dynamic updates (like "Loading..." or "Updated...") and `role="alert"` with `aria-live="assertive"` for critical error or warning states across all dynamic status elements in the cockpit UI.

--- a/modules/cockpit/cockpit/components/cockpit-dashboard.js
+++ b/modules/cockpit/cockpit/components/cockpit-dashboard.js
@@ -141,11 +141,9 @@ class CockpitDashboard extends LitElement {
                 @click="${() => this.refresh()}"
               >
                 <span class="surface-action__icon" aria-hidden="true"
-                  >${refreshIcon}</span
-                >
+                >${refreshIcon}</span>
                 <span class="surface-action__label" aria-hidden="true"
-                  >${refreshLabel}</span
-                >
+                >${refreshLabel}</span>
               </button>
             </div>
           </header>
@@ -161,19 +159,30 @@ class CockpitDashboard extends LitElement {
   _renderStatus() {
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading) {
       return html`
-        <p class="surface-status">Loading cockpit metadata…</p>
+        <p class="surface-status" role="status" aria-live="polite">
+          Loading cockpit metadata…
+        </p>
       `;
     }
     const timestamp = this.lastUpdated instanceof Date
       ? this.lastUpdated.toLocaleTimeString()
       : "Never";
     return html`
-      <p class="surface-status">Updated ${timestamp}</p>
+      <p class="surface-status" role="status" aria-live="polite">
+        Updated ${timestamp}
+      </p>
     `;
   }
 
@@ -190,7 +199,8 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Host</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${this.host.name}</span>
-        <span class="surface-status">Shortname: ${this.host.shortname}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Shortname: ${this.host.shortname}</span>
         <div class="host-actions">
           <button
             type="button"
@@ -201,12 +211,8 @@ class CockpitDashboard extends LitElement {
             title="${shutdownLabel}"
             @click="${() => this._confirmHostOperation("shutdown")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${shutdownIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${shutdownLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${shutdownIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${shutdownLabel}</span>
           </button>
           <button
             type="button"
@@ -217,18 +223,21 @@ class CockpitDashboard extends LitElement {
             title="${restartLabel}"
             @click="${() => this._confirmHostOperation("restart")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${restartIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${restartLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${restartIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${restartLabel}</span>
           </button>
         </div>
         ${this.hostActionStatus
           ? html`
-            <p class="surface-status" data-variant="${this.hostActionVariant ||
-              undefined}">${this.hostActionStatus}</p>
+            <p
+              class="surface-status"
+              role="status"
+              aria-live="polite"
+              data-variant="${this.hostActionVariant ||
+                undefined}"
+            >
+              ${this.hostActionStatus}
+            </p>
           `
           : ""}
       </section>
@@ -240,11 +249,12 @@ class CockpitDashboard extends LitElement {
       <section class="surface-metric">
         <span class="surface-metric__label">ROS Bridge</span>
         <span class="surface-metric__value">${this.bridge.mode}</span>
-        <span class="surface-status">Primary: ${this.bridge
+        <span class="surface-status" role="status" aria-live="polite"
+        >Primary: ${this.bridge
           .effectiveRosbridgeUri}</span>
         ${this.bridge.videoBase
           ? html`
-            <span class="surface-status">
+            <span class="surface-status" role="status" aria-live="polite">
               Video base:
               <a
                 href="${this.bridge.videoUrl || this.bridge.videoBase}"
@@ -268,8 +278,10 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Modules</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${total}</span>
-        <span class="surface-status">Dashboards ready: ${withCockpit}</span>
-        <span class="surface-status">Awaiting dashboards: ${withoutCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Dashboards ready: ${withCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Awaiting dashboards: ${withoutCockpit}</span>
       </section>
     `;
   }
@@ -322,7 +334,7 @@ class CockpitDashboard extends LitElement {
     const hostName = this.host && this.host.name ? this.host.name : "the host";
     if (
       typeof window === "undefined" ||
-      window.confirm(`Are you sure you want to ${verb} ${hostName}?`)
+      globalThis.confirm(`Are you sure you want to ${verb} ${hostName}?`)
     ) {
       await this._runHostOperation(canonical);
     }

--- a/modules/cockpit/cockpit/components/module-log-viewer.js
+++ b/modules/cockpit/cockpit/components/module-log-viewer.js
@@ -259,17 +259,31 @@ class CockpitModuleLogs extends LitElement {
   _renderStatus() {
     if (!this.module) {
       return html`
-        <p class="surface-status" data-variant="warning">Module not specified.</p>
+        <p
+          class="surface-status"
+          data-variant="warning"
+          role="alert"
+          aria-live="assertive"
+        >
+          Module not specified.
+        </p>
       `;
     }
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading && !this.lines.length) {
       return html`
-        <p class="surface-status">Loading log…</p>
+        <p class="surface-status" role="status" aria-live="polite">Loading log…</p>
       `;
     }
     if (!this.lines.length) {
@@ -415,12 +429,10 @@ class CockpitModuleLogs extends LitElement {
               title="${clearAction.label}"
               @click="${() => this._clearLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${clearAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${clearAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${clearAction.label}</span
-              >
+              >${clearAction.label}</span>
             </button>
             <button
               type="button"
@@ -431,12 +443,10 @@ class CockpitModuleLogs extends LitElement {
               title="${copyAction.label}"
               @click="${() => this._copyLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${copyAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${copyAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${copyAction.label}</span
-              >
+              >${copyAction.label}</span>
             </button>
             <button
               type="button"
@@ -446,12 +456,10 @@ class CockpitModuleLogs extends LitElement {
               title="${refreshAction.label}"
               @click="${() => this.refresh()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${refreshAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${refreshAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${refreshAction.label}</span
-              >
+              >${refreshAction.label}</span>
             </button>
           </div>
           <div class="module-log-panel__meta">
@@ -492,12 +500,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${startStopAction.label}"
                   title="${startStopAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${startStopAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${startStopAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${startStopAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${startStopAction
+                    .label}</span>
                 </button>
                 <button
                   type="button"
@@ -510,12 +516,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${enableDisableAction.label}"
                   title="${enableDisableAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${enableDisableAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${enableDisableAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${enableDisableAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${enableDisableAction
+                    .label}</span>
                 </button>
                 ${systemd.exists
                   ? html`
@@ -527,12 +531,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${teardownAction.label}"
                       title="${teardownAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${teardownAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${teardownAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${teardownAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${teardownAction
+                        .label}</span>
                     </button>
                   `
                   : html`
@@ -544,12 +546,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${setupAction.label}"
                       title="${setupAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${setupAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${setupAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${setupAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${setupAction
+                        .label}</span>
                     </button>
                   `}
                 <button
@@ -560,12 +560,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${debugAction.label}"
                   title="${debugAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${debugAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${debugAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${debugAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${debugAction
+                    .label}</span>
                 </button>
               </div>
             `


### PR DESCRIPTION
* 💡 What: Added appropriate `role` and `aria-live` attributes to `.surface-status` elements in `cockpit-dashboard.js` and `module-log-viewer.js`.
* 🎯 Why: Dynamic status messages (such as loading indicators, errors, and updated timestamps) were not automatically announced by screen readers when their text content changed.
* 📸 Before/After: Visual presentation is unchanged, but DOM semantics now support AT announcements.
* ♿ Accessibility: Improved screen reader support by ensuring critical updates use `role="alert" aria-live="assertive"` and non-critical updates use `role="status" aria-live="polite"`.

---
*PR created automatically by Jules for task [1007981864401896031](https://jules.google.com/task/1007981864401896031) started by @dancxjo*