### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded Neo4j credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-09 - Secure environment variable enforcement in docker-compose
+**Vulnerability:** Hardcoded credentials (`neo4j/password`) were present in `services/graphs/docker-compose.yml` via the `NEO4J_AUTH` environment variable, which could expose sensitive data and allows the service to start with known, default credentials.
+**Learning:** Fallbacks like `${VAR:-none}` can inadvertently cause an application to fail open if the environment variable is missing, allowing access with default or weak settings. Instead, configurations should be designed to "fail securely".
+**Prevention:** Use the syntax `${VAR?must be set}` in docker-compose.yml files for critical authentication variables. This strictly enforces the variable's presence and halts deployment if missing, preventing the service from starting in an insecure state.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Hardcoded credentials (`neo4j/password`) were present in `services/graphs/docker-compose.yml` for the Neo4j database service.
🎯 **Impact:** Exposes the database to unauthorized access with known default credentials, and insecure fallback configuration could allow the service to start openly if variables are missing.
🔧 **Fix:** Changed `NEO4J_AUTH: neo4j/password` to `NEO4J_AUTH: ${NEO4J_AUTH?must be set}` to strictly enforce the presence of authentication credentials and ensure the application fails securely.
✅ **Verification:** Verified that `docker compose config` correctly interpolates when `NEO4J_AUTH` is provided, and halts with an error when missing. Added `.jules/sentinel.md` learning entry. Tests and format checks successfully pass.

---
*PR created automatically by Jules for task [8734679866086572175](https://jules.google.com/task/8734679866086572175) started by @dancxjo*