### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-04-10 - Hardcoded Database Credentials in Docker Compose
+
+**Vulnerability:** A hardcoded Neo4j password (`NEO4J_AUTH: neo4j/password`) was discovered in `services/graphs/docker-compose.yml`. This exposes database credentials in version control and allows anyone with access to the codebase or container to authenticate to the graph database.
+
+**Learning:** Development environments often use hardcoded passwords for convenience during initial setup. However, these often leak into production environments or are committed to repositories, creating a critical vulnerability where sensitive data can be accessed or modified by unauthorized individuals.
+
+**Prevention:** Never hardcode secrets or passwords in configuration files or code. Use environment variables with validation (e.g., `${NEO4J_AUTH?must be set}`) to enforce that credentials are provided securely at runtime. This approach ensures the application "fails securely" (refuses to start) rather than "failing open" with default or empty credentials if the environment variable is missing.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
A hardcoded Neo4j password (`neo4j/password`) was present in `services/graphs/docker-compose.yml`. Hardcoded credentials in configuration files or code exposed via version control present a critical security risk.

🎯 **Impact:**
Anyone with access to the codebase or the container environment could easily authenticate to the graph database, potentially reading, modifying, or deleting sensitive application data.

🔧 **Fix:**
Replaced the hardcoded password with an environment variable using bash parameter expansion validation (`${NEO4J_AUTH?must be set}`). This ensures that:
1. Credentials are no longer committed to version control.
2. The application "fails securely" (refuses to start) if the required environment variable is not provided, rather than "failing open" or falling back to an insecure default.

✅ **Verification:**
- Ran `docker compose -f services/graphs/docker-compose.yml config` and verified it properly fails with an error when `NEO4J_AUTH` is missing.
- Ran `NEO4J_AUTH=test docker compose ... config` and verified it successfully constructs the config.
- Ran `pytest` across project tests to ensure no regressions.

---
*PR created automatically by Jules for task [10998550819640358373](https://jules.google.com/task/10998550819640358373) started by @dancxjo*