### PR TITLE
🎨 Palette: Add ARIA live regions to dynamic status messages

### DIFF
--- a/modules/cockpit/cockpit/components/cockpit-dashboard.js
+++ b/modules/cockpit/cockpit/components/cockpit-dashboard.js
@@ -141,11 +141,9 @@ class CockpitDashboard extends LitElement {
                 @click="${() => this.refresh()}"
               >
                 <span class="surface-action__icon" aria-hidden="true"
-                  >${refreshIcon}</span
-                >
+                >${refreshIcon}</span>
                 <span class="surface-action__label" aria-hidden="true"
-                  >${refreshLabel}</span
-                >
+                >${refreshLabel}</span>
               </button>
             </div>
           </header>
@@ -161,19 +159,30 @@ class CockpitDashboard extends LitElement {
   _renderStatus() {
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading) {
       return html`
-        <p class="surface-status">Loading cockpit metadata…</p>
+        <p class="surface-status" role="status" aria-live="polite">
+          Loading cockpit metadata…
+        </p>
       `;
     }
     const timestamp = this.lastUpdated instanceof Date
       ? this.lastUpdated.toLocaleTimeString()
       : "Never";
     return html`
-      <p class="surface-status">Updated ${timestamp}</p>
+      <p class="surface-status" role="status" aria-live="polite">
+        Updated ${timestamp}
+      </p>
     `;
   }
 
@@ -190,7 +199,8 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Host</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${this.host.name}</span>
-        <span class="surface-status">Shortname: ${this.host.shortname}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Shortname: ${this.host.shortname}</span>
         <div class="host-actions">
           <button
             type="button"
@@ -201,12 +211,8 @@ class CockpitDashboard extends LitElement {
             title="${shutdownLabel}"
             @click="${() => this._confirmHostOperation("shutdown")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${shutdownIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${shutdownLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${shutdownIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${shutdownLabel}</span>
           </button>
           <button
             type="button"
@@ -217,18 +223,23 @@ class CockpitDashboard extends LitElement {
             title="${restartLabel}"
             @click="${() => this._confirmHostOperation("restart")}"
           >
-            <span class="surface-action__icon" aria-hidden="true"
-              >${restartIcon}</span
-            >
-            <span class="surface-action__label" aria-hidden="true"
-              >${restartLabel}</span
-            >
+            <span class="surface-action__icon" aria-hidden="true">${restartIcon}</span>
+            <span class="surface-action__label" aria-hidden="true">${restartLabel}</span>
           </button>
         </div>
         ${this.hostActionStatus
           ? html`
-            <p class="surface-status" data-variant="${this.hostActionVariant ||
-              undefined}">${this.hostActionStatus}</p>
+            <p
+              class="surface-status"
+              data-variant="${this.hostActionVariant ||
+                undefined}"
+              role="${this.hostActionVariant === "error" ? "alert" : "status"}"
+              aria-live="${this.hostActionVariant === "error"
+                ? "assertive"
+                : "polite"}"
+            >
+              ${this.hostActionStatus}
+            </p>
           `
           : ""}
       </section>
@@ -240,11 +251,12 @@ class CockpitDashboard extends LitElement {
       <section class="surface-metric">
         <span class="surface-metric__label">ROS Bridge</span>
         <span class="surface-metric__value">${this.bridge.mode}</span>
-        <span class="surface-status">Primary: ${this.bridge
+        <span class="surface-status" role="status" aria-live="polite"
+        >Primary: ${this.bridge
           .effectiveRosbridgeUri}</span>
         ${this.bridge.videoBase
           ? html`
-            <span class="surface-status">
+            <span class="surface-status" role="status" aria-live="polite">
               Video base:
               <a
                 href="${this.bridge.videoUrl || this.bridge.videoBase}"
@@ -268,8 +280,10 @@ class CockpitDashboard extends LitElement {
         <span class="surface-metric__label">Modules</span>
         <span class="surface-metric__value surface-metric__value--large"
         >${total}</span>
-        <span class="surface-status">Dashboards ready: ${withCockpit}</span>
-        <span class="surface-status">Awaiting dashboards: ${withoutCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Dashboards ready: ${withCockpit}</span>
+        <span class="surface-status" role="status" aria-live="polite"
+        >Awaiting dashboards: ${withoutCockpit}</span>
       </section>
     `;
   }

--- a/modules/cockpit/cockpit/components/module-log-viewer.js
+++ b/modules/cockpit/cockpit/components/module-log-viewer.js
@@ -259,22 +259,38 @@ class CockpitModuleLogs extends LitElement {
   _renderStatus() {
     if (!this.module) {
       return html`
-        <p class="surface-status" data-variant="warning">Module not specified.</p>
+        <p
+          class="surface-status"
+          data-variant="warning"
+          role="alert"
+          aria-live="polite"
+        >
+          Module not specified.
+        </p>
       `;
     }
     if (this.errorMessage) {
       return html`
-        <p class="surface-status" data-variant="error">${this.errorMessage}</p>
+        <p
+          class="surface-status"
+          data-variant="error"
+          role="alert"
+          aria-live="assertive"
+        >
+          ${this.errorMessage}
+        </p>
       `;
     }
     if (this.loading && !this.lines.length) {
       return html`
-        <p class="surface-status">Loading log…</p>
+        <p class="surface-status" role="status" aria-live="polite">Loading log…</p>
       `;
     }
     if (!this.lines.length) {
       return html`
-        <p class="surface-log__empty">No log entries captured yet.</p>
+        <p class="surface-log__empty" role="status" aria-live="polite">
+          No log entries captured yet.
+        </p>
       `;
     }
     const ansiText = this.lines.join("\n");
@@ -415,12 +431,10 @@ class CockpitModuleLogs extends LitElement {
               title="${clearAction.label}"
               @click="${() => this._clearLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${clearAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${clearAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${clearAction.label}</span
-              >
+              >${clearAction.label}</span>
             </button>
             <button
               type="button"
@@ -431,12 +445,10 @@ class CockpitModuleLogs extends LitElement {
               title="${copyAction.label}"
               @click="${() => this._copyLogs()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${copyAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${copyAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${copyAction.label}</span
-              >
+              >${copyAction.label}</span>
             </button>
             <button
               type="button"
@@ -446,12 +458,10 @@ class CockpitModuleLogs extends LitElement {
               title="${refreshAction.label}"
               @click="${() => this.refresh()}"
             >
-              <span class="surface-action__icon" aria-hidden="true"
-                >${refreshAction.icon}</span
-              >
+              <span class="surface-action__icon" aria-hidden="true">${refreshAction
+                .icon}</span>
               <span class="surface-action__label" aria-hidden="true"
-                >${refreshAction.label}</span
-              >
+              >${refreshAction.label}</span>
             </button>
           </div>
           <div class="module-log-panel__meta">
@@ -492,12 +502,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${startStopAction.label}"
                   title="${startStopAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${startStopAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${startStopAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${startStopAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${startStopAction
+                    .label}</span>
                 </button>
                 <button
                   type="button"
@@ -510,12 +518,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${enableDisableAction.label}"
                   title="${enableDisableAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${enableDisableAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${enableDisableAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${enableDisableAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${enableDisableAction
+                    .label}</span>
                 </button>
                 ${systemd.exists
                   ? html`
@@ -527,12 +533,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${teardownAction.label}"
                       title="${teardownAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${teardownAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${teardownAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${teardownAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${teardownAction
+                        .label}</span>
                     </button>
                   `
                   : html`
@@ -544,12 +548,10 @@ class CockpitModuleLogs extends LitElement {
                       aria-label="${setupAction.label}"
                       title="${setupAction.label}"
                     >
-                      <span class="surface-action__icon" aria-hidden="true"
-                        >${setupAction.icon}</span
-                      >
-                      <span class="surface-action__label" aria-hidden="true"
-                        >${setupAction.label}</span
-                      >
+                      <span class="surface-action__icon" aria-hidden="true">${setupAction
+                        .icon}</span>
+                      <span class="surface-action__label" aria-hidden="true">${setupAction
+                        .label}</span>
                     </button>
                   `}
                 <button
@@ -560,12 +562,10 @@ class CockpitModuleLogs extends LitElement {
                   aria-label="${debugAction.label}"
                   title="${debugAction.label}"
                 >
-                  <span class="surface-action__icon" aria-hidden="true"
-                    >${debugAction.icon}</span
-                  >
-                  <span class="surface-action__label" aria-hidden="true"
-                    >${debugAction.label}</span
-                  >
+                  <span class="surface-action__icon" aria-hidden="true">${debugAction
+                    .icon}</span>
+                  <span class="surface-action__label" aria-hidden="true">${debugAction
+                    .label}</span>
                 </button>
               </div>
             `


### PR DESCRIPTION
### 💡 What
Added ARIA live region attributes (`role="status"`/`aria-live="polite"`, and `role="alert"`/`aria-live="assertive"`) to dynamically updated status messages across the Cockpit frontend components, specifically targeting the `.surface-status` class instances in `cockpit-dashboard.js` and `module-log-viewer.js`.

### 🎯 Why
These `.surface-status` elements frequently update to display loading text, background refresh times, node health check statuses, and API error states asynchronously. Previously, users relying on screen readers would not be notified of these background state changes without manually navigating back to the text elements. By applying proper ARIA live regions, assistive technologies will now automatically announce critical errors and polite status updates, vastly improving the usability of the diagnostic interfaces.

### 📸 Before/After
*(No visual changes, purely semantic HTML additions.)*

### ♿ Accessibility
- **Screen Reader Announcements:** Dynamic text changes, like "Loading cockpit metadata…", "Updated 10:45 AM", and error boundaries are now actively announced.
- **Appropriate Assertiveness:** Distinguishes between critical errors (`aria-live="assertive"`, `role="alert"`) which interrupt current speech, and background status updates (`aria-live="polite"`, `role="status"`) which wait for a pause.

---
*PR created automatically by Jules for task [4719590103040107488](https://jules.google.com/task/4719590103040107488) started by @dancxjo*