### PR TITLE
⚡ Bolt: [performance improvement] Optimize base64 byte array conversion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Avoid Byte-By-Byte String Concatenation and Full-Array apply for Base64 Conversions
+**Learning:** In JavaScript, converting large byte arrays (like raw PCM audio or video frames) to base64 using a byte-by-byte `forEach` or `for` loop with `String.fromCharCode` creates O(N^2) performance bottlenecks due to string concatenation overhead. Conversely, applying `String.fromCharCode.apply(null, array)` on the entire array at once can cause "Maximum call stack size exceeded" errors for large buffers.
+**Action:** Always process large byte arrays in chunks (e.g., 8192 bytes) when converting to binary strings, using `String.fromCharCode.apply(null, chunk)` within a loop. This approach maintains high performance while staying safely within call stack limits.

--- a/modules/ear/cockpit/browser-ear.html
+++ b/modules/ear/cockpit/browser-ear.html
@@ -217,11 +217,17 @@
             const data = event.inputBuffer.getChannelData(0);
             const downsampled = downsample(data, state.audioContext.sampleRate, state.targetSampleRate);
             const pcm = floatTo16BitPCM(downsampled);
+            let binary = '';
+            const chunkSize = 8192;
+            for (let i = 0; i < pcm.length; i += chunkSize) {
+              const chunk = pcm.subarray(i, i + chunkSize);
+              binary += String.fromCharCode.apply(null, chunk);
+            }
             const payload = {
               type: 'chunk',
               sample_rate: state.targetSampleRate,
               channels: 1,
-              pcm: btoa(String.fromCharCode.apply(null, pcm)),
+              pcm: btoa(binary),
             };
             state.ws.send(JSON.stringify(payload));
           };

--- a/modules/eye/cockpit/browser-eye.html
+++ b/modules/eye/cockpit/browser-eye.html
@@ -223,7 +223,11 @@
         const arrayBuffer = await blob.arrayBuffer();
         const bytes = new Uint8Array(arrayBuffer);
         let binary = '';
-        bytes.forEach((b) => { binary += String.fromCharCode(b); });
+        const chunkSize = 8192;
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          const chunk = bytes.subarray(i, i + chunkSize);
+          binary += String.fromCharCode.apply(null, chunk);
+        }
         const payload = {
           type: 'frame',
           sequence: ++state.sequence,

--- a/modules/pilot/cockpit/components/pilot-dashboard.helpers.js
+++ b/modules/pilot/cockpit/components/pilot-dashboard.helpers.js
@@ -38,8 +38,11 @@ export function encodeBytesToBase64(bytes) {
   }
   const view = bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   let binary = "";
-  for (let i = 0; i < view.byteLength; i += 1) {
-    binary += String.fromCharCode(view[i]);
+  // Process in chunks to prevent 'Maximum call stack size exceeded' while maintaining high performance
+  const chunkSize = 8192;
+  for (let i = 0; i < view.byteLength; i += chunkSize) {
+    const chunk = view.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, chunk);
   }
   if (typeof btoa === "function") {
     return btoa(binary);

--- a/services/asr/app/static/harness.html
+++ b/services/asr/app/static/harness.html
@@ -475,8 +475,10 @@
         function int16ToBase64(int16Array) {
           const bytes = new Uint8Array(int16Array.buffer, int16Array.byteOffset, int16Array.byteLength);
           let binary = '';
-          for (let i = 0; i < bytes.length; i += 1) {
-            binary += String.fromCharCode(bytes[i] & 0xff);
+          const chunkSize = 8192;
+          for (let i = 0; i < bytes.length; i += chunkSize) {
+            const chunk = bytes.subarray(i, i + chunkSize);
+            binary += String.fromCharCode.apply(null, chunk);
           }
           return btoa(binary);
         }


### PR DESCRIPTION
💡 What:
Replaced byte-by-byte string concatenation and full-array `String.fromCharCode.apply` calls with a chunked processing loop (8192 bytes per chunk) when encoding byte arrays to base64.

🎯 Why:
Byte-by-byte string concatenation `binary += String.fromCharCode(view[i])` is an O(N^2) operation that causes major performance bottlenecks for large payloads (like image frames or audio PCM data). Conversely, calling `String.fromCharCode.apply(null, pcm)` on the entire array can cause "Maximum call stack size exceeded" errors for large audio chunks. The chunking method solves both the performance overhead and the stack size limits.

📊 Impact:
Significantly faster and more stable Base64 string generation, preventing UI blocking and call stack overflow crashes when streaming large microphone or camera payloads.

🔬 Measurement:
The optimization can be verified by running the tests for the affected components or by manually testing camera/microphone streaming using the harness files. All relevant tests continue to pass seamlessly.

---
*PR created automatically by Jules for task [10004159590263946583](https://jules.google.com/task/10004159590263946583) started by @dancxjo*