### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded Neo4j credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-18 - Hardcoded Database Credentials in Docker Compose
+
+**Vulnerability:** A hardcoded password (`NEO4J_AUTH: neo4j/password`) was present in the `docker-compose.yml` file for the graph database service.
+
+**Learning:** Hardcoding secrets in infrastructure definitions (like `docker-compose.yml` or Kubernetes manifests) makes it easy to accidentally commit credentials to version control and promotes deploying services with default, insecure passwords, violating the principle of secure defaults.
+
+**Prevention:** Use environment variable interpolation (`${VAR?must be set}`) in infrastructure configurations to ensure the system fails securely (refuses to start) if the required credentials are not explicitly provided by the deployment environment, thus preventing unintentional exposure and enforcing proper secret management.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The Neo4j graph database service was configured with hardcoded credentials (`NEO4J_AUTH: neo4j/password`) in its `docker-compose.yml` file.
🎯 **Impact:** If deployed as-is, the database would be accessible with default, well-known credentials, potentially exposing sensitive application data and allowing unauthorized access or modification. Hardcoding secrets in version control is a major security risk.
🔧 **Fix:** Replaced the hardcoded password with environment variable interpolation (`${NEO4J_AUTH?must be set}`). This ensures that the application fails securely (refuses to start) if the administrator does not explicitly provide a password, enforcing secure configuration.
✅ **Verification:**
1. Run `docker compose -f services/graphs/docker-compose.yml config`. It should fail with a message that `NEO4J_AUTH` is missing.
2. Run `NEO4J_AUTH=neo4j/mysecret docker compose -f services/graphs/docker-compose.yml config`. It should succeed and display the interpolated configuration.

---
*PR created automatically by Jules for task [13959366642828549966](https://jules.google.com/task/13959366642828549966) started by @dancxjo*