### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-13 - Enforce secure configuration in docker-compose
+**Vulnerability:** The database credentials for Neo4j (`neo4j/password`) were hardcoded in `services/graphs/docker-compose.yml`, which is a critical security vulnerability as it could expose the database to unauthorized access.
+**Learning:** Default, insecure configurations in infrastructure definitions are easily overlooked and can silently allow unauthorized access if not replaced before deployment. Falling back to an empty string or standard default when an environment variable is missing is an insecure fail-open pattern.
+**Prevention:** Always enforce the explicit injection of secrets in container orchestrations. Use Docker Compose's variable requirement syntax (e.g., `${NEO4J_AUTH?must be set}`) to ensure the system fails securely (fails to start) if the required credentials are not explicitly provided by the environment, rather than silently falling back to insecure defaults.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded database credentials (`neo4j/password`) in `services/graphs/docker-compose.yml`.
🎯 Impact: Anyone with access to the docker-compose file or repository could potentially access the Neo4j database using the default credentials if deployed as is.
🔧 Fix: Replaced the hardcoded password with a required environment variable `${NEO4J_AUTH?must be set}` to enforce explicit credential provisioning and fail securely if missing.
✅ Verification: Ran `docker compose -f services/graphs/docker-compose.yml config` to verify that it errors out without the variable and parses correctly when `NEO4J_AUTH` is provided. Ran memory unit tests to ensure no regressions.

---
*PR created automatically by Jules for task [6339193278255940157](https://jules.google.com/task/6339193278255940157) started by @dancxjo*