### PR TITLE
⚡ Bolt: [performance improvement] Batch retrieve graph metadata in MemoryService recall to prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - GraphStore Batch Retrieval Optimization
+**Learning:** Performing a sequence of individual `fetch_memory` calls (N+1 queries) significantly impacted the performance of the `recall` method in `MemoryService`.
+**Action:** Always prefer batch retrieval (using Cypher `UNWIND` in Neo4j or analogous methods for other databases) when resolving multiple entities by ID to eliminate round-trips to the database.

--- a/modules/memory/packages/memory/memory/models.py
+++ b/modules/memory/packages/memory/memory/models.py
@@ -95,7 +95,9 @@ class MemoryEventPayload:
         normalised: MutableMapping[str, Any] = dict(self.json_data)
         object.__setattr__(self, "json_data", normalised)
         if self.embedding is not None:
-            object.__setattr__(self, "embedding", [float(value) for value in self.embedding])
+            object.__setattr__(
+                self, "embedding", [float(value) for value in self.embedding]
+            )
 
     @property
     def metadata(self) -> Mapping[str, Any]:

--- a/modules/memory/packages/memory/memory/node.py
+++ b/modules/memory/packages/memory/memory/node.py
@@ -30,17 +30,27 @@ class MemoryNode(Node):
     def __init__(self, service: Optional[MemoryService] = None) -> None:
         super().__init__("memory")
         self._service = service or self._build_service()
-        self._memorize_srv = self.create_service(MemorizeSrv, "/memory/memorize", self._handle_memorize)
-        self._associate_srv = self.create_service(AssociateSrv, "/memory/associate", self._handle_associate)
-        self._recall_srv = self.create_service(RecallSrv, "/memory/recall", self._handle_recall)
-        self._tag_identity_srv = self.create_service(TagIdentitySrv, "/memory/tag_identity", self._handle_tag_identity)
+        self._memorize_srv = self.create_service(
+            MemorizeSrv, "/memory/memorize", self._handle_memorize
+        )
+        self._associate_srv = self.create_service(
+            AssociateSrv, "/memory/associate", self._handle_associate
+        )
+        self._recall_srv = self.create_service(
+            RecallSrv, "/memory/recall", self._handle_recall
+        )
+        self._tag_identity_srv = self.create_service(
+            TagIdentitySrv, "/memory/tag_identity", self._handle_tag_identity
+        )
         self._pilot_feed_publisher = self._create_pilot_feed_publisher()
         self._closeables = self._collect_closeables()
 
     # ------------------------------------------------------------------
     # Service handlers
     # ------------------------------------------------------------------
-    def _handle_memorize(self, request: MemorizeSrv.Request, response: MemorizeSrv.Response) -> MemorizeSrv.Response:
+    def _handle_memorize(
+        self, request: MemorizeSrv.Request, response: MemorizeSrv.Response
+    ) -> MemorizeSrv.Response:
         try:
             event = self._convert_event(request.event)
             record = self._service.memorize(event, flush=request.flush)
@@ -53,7 +63,9 @@ class MemoryNode(Node):
             response.vector_id = ""
         return response
 
-    def _handle_associate(self, request: AssociateSrv.Request, response: AssociateSrv.Response) -> AssociateSrv.Response:
+    def _handle_associate(
+        self, request: AssociateSrv.Request, response: AssociateSrv.Response
+    ) -> AssociateSrv.Response:
         try:
             properties = self._decode_json(request.json_properties)
             self._service.associate(
@@ -68,9 +80,13 @@ class MemoryNode(Node):
             response.success = False
         return response
 
-    def _handle_recall(self, request: RecallSrv.Request, response: RecallSrv.Response) -> RecallSrv.Response:
+    def _handle_recall(
+        self, request: RecallSrv.Request, response: RecallSrv.Response
+    ) -> RecallSrv.Response:
         try:
-            embedding: Optional[Sequence[float]] = list(request.embedding) if request.embedding else None
+            embedding: Optional[Sequence[float]] = (
+                list(request.embedding) if request.embedding else None
+            )
             text_query = request.text or None
             results = self._service.recall(
                 kind=request.kind,
@@ -118,27 +134,37 @@ class MemoryNode(Node):
     # Helpers
     # ------------------------------------------------------------------
     def _build_service(self) -> MemoryService:
-        qdrant_url = str(self.declare_parameter("qdrant.url", "http://localhost:6333").value)
+        qdrant_url = str(
+            self.declare_parameter("qdrant.url", "http://localhost:6333").value
+        )
         qdrant_api_key = str(self.declare_parameter("qdrant.api_key", "").value)
-        neo4j_uri = str(self.declare_parameter("neo4j.uri", "bolt://localhost:7687").value)
+        neo4j_uri = str(
+            self.declare_parameter("neo4j.uri", "bolt://localhost:7687").value
+        )
         neo4j_user = str(self.declare_parameter("neo4j.user", "neo4j").value)
         neo4j_password = str(self.declare_parameter("neo4j.password", "test").value)
         batch_size = int(self.declare_parameter("memory.batch_size", 10).value)
 
         vector_store = self._create_vector_store(qdrant_url, qdrant_api_key)
         graph_store = self._create_graph_store(neo4j_uri, neo4j_user, neo4j_password)
-        return MemoryService(vector_store=vector_store, graph_store=graph_store, batch_size=batch_size)
+        return MemoryService(
+            vector_store=vector_store, graph_store=graph_store, batch_size=batch_size
+        )
 
     def _create_vector_store(self, url: str, api_key: str) -> QdrantVectorStore:
         try:
             from qdrant_client import QdrantClient
         except ImportError as exc:  # pragma: no cover - import guard
-            raise RuntimeError("qdrant-client must be installed to launch the memory node") from exc
+            raise RuntimeError(
+                "qdrant-client must be installed to launch the memory node"
+            ) from exc
 
         client = QdrantClient(url=url, api_key=api_key or None)
         return QdrantVectorStore(client)
 
-    def _create_graph_store(self, uri: str, user: str, password: str) -> Neo4jGraphStore:
+    def _create_graph_store(
+        self, uri: str, user: str, password: str
+    ) -> Neo4jGraphStore:
         return Neo4jGraphStore(uri, user, password)
 
     def _collect_closeables(self) -> list[object]:
@@ -154,7 +180,9 @@ class MemoryNode(Node):
             try:
                 self.destroy_publisher(publisher)
             except Exception:
-                self.get_logger().debug("Failed to destroy pilot feed publisher", exc_info=True)
+                self.get_logger().debug(
+                    "Failed to destroy pilot feed publisher", exc_info=True
+                )
             finally:
                 self._pilot_feed_publisher = None
         try:
@@ -200,12 +228,15 @@ class MemoryNode(Node):
             message.data = self._encode_json(payload)
             publisher.publish(message)
         except Exception:
-            self.get_logger().debug("Failed to publish memory pilot feed entry", exc_info=True)
+            self.get_logger().debug(
+                "Failed to publish memory pilot feed entry", exc_info=True
+            )
 
     @staticmethod
     def _convert_event(message: MemoryEventMsg) -> MemoryEventPayload:
         stamp = datetime.fromtimestamp(
-            float(message.header.stamp.sec) + float(message.header.stamp.nanosec) / 1_000_000_000,
+            float(message.header.stamp.sec)
+            + float(message.header.stamp.nanosec) / 1_000_000_000,
             tz=timezone.utc,
         )
         metadata = MemoryNode._decode_json(message.json_data)
@@ -216,7 +247,9 @@ class MemoryNode(Node):
             source=source or message.header.frame_id or "unknown",
         )
         embedding = list(message.embedding) if message.embedding else None
-        return MemoryEventPayload(header=header, kind=message.kind, json_data=metadata, embedding=embedding)
+        return MemoryEventPayload(
+            header=header, kind=message.kind, json_data=metadata, embedding=embedding
+        )
 
     @staticmethod
     def _decode_json(raw: str) -> dict:
@@ -238,7 +271,12 @@ class MemoryNode(Node):
     def _summarise_metadata(metadata: Mapping[str, object]) -> str:
         if not isinstance(metadata, Mapping):
             return ""
-        for key in ("title", "thought_sentence", "spoken_sentence", "situation_overview"):
+        for key in (
+            "title",
+            "thought_sentence",
+            "spoken_sentence",
+            "situation_overview",
+        ):
             value = metadata.get(key)
             if isinstance(value, str):
                 text = value.strip()
@@ -269,7 +307,12 @@ class MemoryNode(Node):
                 if text and text not in labels:
                     labels.append(text)
 
-        for field in ("memory_tag", "memory_collection_text", "memory_collection_raw", "memory_collection_emoji"):
+        for field in (
+            "memory_tag",
+            "memory_collection_text",
+            "memory_collection_raw",
+            "memory_collection_emoji",
+        ):
             _append(metadata.get(field))
 
         tags = metadata.get("tags")

--- a/modules/memory/packages/memory/memory/service.py
+++ b/modules/memory/packages/memory/memory/service.py
@@ -105,7 +105,9 @@ class MemoryService:
     # ------------------------------------------------------------------
     # Memorisation
     # ------------------------------------------------------------------
-    def memorize(self, event: MemoryEventPayload, *, flush: bool = True) -> MemoryRecord:
+    def memorize(
+        self, event: MemoryEventPayload, *, flush: bool = True
+    ) -> MemoryRecord:
         """Persist a new memory event.
 
         The embedding is queued for batch insertion.  The Neo4j node is
@@ -120,7 +122,9 @@ class MemoryService:
         vector_id: Optional[str] = None
 
         if event.embedding is not None:
-            vector_id = self._queue_vector(event.kind, memory_id, event.embedding, metadata, timestamp, event)
+            vector_id = self._queue_vector(
+                event.kind, memory_id, event.embedding, metadata, timestamp, event
+            )
             if flush or self._pending_count(event.kind) >= self._batch_size:
                 self.flush_vectors()
 
@@ -173,7 +177,9 @@ class MemoryService:
     ) -> None:
         """Create an explicit association between two memories."""
 
-        self.graph_store.create_association(source_id, target_id, relation_type, properties)
+        self.graph_store.create_association(
+            source_id, target_id, relation_type, properties
+        )
 
     # ------------------------------------------------------------------
     # Identity tagging
@@ -203,21 +209,33 @@ class MemoryService:
             raise ValueError(f"Memory '{memory_key}' not found")
 
         metadata_raw = record.get("metadata") if isinstance(record, Mapping) else {}
-        metadata: Dict[str, Any] = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+        metadata: Dict[str, Any] = (
+            dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+        )
 
-        existing_identity = metadata.get("identity") if isinstance(metadata.get("identity"), Mapping) else None
-        candidate_id = self._normalise_text(identity_id) if identity_id is not None else ""
+        existing_identity = (
+            metadata.get("identity")
+            if isinstance(metadata.get("identity"), Mapping)
+            else None
+        )
+        candidate_id = (
+            self._normalise_text(identity_id) if identity_id is not None else ""
+        )
         if not candidate_id and existing_identity:
             candidate_id = self._normalise_text(
                 existing_identity.get("id"),
                 existing_identity.get("identity_id"),
                 existing_identity.get("uuid"),
             )
-        identity_key = candidate_id or self._generate_identity_id(label_text, memory_key)
+        identity_key = candidate_id or self._generate_identity_id(
+            label_text, memory_key
+        )
 
         alias_source: List[str] = []
         if existing_identity:
-            alias_source.extend(self._normalise_text_list(existing_identity.get("aliases")))
+            alias_source.extend(
+                self._normalise_text_list(existing_identity.get("aliases"))
+            )
         alias_source.extend(self._normalise_text_list(aliases))
         alias_source = self._extend_unique(alias_source, [label_text])
 
@@ -254,7 +272,9 @@ class MemoryService:
         if isinstance(tags_field, list):
             if label_text not in tags_field:
                 tags_field.append(label_text)
-        elif isinstance(tags_field, Sequence) and not isinstance(tags_field, (str, bytes)):
+        elif isinstance(tags_field, Sequence) and not isinstance(
+            tags_field, (str, bytes)
+        ):
             tags_list = list(tags_field)
             if label_text not in tags_list:
                 tags_list.append(label_text)
@@ -298,12 +318,21 @@ class MemoryService:
     ) -> List[MemoryRecallResult]:
         """Return memories similar to the provided query."""
 
-        query_vector = self._resolve_query_vector(kind=kind, embedding=embedding, text=text)
+        query_vector = self._resolve_query_vector(
+            kind=kind, embedding=embedding, text=text
+        )
         results = self.vector_store.search(kind, query_vector, limit)
+
+        memory_ids = [r.memory_id for r in results]
+        batch_metadata = self.graph_store.fetch_memories(memory_ids)
+
         enriched: List[MemoryRecallResult] = []
         for result in results:
-            graph_metadata = self.graph_store.fetch_memory(result.memory_id)
-            merged_metadata = {**graph_metadata.get("metadata", {}), **dict(result.metadata)}
+            graph_metadata = batch_metadata.get(result.memory_id, {})
+            merged_metadata = {
+                **graph_metadata.get("metadata", {}),
+                **dict(result.metadata),
+            }
             merged_metadata.update(
                 {
                     "kind": graph_metadata.get("kind", kind),
@@ -354,7 +383,9 @@ class MemoryService:
             "source": event.header.source,
             "metadata": dict(metadata),
         }
-        record = VectorRecord(vector_id=vector_id, values=list(embedding), payload=payload)
+        record = VectorRecord(
+            vector_id=vector_id, values=list(embedding), payload=payload
+        )
         self._vector_queue[collection].append(record)
         return vector_id
 
@@ -410,23 +441,38 @@ class MemoryService:
             self._merge_identity_lists(bucket["props"], graph_props, "signatures")
             self._merge_identity_lists(bucket["props"], graph_props, "memory_ids")
             self._merge_identity_lists(bucket["display"], display_identity, "aliases")
-            self._merge_identity_lists(bucket["display"], display_identity, "signatures")
-            self._merge_identity_lists(bucket["display"], display_identity, "memory_ids")
+            self._merge_identity_lists(
+                bucket["display"], display_identity, "signatures"
+            )
+            self._merge_identity_lists(
+                bucket["display"], display_identity, "memory_ids"
+            )
             if display_identity.get("name"):
                 bucket["display"].setdefault("name", display_identity["name"])
-            candidate_confidence = self._coerce_float(display_identity.get("confidence"))
+            candidate_confidence = self._coerce_float(
+                display_identity.get("confidence")
+            )
             if candidate_confidence is not None:
-                existing_confidence = self._coerce_float(bucket["display"].get("confidence"))
-                if existing_confidence is None or candidate_confidence > existing_confidence:
+                existing_confidence = self._coerce_float(
+                    bucket["display"].get("confidence")
+                )
+                if (
+                    existing_confidence is None
+                    or candidate_confidence > existing_confidence
+                ):
                     bucket["display"]["confidence"] = candidate_confidence
         cleaned: List[Dict[str, Any]] = []
         prepared: List[tuple[str, Dict[str, Any]]] = []
         for identity_id, bundle in consolidated.items():
             props = {
-                key: value for key, value in bundle["props"].items() if value not in (None, [], {})
+                key: value
+                for key, value in bundle["props"].items()
+                if value not in (None, [], {})
             }
             display = {
-                key: value for key, value in bundle["display"].items() if value not in (None, [], {})
+                key: value
+                for key, value in bundle["display"].items()
+                if value not in (None, [], {})
             }
             display.setdefault("id", identity_id)
             if props.get("signatures"):
@@ -471,7 +517,9 @@ class MemoryService:
         if labels:
             aliases = self._extend_unique(aliases, labels)
         signatures = self._normalise_text_list(candidate.get("signatures"))
-        signature_history = self._normalise_text_list(candidate.get("signature_history"))
+        signature_history = self._normalise_text_list(
+            candidate.get("signature_history")
+        )
         if signature_history:
             signatures = self._extend_unique(signatures, signature_history)
         signature_hint = self._normalise_text(candidate.get("signature"))
@@ -526,7 +574,9 @@ class MemoryService:
             if text:
                 items.append(text)
             return items
-        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        if isinstance(value, Sequence) and not isinstance(
+            value, (bytes, bytearray, str)
+        ):
             for element in value:
                 text = self._normalise_text(element)
                 if text and text not in items:
@@ -598,7 +648,9 @@ class MemoryService:
             return embedding
         if text is not None:
             if self._embedding_provider is None:
-                raise ValueError("text recall requested but no embedding provider is configured")
+                raise ValueError(
+                    "text recall requested but no embedding provider is configured"
+                )
             return self._embedding_provider.embed_text(text, kind=kind)
         raise ValueError("either embedding or text must be provided")
 

--- a/modules/memory/packages/memory/memory/stores.py
+++ b/modules/memory/packages/memory/memory/stores.py
@@ -81,6 +81,11 @@ class GraphStoreProtocol(Protocol):
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         """Return metadata describing a stored memory node."""
 
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        """Return metadata describing multiple stored memory nodes."""
+
     def link_identity(
         self,
         memory_id: str,
@@ -93,7 +98,9 @@ class GraphStoreProtocol(Protocol):
 class QdrantVectorStore(VectorStoreProtocol):
     """Implementation of :class:`VectorStoreProtocol` using Qdrant."""
 
-    def __init__(self, client: "QdrantClient") -> None:  # pragma: no cover - simple assignment
+    def __init__(
+        self, client: "Any"
+    ) -> None:  # pragma: no cover - simple assignment
         self._client = client
         self._known_collections: set[str] = set()
 
@@ -103,14 +110,17 @@ class QdrantVectorStore(VectorStoreProtocol):
         dimension = len(records[0].values)
         self._ensure_collection(collection, dimension)
         point_structs = [
-            self._point_struct(record.vector_id, record.values, record.payload) for record in records
+            self._point_struct(record.vector_id, record.values, record.payload)
+            for record in records
         ]
         self._client.upsert(collection_name=collection, points=point_structs, wait=True)
 
     def search(
         self, collection: str, vector: Sequence[float], limit: int
     ) -> Sequence[MemoryRecallResult]:
-        results = self._client.search(collection_name=collection, query_vector=vector, limit=limit)
+        results = self._client.search(
+            collection_name=collection, query_vector=vector, limit=limit
+        )
         output: list[MemoryRecallResult] = []
         for result in results:
             payload = result.payload or {}
@@ -134,16 +144,20 @@ class QdrantVectorStore(VectorStoreProtocol):
             self._client.get_collection(collection_name=collection)
         except Exception:  # pragma: no cover - network failure paths
             vector_params = self._vector_params(dimension)
-            self._client.create_collection(collection_name=collection, vectors_config=vector_params)
+            self._client.create_collection(
+                collection_name=collection, vectors_config=vector_params
+            )
         self._known_collections.add(collection)
 
     @staticmethod
-    def _point_struct(vector_id: str, values: Sequence[float], payload: Mapping[str, Any]) -> "PointStruct":
+    def _point_struct(
+        vector_id: str, values: Sequence[float], payload: Mapping[str, Any]
+    ) -> "Any":
         PointStruct = _lazy_import_point_struct()
         return PointStruct(id=vector_id, vector=list(values), payload=dict(payload))
 
     @staticmethod
-    def _vector_params(dimension: int) -> "VectorParams":
+    def _vector_params(dimension: int) -> "Any":
         models = _lazy_import_qdrant_models()
         return models.VectorParams(size=dimension, distance=models.Distance.COSINE)
 
@@ -151,7 +165,9 @@ class QdrantVectorStore(VectorStoreProtocol):
 class Neo4jGraphStore(GraphStoreProtocol):
     """Implementation of :class:`GraphStoreProtocol` backed by Neo4j."""
 
-    def __init__(self, uri: str, user: str, password: str) -> None:  # pragma: no cover - trivial wiring
+    def __init__(
+        self, uri: str, user: str, password: str
+    ) -> None:  # pragma: no cover - trivial wiring
         self._driver = _lazy_import_neo4j_driver()(uri, auth=(user, password))
 
     def close(self) -> None:  # pragma: no cover - used in production
@@ -167,7 +183,12 @@ class Neo4jGraphStore(GraphStoreProtocol):
         self, previous_id: Optional[str], memory_id: str, timestamp: datetime
     ) -> None:
         with self._driver.session() as session:
-            session.execute_write(self._write_temporal_links, previous_id, memory_id, timestamp.isoformat())
+            session.execute_write(
+                self._write_temporal_links,
+                previous_id,
+                memory_id,
+                timestamp.isoformat(),
+            )
 
     def link_source(self, memory_id: str, frame_id: str) -> None:
         if not frame_id:
@@ -190,12 +211,26 @@ class Neo4jGraphStore(GraphStoreProtocol):
     ) -> None:
         rel_type = self._relationship_type(relation_type)
         with self._driver.session() as session:
-            session.execute_write(self._write_association, source_id, target_id, rel_type, dict(properties or {}))
+            session.execute_write(
+                self._write_association,
+                source_id,
+                target_id,
+                rel_type,
+                dict(properties or {}),
+            )
 
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         with self._driver.session() as session:
             record = session.execute_read(self._read_memory, memory_id)
             return record or {}
+
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        if not memory_ids:
+            return {}
+        with self._driver.session() as session:
+            return session.execute_read(self._read_memories, list(memory_ids))
 
     def link_identity(
         self,
@@ -216,7 +251,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
 
     # Neo4j transactions -----------------------------------------------
     @staticmethod
-    def _write_memory(tx, label: str, properties: Mapping[str, Any]) -> None:  # pragma: no cover - exercised via driver
+    def _write_memory(
+        tx, label: str, properties: Mapping[str, Any]
+    ) -> None:  # pragma: no cover - exercised via driver
         query = f"""
         MERGE (m:Memory:{label} {{memory_id: $memory_id}})
         SET m += $properties
@@ -224,7 +261,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
         tx.run(query, memory_id=properties["memory_id"], properties=dict(properties))
 
     @staticmethod
-    def _write_temporal_links(tx, previous_id: Optional[str], memory_id: str, timestamp: str) -> None:
+    def _write_temporal_links(
+        tx, previous_id: Optional[str], memory_id: str, timestamp: str
+    ) -> None:
         tx.run(
             """
             MATCH (current:Memory {memory_id: $memory_id})
@@ -279,7 +318,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
         MERGE (source)-[rel:{relation_type}]->(target)
         SET rel += $properties
         """
-        tx.run(query, source_id=source_id, target_id=target_id, properties=dict(properties))
+        tx.run(
+            query, source_id=source_id, target_id=target_id, properties=dict(properties)
+        )
 
     @staticmethod
     def _write_identity_link(
@@ -322,15 +363,42 @@ class Neo4jGraphStore(GraphStoreProtocol):
         return node
 
     @staticmethod
+    def _read_memories(tx, memory_ids: list[str]) -> Mapping[str, Mapping[str, Any]]:
+        result = tx.run(
+            """
+            UNWIND $memory_ids AS memory_id
+            MATCH (memory:Memory {memory_id: memory_id})
+            OPTIONAL MATCH (memory)-[:IDENTIFIES]->(identity:Identity)
+            RETURN memory, collect(identity) AS identities
+            """,
+            memory_ids=memory_ids,
+        )
+        output: dict[str, Mapping[str, Any]] = {}
+        for record in result:
+            node = dict(record["memory"])
+            identities = record.get("identities")
+            if identities:
+                node["identities"] = [
+                    dict(identity) for identity in identities if identity is not None
+                ]
+            output[node["memory_id"]] = node
+        return output
+
+    @staticmethod
     def _kind_to_label(kind: str) -> str:
-        cleaned = ''.join(ch if ch.isalnum() else '_' for ch in kind.strip()) or "Memory"
+        cleaned = (
+            "".join(ch if ch.isalnum() else "_" for ch in kind.strip()) or "Memory"
+        )
         if cleaned[0].isdigit():
             cleaned = f"_{cleaned}"
         return cleaned
 
     @staticmethod
     def _relationship_type(relation_type: str) -> str:
-        cleaned = ''.join(ch if ch.isalnum() else '_' for ch in relation_type.strip()) or "ASSOCIATED_WITH"
+        cleaned = (
+            "".join(ch if ch.isalnum() else "_" for ch in relation_type.strip())
+            or "ASSOCIATED_WITH"
+        )
         if cleaned[0].isdigit():
             cleaned = f"_{cleaned}"
         return cleaned

--- a/modules/memory/packages/memory/setup.py
+++ b/modules/memory/packages/memory/setup.py
@@ -1,24 +1,24 @@
 from setuptools import find_packages, setup
 
-package_name = 'memory'
+package_name = "memory"
 
 setup(
     name=package_name,
-    version='0.1.0',
+    version="0.1.0",
     packages=find_packages(include=[package_name, f"{package_name}.*"]),
     data_files=[
-        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
     ],
-    install_requires=['setuptools', 'neo4j>=5.15,<6', 'qdrant-client>=1.7,<2'],
+    install_requires=["setuptools", "neo4j>=5.15,<6", "qdrant-client>=1.7,<2"],
     zip_safe=False,
-    maintainer='Psyched Maintainers',
-    maintainer_email='pete@psyched.local',
-    description='Memory module connecting Qdrant vector storage with Neo4j.',
-    license='Apache-2.0',
+    maintainer="Psyched Maintainers",
+    maintainer_email="pete@psyched.local",
+    description="Memory module connecting Qdrant vector storage with Neo4j.",
+    license="Apache-2.0",
     entry_points={
-        'console_scripts': [
-            'memory_node = memory.node:main',
+        "console_scripts": [
+            "memory_node = memory.node:main",
         ],
     },
 )

--- a/modules/memory/packages/memory/tests/test_memory_service.py
+++ b/modules/memory/packages/memory/tests/test_memory_service.py
@@ -8,7 +8,16 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+)
 
 import pytest
 
@@ -78,13 +87,24 @@ class FakeGraphStore:
         relation_type: str,
         properties: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        self.associations.append((source_id, target_id, relation_type, dict(properties or {})))
+        self.associations.append(
+            (source_id, target_id, relation_type, dict(properties or {}))
+        )
 
-    def link_identity(self, memory_id: str, identity_id: str, properties: Mapping[str, Any]) -> None:
+    def link_identity(
+        self, memory_id: str, identity_id: str, properties: Mapping[str, Any]
+    ) -> None:
         self.identity_links.append((memory_id, identity_id, dict(properties)))
 
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         return self.memories[memory_id]
+
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        return {
+            m_id: self.memories[m_id] for m_id in memory_ids if m_id in self.memories
+        }
 
 
 @pytest.fixture(name="service")
@@ -147,7 +167,9 @@ def test_memorize_batches_vectors_until_threshold(service: MemoryService) -> Non
     assert len(service.graph_store.frame_links) == 2  # type: ignore[attr-defined]
 
 
-def test_memorize_without_embedding_skips_vector_storage(service: MemoryService) -> None:
+def test_memorize_without_embedding_skips_vector_storage(
+    service: MemoryService,
+) -> None:
     """Given an event lacking an embedding, only the graph is updated."""
 
     event = _build_event(
@@ -239,13 +261,22 @@ def test_associate_records_relationship(service: MemoryService) -> None:
     )
     record = service.memorize(event)
 
-    service.associate(record.memory_id, record.memory_id, relation_type="REMEMBERS", properties={"confidence": 0.8})
+    service.associate(
+        record.memory_id,
+        record.memory_id,
+        relation_type="REMEMBERS",
+        properties={"confidence": 0.8},
+    )
 
     associations = service.graph_store.associations  # type: ignore[attr-defined]
-    assert associations == [(record.memory_id, record.memory_id, "REMEMBERS", {"confidence": 0.8})]
+    assert associations == [
+        (record.memory_id, record.memory_id, "REMEMBERS", {"confidence": 0.8})
+    ]
 
 
-def test_recall_enriches_vector_results_with_graph_context(service: MemoryService) -> None:
+def test_recall_enriches_vector_results_with_graph_context(
+    service: MemoryService,
+) -> None:
     """Vector results are hydrated with metadata fetched from the graph store."""
 
     event = _build_event(
@@ -257,7 +288,9 @@ def test_recall_enriches_vector_results_with_graph_context(service: MemoryServic
         {"id": "person:alice", "name": "Alice Example"}
     ]
 
-    fake_result = MemoryRecallResult(memory_id=record.memory_id, score=0.92, metadata={"foo": "bar"})
+    fake_result = MemoryRecallResult(
+        memory_id=record.memory_id, score=0.92, metadata={"foo": "bar"}
+    )
     service.vector_store.queue_search_result("face", [fake_result])  # type: ignore[attr-defined]
 
     results = service.recall(kind="face", embedding=[0.7, 0.4])

--- a/modules/memory/packages/memory/tests/test_packaging.py
+++ b/modules/memory/packages/memory/tests/test_packaging.py
@@ -16,7 +16,9 @@ from pathlib import Path
 import pytest
 
 
-def test_package_installs_and_imports(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_package_installs_and_imports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Given the project is installed in isolation, the :mod:`memory` package is importable."""
     package_root = Path(__file__).resolve().parents[1]
     install_root = tmp_path / "site-packages"
@@ -42,7 +44,9 @@ def test_package_installs_and_imports(tmp_path: Path, monkeypatch: pytest.Monkey
         module = importlib.import_module("memory")
         assert module.MemoryService is not None
         entrypoint = install_root / "bin" / "memory_node"
-        assert entrypoint.exists(), "Expected the memory_node console script to be installed"
+        assert (
+            entrypoint.exists()
+        ), "Expected the memory_node console script to be installed"
     finally:
         if egg_info_dir.exists():
             shutil.rmtree(egg_info_dir)


### PR DESCRIPTION
### 💡 What
Introduced a batched `fetch_memories` method to the graph store implementations (`Neo4jGraphStore`, `FakeGraphStore`) and integrated it into the `MemoryService.recall` flow.

### 🎯 Why
During memory recall, after retrieving vector similarity results, the application was executing an individual Neo4j query for each resulting `memory_id` in a loop. This is a classic N+1 query problem that resulted in high latency, especially with larger vector recall limits.

### 📊 Impact
*   Replaces N database round-trips with 1 round-trip.
*   Significantly lowers the overall latency of the `recall` method.
*   Reduces connection overhead and load on the Neo4j instance.

### 🔬 Measurement
Run `pytest modules/memory/packages/memory/tests/test_memory_service.py` to verify the functionality of `MemoryService.recall` after the optimization. Look at tracing data for the number of queries fired against Neo4j during recall tasks to observe the reduction from N to 1.

---
*PR created automatically by Jules for task [13963101754356382572](https://jules.google.com/task/13963101754356382572) started by @dancxjo*