### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-14 - Hardcoded Neo4j Credentials in docker-compose.yml
+**Vulnerability:** A hardcoded default password (`neo4j/password`) was embedded in `services/graphs/docker-compose.yml` via the `NEO4J_AUTH` environment variable. This fails open, allowing unrestricted access to the database using default credentials if deployed without overriding the value.
+**Learning:** Default configurations in Docker Compose files often prioritize ease of local setup over secure-by-default practices.
+**Prevention:** Use the `?must be set` bash substitution syntax (e.g., `NEO4J_AUTH: ${NEO4J_AUTH?must be set}`) in docker-compose files. This enforces a secure fail-safe, preventing the container from starting if the credential is not explicitly provided in the environment.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded default password (`neo4j/password`) was embedded in `services/graphs/docker-compose.yml` via the `NEO4J_AUTH` environment variable. 
🎯 **Impact:** If deployed as-is, the graph database fails open with default credentials, granting potential attackers unrestricted access to read, modify, or delete sensitive semantic metadata and semantic vectors stored in Neo4j.
🔧 **Fix:** Substituted the hardcoded string with `${NEO4J_AUTH?must be set}`. This adheres to the "Fail Securely" principle by preventing the container from starting up unless a valid password is explicitly supplied in the environment.
✅ **Verification:** Verified by running `docker compose -f services/graphs/docker-compose.yml config` and validating that the command properly throws a missing required variable error, enforcing the requirement.

---
*PR created automatically by Jules for task [649856919983241896](https://jules.google.com/task/649856919983241896) started by @dancxjo*