### PR TITLE
🎨 Palette: Add accessible surface-button for module retry

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-14 - Use shared surface-button for consistent interactions
+**Learning:** Found an error state 'Retry' button in `cockpit-app.js` that was implemented as a generic button without accessible labels or design system classes, leaving it inaccessible and visually inconsistent.
+**Action:** Replaced raw buttons with the `surface-button` design token to ensure proper hover, focus, and aria attributes, bringing them in line with the established UI patterns.

--- a/modules/cockpit/cockpit/components/cockpit-app.js
+++ b/modules/cockpit/cockpit/components/cockpit-app.js
@@ -142,7 +142,7 @@ class CockpitApp extends LitElement {
       return html`<section class="cockpit-error">
         <h2>Failed to load modules</h2>
         <p>${this.errorMessage}</p>
-        <button type="button" @click=${() => this.refresh()}>🔄 Retry</button>
+        <button type="button" class="surface-button" aria-label="Retry loading modules" title="Retry loading modules" @click=${() => this.refresh()}>🔄 Retry</button>
       </section>`;
     }
     if (!this.modules.length) {


### PR DESCRIPTION
💡 **What:** Replaced the raw `<button>` in the module error fallback state of `cockpit-app.js` with a styled `surface-button`.
🎯 **Why:** The previous 'Retry' button was unstyled and inconsistent with the rest of the application, rendering as a plain HTML button. This improves visual consistency and interaction states.
📸 **Before/After:** Before: Plain HTML button. After: A styled, transparent, interactive button with proper hover/focus box-shadows and correct alignment.
♿ **Accessibility:** Added an `aria-label` ("Retry loading modules") and `title` to provide explicit context for screen readers and helpful tooltips for mouse users, respectively. Replaced native focus rings with the design system's consistent focus-visible styles.

---
*PR created automatically by Jules for task [12528630593644578298](https://jules.google.com/task/12528630593644578298) started by @dancxjo*