### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database password in graphs docker-compose

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - Enforce Database Authentication Environment Variables
+**Vulnerability:** Hardcoded database credentials (neo4j/password) in `docker-compose.yml` or fallback defaults (e.g. `${NEO4J_AUTH:-none}`).
+**Learning:** Defaulting to 'none' or hardcoding passwords causes the application to fail open and expose the database directly if the environment variable is not supplied or if there is a misconfiguration in how variables are injected.
+**Prevention:** Always use `${VAR?must be set}` syntax for critical authentication variables in `docker-compose.yml` files. This enforces a fail-secure approach where the container outright refuses to start rather than exposing unprotected access.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded database credentials (`neo4j/password`) were found in `services/graphs/docker-compose.yml`.
🎯 Impact: Anyone with access to the codebase or the deployed container environment could read the hardcoded password, potentially leading to unauthorized access to the graph database. Furthermore, if a user tried to override it but made a typo in the variable name, the container would start with the hardcoded default, silently exposing the database.
🔧 Fix: Replaced the hardcoded password with `${NEO4J_AUTH?must be set}` to enforce the presence of the environment variable and ensure a fail-secure approach where the container refuses to start without explicit credentials. Also added a journal entry in `.jules/sentinel.md` capturing this fail-secure docker compose learning.
✅ Verification: Ran `docker compose config` with and without the variable set to confirm it enforces the variable presence and fails securely if omitted. Also ran linters/formatters (`ruff check .`, `black --check .`) to confirm no regressions.

---
*PR created automatically by Jules for task [8904166838594079017](https://jules.google.com/task/8904166838594079017) started by @dancxjo*