### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded neo4j credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-16 - Hardcoded credentials in docker-compose.yml
+**Vulnerability:** Found hardcoded Neo4j credentials (`NEO4J_AUTH: neo4j/password`) in `services/graphs/docker-compose.yml`.
+**Learning:** Hardcoded credentials should never be committed to source code as they pose a critical security risk. We must enforce the presence of environment variables instead of falling back to insecure defaults.
+**Prevention:** Use variable substitution with mandatory checking (`${NEO4J_AUTH?must be set}`) in docker-compose files to enforce that the variable is provided, failing securely rather than defaulting to an insecure state.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded neo4j database credentials (`neo4j/password`) were found in `services/graphs/docker-compose.yml`.
🎯 Impact: Anyone with access to the source code would have the credentials to the database, which could lead to unauthorized access and data breaches.
🔧 Fix: Used Docker Compose's variable substitution with mandatory checking (`${NEO4J_AUTH?must be set}`) to enforce the presence of the environment variable, ensuring the container will fail to start securely if not provided.
✅ Verification: Ran `docker compose -f services/graphs/docker-compose.yml config` and verified it properly fails with `required variable NEO4J_AUTH is missing a value`. Tested with `NEO4J_AUTH=test/test` and verified it is accepted. Tests for modules interacting with the database were also run.

---
*PR created automatically by Jules for task [5747690053052550407](https://jules.google.com/task/5747690053052550407) started by @dancxjo*