### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials in graphs service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Fail Securely with Docker Compose Variables
+**Vulnerability:** Hardcoded database credentials (`NEO4J_AUTH: neo4j/password`) in `docker-compose.yml`.
+**Learning:** Services that depend on environment variables for authentication shouldn't use hardcoded values or fallbacks (e.g. `${VAR:-none}`) which cause the system to fail open and run insecurely.
+**Prevention:** Use bash-style parameter expansion with error messages like `${VAR?must be set}` to enforce required secrets and fail securely before the service even starts.

--- a/services/graphs/docker-compose.yml
+++ b/services/graphs/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: neo4j:latest
     container_name: graphs
     environment:
-      NEO4J_AUTH: neo4j/password
+      NEO4J_AUTH: ${NEO4J_AUTH?must be set}
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
## 🚨 Severity: CRITICAL

## 💡 Vulnerability
The `services/graphs/docker-compose.yml` file contained hardcoded authentication credentials for the Neo4j database (`NEO4J_AUTH: neo4j/password`). Hardcoding credentials in source control is a significant security risk, as anyone with access to the repository could potentially access the database instance.

## 🎯 Impact
If deployed as-is, the Neo4j service would initialize with default, well-known credentials. An attacker who gains access to the deployment environment or network could easily authenticate, allowing unauthorized data access, modification, or destruction.

## 🔧 Fix
Replaced the hardcoded credentials with bash-style parameter expansion (`NEO4J_AUTH: ${NEO4J_AUTH?must be set}`). This approach eliminates the hardcoded secret from the repository and enforces the 'fail securely' principle. If the required environment variable is not provided at deployment time, `docker compose` will fail to start the service rather than falling back to an insecure default.

## ✅ Verification
1.  Verify the failure behavior when the variable is missing:
    `docker compose -f services/graphs/docker-compose.yml config`
    *Output should be an error stating `required variable NEO4J_AUTH is missing a value: must be set`.*
2.  Verify successful parsing when the variable is provided:
    `NEO4J_AUTH=test/test docker compose -f services/graphs/docker-compose.yml config`
    *Output should render the compose file with the provided credentials.*

---
*PR created automatically by Jules for task [17850739185262428394](https://jules.google.com/task/17850739185262428394) started by @dancxjo*