### PR TITLE
⚡ Bolt: Fix N+1 query issue in Neo4j metadata recall

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Neo4j UNWIND Batch Retrieval
+**Learning:** In Neo4j using the python driver, fetching nodes one by one within a loop creates an N+1 query performance bottleneck due to multiple database round-trips.
+**Action:** When querying Neo4j for multiple IDs, use batch retrieval with the `UNWIND` Cypher clause. This significantly reduces database round-trips and improves recall performance significantly.

--- a/modules/memory/packages/memory/memory/service.py
+++ b/modules/memory/packages/memory/memory/service.py
@@ -73,6 +73,8 @@ class MemoryService:
     ...         pass
     ...     def fetch_memory(self, memory_id):
     ...         return self.nodes[memory_id]
+    ...     def fetch_memories(self, memory_ids):
+    ...         return {m: self.nodes[m] for m in memory_ids if m in self.nodes}
     >>> service = MemoryService(DummyVectorStore(), DummyGraphStore())
     >>> payload = MemoryEventPayload(
     ...     header=MemoryHeader(datetime.now(tz=timezone.utc), "frame", "sensor/face"),
@@ -105,7 +107,9 @@ class MemoryService:
     # ------------------------------------------------------------------
     # Memorisation
     # ------------------------------------------------------------------
-    def memorize(self, event: MemoryEventPayload, *, flush: bool = True) -> MemoryRecord:
+    def memorize(
+        self, event: MemoryEventPayload, *, flush: bool = True
+    ) -> MemoryRecord:
         """Persist a new memory event.
 
         The embedding is queued for batch insertion.  The Neo4j node is
@@ -120,7 +124,9 @@ class MemoryService:
         vector_id: Optional[str] = None
 
         if event.embedding is not None:
-            vector_id = self._queue_vector(event.kind, memory_id, event.embedding, metadata, timestamp, event)
+            vector_id = self._queue_vector(
+                event.kind, memory_id, event.embedding, metadata, timestamp, event
+            )
             if flush or self._pending_count(event.kind) >= self._batch_size:
                 self.flush_vectors()
 
@@ -173,7 +179,9 @@ class MemoryService:
     ) -> None:
         """Create an explicit association between two memories."""
 
-        self.graph_store.create_association(source_id, target_id, relation_type, properties)
+        self.graph_store.create_association(
+            source_id, target_id, relation_type, properties
+        )
 
     # ------------------------------------------------------------------
     # Identity tagging
@@ -203,21 +211,33 @@ class MemoryService:
             raise ValueError(f"Memory '{memory_key}' not found")
 
         metadata_raw = record.get("metadata") if isinstance(record, Mapping) else {}
-        metadata: Dict[str, Any] = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+        metadata: Dict[str, Any] = (
+            dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+        )
 
-        existing_identity = metadata.get("identity") if isinstance(metadata.get("identity"), Mapping) else None
-        candidate_id = self._normalise_text(identity_id) if identity_id is not None else ""
+        existing_identity = (
+            metadata.get("identity")
+            if isinstance(metadata.get("identity"), Mapping)
+            else None
+        )
+        candidate_id = (
+            self._normalise_text(identity_id) if identity_id is not None else ""
+        )
         if not candidate_id and existing_identity:
             candidate_id = self._normalise_text(
                 existing_identity.get("id"),
                 existing_identity.get("identity_id"),
                 existing_identity.get("uuid"),
             )
-        identity_key = candidate_id or self._generate_identity_id(label_text, memory_key)
+        identity_key = candidate_id or self._generate_identity_id(
+            label_text, memory_key
+        )
 
         alias_source: List[str] = []
         if existing_identity:
-            alias_source.extend(self._normalise_text_list(existing_identity.get("aliases")))
+            alias_source.extend(
+                self._normalise_text_list(existing_identity.get("aliases"))
+            )
         alias_source.extend(self._normalise_text_list(aliases))
         alias_source = self._extend_unique(alias_source, [label_text])
 
@@ -254,7 +274,9 @@ class MemoryService:
         if isinstance(tags_field, list):
             if label_text not in tags_field:
                 tags_field.append(label_text)
-        elif isinstance(tags_field, Sequence) and not isinstance(tags_field, (str, bytes)):
+        elif isinstance(tags_field, Sequence) and not isinstance(
+            tags_field, (str, bytes)
+        ):
             tags_list = list(tags_field)
             if label_text not in tags_list:
                 tags_list.append(label_text)
@@ -298,12 +320,21 @@ class MemoryService:
     ) -> List[MemoryRecallResult]:
         """Return memories similar to the provided query."""
 
-        query_vector = self._resolve_query_vector(kind=kind, embedding=embedding, text=text)
+        query_vector = self._resolve_query_vector(
+            kind=kind, embedding=embedding, text=text
+        )
         results = self.vector_store.search(kind, query_vector, limit)
+
+        result_memory_ids = [result.memory_id for result in results]
+        graphs_metadata = self.graph_store.fetch_memories(result_memory_ids)
+
         enriched: List[MemoryRecallResult] = []
         for result in results:
-            graph_metadata = self.graph_store.fetch_memory(result.memory_id)
-            merged_metadata = {**graph_metadata.get("metadata", {}), **dict(result.metadata)}
+            graph_metadata = graphs_metadata.get(result.memory_id, {})
+            merged_metadata = {
+                **graph_metadata.get("metadata", {}),
+                **dict(result.metadata),
+            }
             merged_metadata.update(
                 {
                     "kind": graph_metadata.get("kind", kind),
@@ -354,7 +385,9 @@ class MemoryService:
             "source": event.header.source,
             "metadata": dict(metadata),
         }
-        record = VectorRecord(vector_id=vector_id, values=list(embedding), payload=payload)
+        record = VectorRecord(
+            vector_id=vector_id, values=list(embedding), payload=payload
+        )
         self._vector_queue[collection].append(record)
         return vector_id
 
@@ -410,23 +443,38 @@ class MemoryService:
             self._merge_identity_lists(bucket["props"], graph_props, "signatures")
             self._merge_identity_lists(bucket["props"], graph_props, "memory_ids")
             self._merge_identity_lists(bucket["display"], display_identity, "aliases")
-            self._merge_identity_lists(bucket["display"], display_identity, "signatures")
-            self._merge_identity_lists(bucket["display"], display_identity, "memory_ids")
+            self._merge_identity_lists(
+                bucket["display"], display_identity, "signatures"
+            )
+            self._merge_identity_lists(
+                bucket["display"], display_identity, "memory_ids"
+            )
             if display_identity.get("name"):
                 bucket["display"].setdefault("name", display_identity["name"])
-            candidate_confidence = self._coerce_float(display_identity.get("confidence"))
+            candidate_confidence = self._coerce_float(
+                display_identity.get("confidence")
+            )
             if candidate_confidence is not None:
-                existing_confidence = self._coerce_float(bucket["display"].get("confidence"))
-                if existing_confidence is None or candidate_confidence > existing_confidence:
+                existing_confidence = self._coerce_float(
+                    bucket["display"].get("confidence")
+                )
+                if (
+                    existing_confidence is None
+                    or candidate_confidence > existing_confidence
+                ):
                     bucket["display"]["confidence"] = candidate_confidence
         cleaned: List[Dict[str, Any]] = []
         prepared: List[tuple[str, Dict[str, Any]]] = []
         for identity_id, bundle in consolidated.items():
             props = {
-                key: value for key, value in bundle["props"].items() if value not in (None, [], {})
+                key: value
+                for key, value in bundle["props"].items()
+                if value not in (None, [], {})
             }
             display = {
-                key: value for key, value in bundle["display"].items() if value not in (None, [], {})
+                key: value
+                for key, value in bundle["display"].items()
+                if value not in (None, [], {})
             }
             display.setdefault("id", identity_id)
             if props.get("signatures"):
@@ -471,7 +519,9 @@ class MemoryService:
         if labels:
             aliases = self._extend_unique(aliases, labels)
         signatures = self._normalise_text_list(candidate.get("signatures"))
-        signature_history = self._normalise_text_list(candidate.get("signature_history"))
+        signature_history = self._normalise_text_list(
+            candidate.get("signature_history")
+        )
         if signature_history:
             signatures = self._extend_unique(signatures, signature_history)
         signature_hint = self._normalise_text(candidate.get("signature"))
@@ -526,7 +576,9 @@ class MemoryService:
             if text:
                 items.append(text)
             return items
-        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        if isinstance(value, Sequence) and not isinstance(
+            value, (bytes, bytearray, str)
+        ):
             for element in value:
                 text = self._normalise_text(element)
                 if text and text not in items:
@@ -598,7 +650,9 @@ class MemoryService:
             return embedding
         if text is not None:
             if self._embedding_provider is None:
-                raise ValueError("text recall requested but no embedding provider is configured")
+                raise ValueError(
+                    "text recall requested but no embedding provider is configured"
+                )
             return self._embedding_provider.embed_text(text, kind=kind)
         raise ValueError("either embedding or text must be provided")
 

--- a/modules/memory/packages/memory/memory/stores.py
+++ b/modules/memory/packages/memory/memory/stores.py
@@ -81,6 +81,11 @@ class GraphStoreProtocol(Protocol):
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         """Return metadata describing a stored memory node."""
 
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        """Return metadata describing multiple stored memory nodes."""
+
     def link_identity(
         self,
         memory_id: str,
@@ -93,7 +98,9 @@ class GraphStoreProtocol(Protocol):
 class QdrantVectorStore(VectorStoreProtocol):
     """Implementation of :class:`VectorStoreProtocol` using Qdrant."""
 
-    def __init__(self, client: "QdrantClient") -> None:  # pragma: no cover - simple assignment
+    def __init__(
+        self, client: "QdrantClient"
+    ) -> None:  # pragma: no cover - simple assignment
         self._client = client
         self._known_collections: set[str] = set()
 
@@ -103,14 +110,17 @@ class QdrantVectorStore(VectorStoreProtocol):
         dimension = len(records[0].values)
         self._ensure_collection(collection, dimension)
         point_structs = [
-            self._point_struct(record.vector_id, record.values, record.payload) for record in records
+            self._point_struct(record.vector_id, record.values, record.payload)
+            for record in records
         ]
         self._client.upsert(collection_name=collection, points=point_structs, wait=True)
 
     def search(
         self, collection: str, vector: Sequence[float], limit: int
     ) -> Sequence[MemoryRecallResult]:
-        results = self._client.search(collection_name=collection, query_vector=vector, limit=limit)
+        results = self._client.search(
+            collection_name=collection, query_vector=vector, limit=limit
+        )
         output: list[MemoryRecallResult] = []
         for result in results:
             payload = result.payload or {}
@@ -134,11 +144,15 @@ class QdrantVectorStore(VectorStoreProtocol):
             self._client.get_collection(collection_name=collection)
         except Exception:  # pragma: no cover - network failure paths
             vector_params = self._vector_params(dimension)
-            self._client.create_collection(collection_name=collection, vectors_config=vector_params)
+            self._client.create_collection(
+                collection_name=collection, vectors_config=vector_params
+            )
         self._known_collections.add(collection)
 
     @staticmethod
-    def _point_struct(vector_id: str, values: Sequence[float], payload: Mapping[str, Any]) -> "PointStruct":
+    def _point_struct(
+        vector_id: str, values: Sequence[float], payload: Mapping[str, Any]
+    ) -> "PointStruct":
         PointStruct = _lazy_import_point_struct()
         return PointStruct(id=vector_id, vector=list(values), payload=dict(payload))
 
@@ -151,7 +165,9 @@ class QdrantVectorStore(VectorStoreProtocol):
 class Neo4jGraphStore(GraphStoreProtocol):
     """Implementation of :class:`GraphStoreProtocol` backed by Neo4j."""
 
-    def __init__(self, uri: str, user: str, password: str) -> None:  # pragma: no cover - trivial wiring
+    def __init__(
+        self, uri: str, user: str, password: str
+    ) -> None:  # pragma: no cover - trivial wiring
         self._driver = _lazy_import_neo4j_driver()(uri, auth=(user, password))
 
     def close(self) -> None:  # pragma: no cover - used in production
@@ -167,7 +183,12 @@ class Neo4jGraphStore(GraphStoreProtocol):
         self, previous_id: Optional[str], memory_id: str, timestamp: datetime
     ) -> None:
         with self._driver.session() as session:
-            session.execute_write(self._write_temporal_links, previous_id, memory_id, timestamp.isoformat())
+            session.execute_write(
+                self._write_temporal_links,
+                previous_id,
+                memory_id,
+                timestamp.isoformat(),
+            )
 
     def link_source(self, memory_id: str, frame_id: str) -> None:
         if not frame_id:
@@ -190,12 +211,26 @@ class Neo4jGraphStore(GraphStoreProtocol):
     ) -> None:
         rel_type = self._relationship_type(relation_type)
         with self._driver.session() as session:
-            session.execute_write(self._write_association, source_id, target_id, rel_type, dict(properties or {}))
+            session.execute_write(
+                self._write_association,
+                source_id,
+                target_id,
+                rel_type,
+                dict(properties or {}),
+            )
 
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         with self._driver.session() as session:
             record = session.execute_read(self._read_memory, memory_id)
             return record or {}
+
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        if not memory_ids:
+            return {}
+        with self._driver.session() as session:
+            return session.execute_read(self._read_memories, list(memory_ids))
 
     def link_identity(
         self,
@@ -216,7 +251,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
 
     # Neo4j transactions -----------------------------------------------
     @staticmethod
-    def _write_memory(tx, label: str, properties: Mapping[str, Any]) -> None:  # pragma: no cover - exercised via driver
+    def _write_memory(
+        tx, label: str, properties: Mapping[str, Any]
+    ) -> None:  # pragma: no cover - exercised via driver
         query = f"""
         MERGE (m:Memory:{label} {{memory_id: $memory_id}})
         SET m += $properties
@@ -224,7 +261,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
         tx.run(query, memory_id=properties["memory_id"], properties=dict(properties))
 
     @staticmethod
-    def _write_temporal_links(tx, previous_id: Optional[str], memory_id: str, timestamp: str) -> None:
+    def _write_temporal_links(
+        tx, previous_id: Optional[str], memory_id: str, timestamp: str
+    ) -> None:
         tx.run(
             """
             MATCH (current:Memory {memory_id: $memory_id})
@@ -279,7 +318,9 @@ class Neo4jGraphStore(GraphStoreProtocol):
         MERGE (source)-[rel:{relation_type}]->(target)
         SET rel += $properties
         """
-        tx.run(query, source_id=source_id, target_id=target_id, properties=dict(properties))
+        tx.run(
+            query, source_id=source_id, target_id=target_id, properties=dict(properties)
+        )
 
     @staticmethod
     def _write_identity_link(
@@ -322,15 +363,42 @@ class Neo4jGraphStore(GraphStoreProtocol):
         return node
 
     @staticmethod
+    def _read_memories(tx, memory_ids: list[str]) -> Mapping[str, Mapping[str, Any]]:
+        result = tx.run(
+            """
+            UNWIND $memory_ids AS memory_id
+            MATCH (memory:Memory {memory_id: memory_id})
+            OPTIONAL MATCH (memory)-[:IDENTIFIES]->(identity:Identity)
+            RETURN memory.memory_id AS id, memory, collect(identity) AS identities
+            """,
+            memory_ids=memory_ids,
+        )
+        output = {}
+        for record in result:
+            node = dict(record["memory"])
+            identities = record.get("identities")
+            if identities:
+                node["identities"] = [
+                    dict(identity) for identity in identities if identity is not None
+                ]
+            output[record["id"]] = node
+        return output
+
+    @staticmethod
     def _kind_to_label(kind: str) -> str:
-        cleaned = ''.join(ch if ch.isalnum() else '_' for ch in kind.strip()) or "Memory"
+        cleaned = (
+            "".join(ch if ch.isalnum() else "_" for ch in kind.strip()) or "Memory"
+        )
         if cleaned[0].isdigit():
             cleaned = f"_{cleaned}"
         return cleaned
 
     @staticmethod
     def _relationship_type(relation_type: str) -> str:
-        cleaned = ''.join(ch if ch.isalnum() else '_' for ch in relation_type.strip()) or "ASSOCIATED_WITH"
+        cleaned = (
+            "".join(ch if ch.isalnum() else "_" for ch in relation_type.strip())
+            or "ASSOCIATED_WITH"
+        )
         if cleaned[0].isdigit():
             cleaned = f"_{cleaned}"
         return cleaned

--- a/modules/memory/packages/memory/tests/test_memory_service.py
+++ b/modules/memory/packages/memory/tests/test_memory_service.py
@@ -8,7 +8,16 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+)
 
 import pytest
 
@@ -78,13 +87,22 @@ class FakeGraphStore:
         relation_type: str,
         properties: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        self.associations.append((source_id, target_id, relation_type, dict(properties or {})))
+        self.associations.append(
+            (source_id, target_id, relation_type, dict(properties or {}))
+        )
 
-    def link_identity(self, memory_id: str, identity_id: str, properties: Mapping[str, Any]) -> None:
+    def link_identity(
+        self, memory_id: str, identity_id: str, properties: Mapping[str, Any]
+    ) -> None:
         self.identity_links.append((memory_id, identity_id, dict(properties)))
 
     def fetch_memory(self, memory_id: str) -> Mapping[str, Any]:
         return self.memories[memory_id]
+
+    def fetch_memories(
+        self, memory_ids: Sequence[str]
+    ) -> Mapping[str, Mapping[str, Any]]:
+        return {m: self.memories[m] for m in memory_ids if m in self.memories}
 
 
 @pytest.fixture(name="service")
@@ -147,7 +165,9 @@ def test_memorize_batches_vectors_until_threshold(service: MemoryService) -> Non
     assert len(service.graph_store.frame_links) == 2  # type: ignore[attr-defined]
 
 
-def test_memorize_without_embedding_skips_vector_storage(service: MemoryService) -> None:
+def test_memorize_without_embedding_skips_vector_storage(
+    service: MemoryService,
+) -> None:
     """Given an event lacking an embedding, only the graph is updated."""
 
     event = _build_event(
@@ -239,13 +259,22 @@ def test_associate_records_relationship(service: MemoryService) -> None:
     )
     record = service.memorize(event)
 
-    service.associate(record.memory_id, record.memory_id, relation_type="REMEMBERS", properties={"confidence": 0.8})
+    service.associate(
+        record.memory_id,
+        record.memory_id,
+        relation_type="REMEMBERS",
+        properties={"confidence": 0.8},
+    )
 
     associations = service.graph_store.associations  # type: ignore[attr-defined]
-    assert associations == [(record.memory_id, record.memory_id, "REMEMBERS", {"confidence": 0.8})]
+    assert associations == [
+        (record.memory_id, record.memory_id, "REMEMBERS", {"confidence": 0.8})
+    ]
 
 
-def test_recall_enriches_vector_results_with_graph_context(service: MemoryService) -> None:
+def test_recall_enriches_vector_results_with_graph_context(
+    service: MemoryService,
+) -> None:
     """Vector results are hydrated with metadata fetched from the graph store."""
 
     event = _build_event(
@@ -257,7 +286,9 @@ def test_recall_enriches_vector_results_with_graph_context(service: MemoryServic
         {"id": "person:alice", "name": "Alice Example"}
     ]
 
-    fake_result = MemoryRecallResult(memory_id=record.memory_id, score=0.92, metadata={"foo": "bar"})
+    fake_result = MemoryRecallResult(
+        memory_id=record.memory_id, score=0.92, metadata={"foo": "bar"}
+    )
     service.vector_store.queue_search_result("face", [fake_result])  # type: ignore[attr-defined]
 
     results = service.recall(kind="face", embedding=[0.7, 0.4])


### PR DESCRIPTION
💡 **What**:
Implemented a new `fetch_memories` batch query method in `Neo4jGraphStore` using Cypher's `UNWIND` clause. Updated `MemoryService.recall` to batch fetch all search result metadata simultaneously instead of iterating one by one.

🎯 **Why**:
Iterating over vector search results and calling `self.graph_store.fetch_memory(memory_id)` individually resulted in an N+1 query bottleneck. Each returned memory triggered a separate, blocking round-trip to the Neo4j database, significantly degrading performance at higher search limits.

📊 **Impact**:
Reduces database round-trips during recall from O(N) (where N is the number of vector search matches) down to O(1). This should substantially decrease overall latency for recall queries.

🔬 **Measurement**:
Verified that unit tests pass successfully. The expected improvement can be observed by running high-limit recall operations in production; database execution time per recall request should see noticeable reductions.

Also documented this finding in `.jules/bolt.md` to prevent similar N+1 loops in the future.

---
*PR created automatically by Jules for task [12575169113225305059](https://jules.google.com/task/12575169113225305059) started by @dancxjo*