### PR TITLE
🧹 Fix unused import and typo in Ear transcriber node

### DIFF
--- a/modules/ear/packages/ear/ear/transcriber_node.py
+++ b/modules/ear/packages/ear/ear/transcriber_node.py
@@ -337,7 +337,7 @@ class TranscriberNode(Node):
         self._forward_transcript_to_conversant(text)
 
     @staticmethod
-    def _segments_to_text(segments: Sequence[TranscriptionSegment]) -> str:
+    def _segments_to_text(segments: Sequence[TranscriptSegment]) -> str:
         parts = [segment.text.strip() for segment in segments if getattr(segment, "text", "").strip()]
         return " ".join(parts)
 


### PR DESCRIPTION
Identified that `TranscriptSegment` was imported but flagged as unused due to a typo in the `_segments_to_text` method where `TranscriptionSegment` was used instead. Correcting this typo resolves both the unused import and the undefined name linting errors.

🎯 **What:** Corrected typo in type hint from `TranscriptionSegment` to `TranscriptSegment`.
💡 **Why:** Improves maintainability by resolving linting errors and ensuring type hint correctness.
✅ **Verification:** Ran `ruff check` and unit tests in `modules/ear/packages/ear/tests/`.
✨ **Result:** Clean lint output and improved code health.

---
*PR created automatically by Jules for task [3503009516313403686](https://jules.google.com/task/3503009516313403686) started by @dancxjo*