### PR TITLE
🧪 [Test] Add comprehensive coverage for hunger_feeler

### DIFF
--- a/modules/viscera/packages/viscera/tests/test_feelers.py
+++ b/modules/viscera/packages/viscera/tests/test_feelers.py
@@ -62,6 +62,34 @@ class TestHungerFeeler:
             for sentiment in sentiments
         ), sentiments
 
+    def test_none_charge_fraction_returns_nothing(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=None, is_charging=False))
+        assert hunger_feeler(state) == []
+
+    def test_satiated_when_charge_is_high(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.85, is_charging=False))
+        sentiments = hunger_feeler(state)
+        assert any("nourished and steady" in s.narrative.lower() for s in sentiments)
+
+    def test_hungry_phase_before_panic(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.45, is_charging=False))
+        sentiments = hunger_feeler(state)
+        assert any("hunger nibbling" in s.narrative.lower() for s in sentiments)
+
+    def test_charging_relief_narrative(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.2, is_charging=True))
+        sentiments = hunger_feeler(state)
+        recharging = next(s for s in sentiments if s.name == "recharging")
+        assert "calm relief" in recharging.narrative.lower()
+        assert recharging.intensity == 0.5
+
+    def test_charging_electrons_narrative(self) -> None:
+        state = make_state(battery=BatteryState(charge_fraction=0.7, is_charging=True))
+        sentiments = hunger_feeler(state)
+        recharging = next(s for s in sentiments if s.name == "recharging")
+        assert "fresh electrons" in recharging.narrative.lower()
+        assert recharging.intensity == 0.35
+
 
 class TestLoadFeeler:
     """Stress mapping for computational resource pressure."""


### PR DESCRIPTION
🎯 **What:** The testing gap for the `hunger_feeler` function in `viscera/feelers.py` has been addressed.
📊 **Coverage:** The following scenarios are now tested:
- `charge_fraction is None` returning an empty list.
- `charge_fraction >= 0.8` (satiated sentiment).
- `0.4 <= charge_fraction < 0.55` (hungry sentiment).
- `is_charging=True` with `level < 0.4` (relief narrative and 0.5 intensity).
- `is_charging=True` with `level >= 0.4` (fresh electrons narrative and 0.35 intensity).
✨ **Result:** Improved test coverage and reliability for the battery-to-sentiment mapping logic. Verified that tests catch regressions by temporarily modifying logic thresholds.

---
*PR created automatically by Jules for task [8294677994908187350](https://jules.google.com/task/8294677994908187350) started by @dancxjo*